### PR TITLE
chore: bump version to 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-04-08
+
+### Fixed
+
+- **NoScriptError Handling**: Fixed exception hierarchy bug in sync and async Redis backends where generic `RedisError` catch masked the specific `NoScriptError` handler (#62)
+
+### Added
+
+- **PEP 561 Support**: Added `py.typed` marker file for mypy and other type checkers (#63)
+
+### Changed
+
+- **CI**: Bumped `actions/checkout` from 4 to 6, `release-drafter` from 6 to 7, `actions/upload-artifact` from 6 to 7 (#59, #60, #61)
+- **Documentation**: Comprehensive documentation cleanup, removed all emojis, updated to reflect v2.2.0 features (#58)
+
 ## [2.2.0] - 2026-03-26
 
 ### Added

--- a/FEATURES_ROADMAP.md
+++ b/FEATURES_ROADMAP.md
@@ -1,7 +1,7 @@
 # Django Smart Ratelimit - Core Features Roadmap
 
-**Last Updated:** 2026-03-26
-**Current Version:** 2.2.0
+**Last Updated:** 2026-04-08
+**Current Version:** 2.2.1
 
 This document tracks the feature status for Django Smart Ratelimit (Core). For database-backed features, analytics, and enterprise capabilities, see the [Pro Roadmap](../django-smart-ratelimit-pro/FEATURES_ROADMAP.md).
 

--- a/django_smart_ratelimit/__init__.py
+++ b/django_smart_ratelimit/__init__.py
@@ -5,7 +5,7 @@ with support for multiple backends, algorithms (including token bucket),
 and comprehensive rate limiting strategies.
 """
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 __author__ = "Yasser Shkeir"
 
 # Optional backend imports (may not be available)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-smart-ratelimit"
-version = "2.2.0"
+version = "2.2.1"
 dynamic = []
 description = "A flexible and efficient rate limiting library for Django applications"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Bump version to v2.2.1 for patch release.

### Changes included in this release:
- Fix NoScriptError handling in sync and async Redis backends (#62)
- Add PEP 561 py.typed marker file (#63)
- Bump CI actions: checkout v6, release-drafter v7, upload-artifact v7 (#59, #60, #61)
- Comprehensive documentation cleanup and professional formatting (#58)

## Type of Change
- [x] Other (please describe): Version bump for patch release

## Testing
- [x] All existing tests pass
- [x] No code changes, only version numbers and changelog