### PR TITLE
Add Retry-After header to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ The library adds standard rate limit headers to responses:
 X-RateLimit-Limit: 100
 X-RateLimit-Remaining: 99
 X-RateLimit-Reset: 1642678800
+Retry-After: 200
 ```
 
 ## Monitoring and Management


### PR DESCRIPTION
## Description

I have added the missing `Retry-After` header to README.md

> **💡 Tip**: For feature discussions or questions about implementation, consider starting a discussion in [GitHub Discussions](https://github.com/YasserShkeir/django-smart-ratelimit/discussions) first.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Testing

- [ ] I have added tests for my changes
- [x] All existing tests pass
- [x] I have tested the changes manually
- [x] I have tested with multiple Django versions (if applicable)
- [x] I have tested with multiple Python versions (if applicable)

## Documentation

- [x] I have updated the README.md (if needed)
- [x] I have updated the documentation (if needed)
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated type hints

## Code Quality

- [ ] I have run `black` to format the code
- [ ] I have run `flake8` and fixed any linting issues
- [ ] I have run `mypy` and fixed any type checking issues
- [ ] I have run the pre-commit hooks
- [x] My code follows the project's style guidelines

## Backwards Compatibility

- [x] This change is backwards compatible
- [ ] This change requires a migration or configuration update
- [ ] This change breaks existing functionality (requires major version bump)

## Related Issues

Related to #(11)

## Checklist

- [ ] I have read the contributing guidelines
- [ ] I have signed off my commits (if required)
- [ ] I have squashed my commits into logical units
- [ ] I have written clear commit messages
- [ ] I have tested my changes thoroughly
- [ ] I have documented any new functionality
