### PR TITLE
Fix NoScriptError handling in sync and async Redis backends

### DIFF
--- a/django_smart_ratelimit/backends/redis_backend.py
+++ b/django_smart_ratelimit/backends/redis_backend.py
@@ -325,6 +325,8 @@ class RedisBackend(BaseBackend):
             except (redis.ConnectionError, redis.TimeoutError) as e:
                 last_error = e
                 self._reconnect()
+            except redis.exceptions.NoScriptError:
+                raise  # Let _eval_lua handle script reload
             except redis.RedisError as e:
                 raise BackendError(f"Redis error: {e}") from e
 
@@ -991,12 +993,28 @@ class AsyncRedisBackend(BaseBackend):
             now = get_current_timestamp()
 
             if self.algorithm == "sliding_window":
-                sha = self.sliding_window_sha
-                # args: normalized_key, period, limit, now
-                res = await client.evalsha(sha, 1, normalized_key, period, 999999, now)
+                sha_attr = "sliding_window_sha"
+                script = RedisBackend.SLIDING_WINDOW_SCRIPT
             else:
-                sha = self.fixed_window_sha
+                sha_attr = "fixed_window_sha"
+                script = RedisBackend.FIXED_WINDOW_SCRIPT
+
+            sha = getattr(self, sha_attr)
+            try:
                 res = await client.evalsha(sha, 1, normalized_key, period, 999999, now)
+            except redis.exceptions.NoScriptError:
+                # Script evicted (Redis restart). Reload and retry.
+                log_backend_operation(
+                    "async_reload_script",
+                    "Reloading Lua script after NoScriptError",
+                    level="warning",
+                    script=sha_attr,
+                )
+                new_sha = await self._load_script(client, script)
+                setattr(self, sha_attr, new_sha)
+                res = await client.evalsha(
+                    new_sha, 1, normalized_key, period, 999999, now
+                )
 
             # Report Success
             if self._circuit_breaker:

--- a/tests/unit/backends/test_noscript_error_handling.py
+++ b/tests/unit/backends/test_noscript_error_handling.py
@@ -1,0 +1,233 @@
+"""
+Tests for NoScriptError handling in Redis backends.
+
+After a Redis restart, cached Lua scripts are evicted. The backends must
+detect NoScriptError, reload the script, and retry — rather than wrapping
+the error in BackendError (which prevents recovery and keeps the circuit
+breaker stuck open indefinitely).
+"""
+
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from django.test import SimpleTestCase, TestCase
+
+try:
+    import redis as redis_module
+
+    REDIS_AVAILABLE = True
+except ImportError:
+    REDIS_AVAILABLE = False
+
+
+@unittest.skipUnless(REDIS_AVAILABLE, "redis package not installed")
+class RedisBackendNoScriptErrorTests(TestCase):
+    """Test that sync RedisBackend recovers from NoScriptError."""
+
+    def setUp(self):
+        from django_smart_ratelimit.backends.redis_backend import RedisBackend
+
+        self.RedisBackend = RedisBackend
+
+        self.redis_patcher = patch(
+            "django_smart_ratelimit.backends.redis_backend.redis"
+        )
+        self.mock_redis_module = self.redis_patcher.start()
+
+        self.mock_redis_client = Mock()
+        self.mock_redis_module.Redis.return_value = self.mock_redis_client
+        self.mock_redis_module.RedisError = redis_module.RedisError
+        self.mock_redis_module.ConnectionError = redis_module.ConnectionError
+        self.mock_redis_module.TimeoutError = redis_module.TimeoutError
+        self.mock_redis_module.exceptions = redis_module.exceptions
+        self.mock_redis_client.ping.return_value = True
+        self.mock_redis_client.script_load.return_value = "initial_sha"
+
+        self.addCleanup(self.redis_patcher.stop)
+
+    def test_execute_with_retry_propagates_noscript_error(self):
+        """_execute_with_retry must not wrap NoScriptError in BackendError.
+
+        Bug: redis.RedisError catch clause was swallowing NoScriptError
+        (a subclass of RedisError), wrapping it in BackendError. This
+        prevented _eval_lua from catching NoScriptError and reloading
+        the script.
+        """
+        backend = self.RedisBackend()
+
+        def raise_noscript():
+            raise redis_module.exceptions.NoScriptError("No matching script")
+
+        with self.assertRaises(redis_module.exceptions.NoScriptError):
+            backend._execute_with_retry(raise_noscript)
+
+    def test_eval_lua_reloads_script_on_noscript_error(self):
+        """_eval_lua should reload the script and retry on NoScriptError.
+
+        Simulates Redis restart: first evalsha fails with NoScriptError,
+        script_load returns a new SHA, second evalsha succeeds.
+        """
+        backend = self.RedisBackend()
+
+        # First call: NoScriptError (stale SHA after Redis restart)
+        # Second call (after reload): success
+        self.mock_redis_client.evalsha.side_effect = [
+            redis_module.exceptions.NoScriptError("No matching script"),
+            42,
+        ]
+        self.mock_redis_client.script_load.return_value = "new_sha"
+
+        result = backend._eval_lua(
+            "sliding_window_sha",
+            backend.SLIDING_WINDOW_SCRIPT,
+            1,
+            "test_key",
+            60,
+            100,
+            1234567890,
+        )
+
+        self.assertEqual(result, 42)
+        # Script should have been reloaded
+        self.assertEqual(backend.sliding_window_sha, "new_sha")
+        # evalsha called twice: once with old SHA, once with new
+        self.assertEqual(self.mock_redis_client.evalsha.call_count, 2)
+
+    def test_incr_recovers_from_noscript_error(self):
+        """Full incr() call should recover from NoScriptError transparently.
+
+        This is the end-to-end test: a rate limit check should succeed
+        even after Redis has restarted and evicted cached scripts.
+        """
+        backend = self.RedisBackend()
+
+        self.mock_redis_client.evalsha.side_effect = [
+            redis_module.exceptions.NoScriptError("No matching script"),
+            5,
+        ]
+        self.mock_redis_client.script_load.return_value = "reloaded_sha"
+
+        result = backend.incr("test_key", 60)
+
+        self.assertEqual(result, 5)
+
+
+@pytest.mark.asyncio
+@unittest.skipUnless(REDIS_AVAILABLE, "redis package not installed")
+class AsyncRedisBackendNoScriptErrorTests(SimpleTestCase):
+    """Test that async AsyncRedisBackend recovers from NoScriptError."""
+
+    @patch("redis.asyncio.Redis")
+    @patch("redis.asyncio.from_url")
+    async def test_aincr_reloads_script_on_noscript_error(
+        self, mock_from_url, mock_redis_cls
+    ):
+        """Aincr should reload the script and retry on NoScriptError.
+
+        Bug: aincr had no NoScriptError handling at all — any Redis
+        restart would cause permanent failure until process restart.
+        """
+        from django_smart_ratelimit.backends.redis_backend import AsyncRedisBackend
+
+        mock_client = AsyncMock()
+        mock_from_url.return_value = mock_client
+        mock_redis_cls.return_value = mock_client
+
+        # script_load returns SHAs during init and reload
+        mock_client.script_load.return_value = "initial_sha"
+
+        backend = AsyncRedisBackend(url="redis://localhost:6379/0")
+
+        # Ensure client is initialized
+        await backend._get_client()
+
+        # First evalsha: NoScriptError (stale SHA)
+        # Second evalsha (after reload): success
+        mock_client.evalsha.side_effect = [
+            redis_module.exceptions.NoScriptError("No matching script"),
+            7,
+        ]
+        mock_client.script_load.return_value = "reloaded_sha"
+
+        result = await backend.aincr("test_key", 60)
+
+        self.assertEqual(result, 7)
+        # evalsha called twice: stale SHA, then reloaded SHA
+        self.assertEqual(mock_client.evalsha.call_count, 2)
+
+    @patch("redis.asyncio.Redis")
+    @patch("redis.asyncio.from_url")
+    async def test_aincr_noscript_updates_cached_sha(
+        self, mock_from_url, mock_redis_cls
+    ):
+        """After NoScriptError recovery, the new SHA should be cached.
+
+        Subsequent calls should use the reloaded SHA directly without
+        triggering another reload.
+        """
+        from django_smart_ratelimit.backends.redis_backend import AsyncRedisBackend
+
+        mock_client = AsyncMock()
+        mock_from_url.return_value = mock_client
+        mock_redis_cls.return_value = mock_client
+        mock_client.script_load.return_value = "initial_sha"
+
+        backend = AsyncRedisBackend(url="redis://localhost:6379/0")
+        await backend._get_client()
+
+        # First call: NoScriptError then success after reload
+        mock_client.evalsha.side_effect = [
+            redis_module.exceptions.NoScriptError("No matching script"),
+            3,
+        ]
+        mock_client.script_load.return_value = "reloaded_sha"
+
+        await backend.aincr("test_key", 60)
+
+        # SHA should now be updated
+        sha_attr = (
+            "sliding_window_sha"
+            if backend.algorithm == "sliding_window"
+            else "fixed_window_sha"
+        )
+        self.assertEqual(getattr(backend, sha_attr), "reloaded_sha")
+
+        # Second call: should work directly with cached SHA
+        mock_client.evalsha.side_effect = None
+        mock_client.evalsha.return_value = 4
+
+        result = await backend.aincr("test_key", 60)
+
+        self.assertEqual(result, 4)
+
+    @patch("redis.asyncio.Redis")
+    @patch("redis.asyncio.from_url")
+    async def test_aincr_fixed_window_reloads_script_on_noscript_error(
+        self, mock_from_url, mock_redis_cls
+    ):
+        """Fixed-window algorithm should also recover from NoScriptError."""
+        from django_smart_ratelimit.backends.redis_backend import AsyncRedisBackend
+
+        mock_client = AsyncMock()
+        mock_from_url.return_value = mock_client
+        mock_redis_cls.return_value = mock_client
+        mock_client.script_load.return_value = "initial_sha"
+
+        backend = AsyncRedisBackend(
+            url="redis://localhost:6379/0", algorithm="fixed_window"
+        )
+        await backend._get_client()
+
+        mock_client.evalsha.side_effect = [
+            redis_module.exceptions.NoScriptError("No matching script"),
+            5,
+        ]
+        mock_client.script_load.return_value = "reloaded_sha"
+
+        result = await backend.aincr("test_key", 60)
+
+        self.assertEqual(result, 5)
+        self.assertEqual(backend.fixed_window_sha, "reloaded_sha")
+        self.assertEqual(mock_client.evalsha.call_count, 2)


### PR DESCRIPTION
## Description

Fix `NoScriptError` handling in both `RedisBackend` and `AsyncRedisBackend` so they recover after a Redis restart.

When Redis restarts, cached Lua scripts are evicted. Two bugs prevent recovery:

1. **`_execute_with_retry`** catches `redis.RedisError` (parent of `NoScriptError`) and wraps it in `BackendError`, making `_eval_lua`'s `NoScriptError` handler on line 366 unreachable.
2. **`AsyncRedisBackend.aincr`** has no `NoScriptError` handling at all.

With `fail_open=False` (default), this causes the circuit breaker to get stuck open — returning 429 to all requests indefinitely until the process is restarted.

**Fix:** Re-raise `NoScriptError` before the generic `RedisError` handler in `_execute_with_retry`, and add script-reload logic to `aincr`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Testing

- [x] I have added tests for my changes
- [x] All existing tests pass
- [x] I have tested the changes manually
- [ ] I have tested with multiple Django versions (if applicable)
- [ ] I have tested with multiple Python versions (if applicable)

5 unit tests added in `tests/unit/backends/test_noscript_error_handling.py` covering both sync and async backends.

## Documentation

- [ ] I have updated the README.md (if needed)
- [ ] I have updated the documentation (if needed)
- [x] I have added docstrings to new functions/classes
- [ ] I have updated type hints

## Code Quality

- [x] I have run `black` to format the code
- [x] I have run `flake8` and fixed any linting issues
- [ ] I have run `mypy` and fixed any type checking issues
- [ ] I have run the pre-commit hooks
- [x] My code follows the project's style guidelines

## Backwards Compatibility

- [x] This change is backwards compatible
- [ ] This change requires a migration or configuration update
- [ ] This change breaks existing functionality (requires major version bump)

## Related Issues

N/A — discovered via production incident. Happy to open a separate issue if preferred.

## Screenshots/Examples

```python
# Simulate Redis restart clearing script cache
backend = RedisBackend()
# ... Redis restarts here, scripts evicted ...
backend.incr("test_key", 60)
# Before fix: BackendError("Redis error: No matching script. Please use EVAL.")
#   → circuit breaker opens → all requests get 429 indefinitely
# After fix: script silently reloaded, incr succeeds
```

## Checklist

- [x] I have read the contributing guidelines
- [ ] I have signed off my commits (if required)
- [x] I have squashed my commits into logical units
- [x] I have written clear commit messages
- [x] I have tested my changes thoroughly
- [x] I have documented any new functionality

## Additional Notes

The root cause is an exception hierarchy issue: `NoScriptError` inherits from `RedisError`, so the generic `except redis.RedisError` catches it before `_eval_lua` can handle it specifically.
