### PR TITLE
feat!: v3.0.0 — pipeline refactor, shadow mode, cost limits, CIDR lists, DRF adapter

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,8 +1,10 @@
 [bandit]
 # Bandit configuration for django-smart-ratelimit
 
-# Skip specific tests that are false positives
-skips = B105
+# Skip specific tests that are false positives.
+# B105 - hardcoded password strings (Lua scripts / cache key prefixes, not credentials)
+# B101 - assert_used (only present in django_smart_ratelimit.testing pytest helpers)
+skips = B101,B105
 
 # Lua scripts in Redis backend are not passwords
 exclude_dirs = []

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 jobs:
   update_release_draft:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
     rev: v1.19.1
     hooks:
       - id: mypy
-        additional_dependencies: [django-stubs, types-redis]
+        additional_dependencies: [django-stubs, types-redis, pytest]
         exclude: ^\.venv/
 
   - repo: https://github.com/commitizen-tools/commitizen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,91 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2026-04-17
+
+This is a major release that consolidates and hardens the v2.x runtime. Existing
+`@rate_limit(...)` and `RateLimitMiddleware` call-sites keep working unchanged;
+new keyword arguments are all optional. See `MIGRATION.md` for upgrade notes.
+
+### Added
+
+- **Shadow mode** (`shadow=True` on the decorator and `SHADOW` in the
+  middleware config). Requests that would have been blocked are allowed
+  through and logged with a `SHADOW_RATE_LIMIT_BLOCK` event plus an
+  OpenTelemetry `ratelimit.shadow.block` attribute. Use this to validate a
+  new limit in production before flipping enforcement on.
+- **Cost-based (weighted) limiting** (`cost=<int | callable>` on the
+  decorator). Expensive operations can consume more than one token per
+  request. The cost may be a constant int or a callable `f(request) -> int`.
+  Values are clamped to a minimum of 1 so `cost=0` cannot be used to bypass
+  the limiter. Backends that don't natively accept a cost fall back to a
+  loop of single-token increments so weighted limits still work end-to-end.
+- **CIDR allow-lists and deny-lists** (`allow_list=` / `deny_list=` on the
+  decorator, `ALLOW_LIST` / `DENY_LIST` in `RATELIMIT_MIDDLEWARE`). Accepts
+  `IPList` instances, iterables of CIDR strings, file paths, or URLs.
+  Deny always takes precedence over allow. Evaluated before any backend
+  work so deny-listed clients never touch the cache.
+- **DRF throttle adapter** at `django_smart_ratelimit.integrations.drf`.
+  Three ready-to-use classes (`UserRateLimitThrottle`,
+  `AnonRateLimitThrottle`, `ScopedRateLimitThrottle`) plus a
+  `SmartRateLimitThrottle` base you can subclass.
+- **pytest fixtures** at `django_smart_ratelimit.testing`, auto-registered
+  via the `pytest11` entry point so your test project picks them up with
+  zero configuration.
+- **OpenTelemetry exporter** at `django_smart_ratelimit.observability`.
+  Emits a span and metrics per rate-limit decision, covering both
+  enforcement and shadow paths.
+- **Shared v3 pipeline** (`django_smart_ratelimit.pipeline`) exposing
+  `resolve_effective_rate`, `apply_policy_lists`, `handle_shadow_decision`,
+  and the `POLICY_ALLOW` / `POLICY_DENY` / `POLICY_CONTINUE` sentinels.
+  Third-party middlewares and adapters can now reuse the same evaluation
+  primitives the built-in decorator uses.
+- **`ratelimit` alias** for the `rate_limit` decorator to match
+  `django-ratelimit` naming conventions, with the full v3 signature.
+- Integration tests for shadow mode, cost limiting, CIDR lists, and key
+  validation; unit tests for the pipeline module.
+
+### Changed
+
+- **Empty keys now raise** `KeyGenerationError` instead of silently
+  collapsing every caller onto the empty-string bucket. Previously a key
+  function that returned `""` or `None` would rate-limit the entire service
+  as if it were a single client — a dangerous footgun. Pass
+  `validate_key=False` to `resolve_effective_rate` if you need the old
+  behavior in custom pipelines.
+- **Generic token-bucket fallback is now serialized within-process** via a
+  per-key `threading.Lock`. Backends intended for multi-process production
+  use must still implement an atomic `token_bucket_check` — documented
+  explicitly in the docstring. This closes the within-process race without
+  pretending to solve the cross-process one.
+- **Reset times for first-request-aligned windows are cached per key** so
+  repeat callers within the same window see a stable `X-RateLimit-Reset`
+  and `Retry-After` instead of a value that drifts forward on each call.
+  Clock-aligned reset times were already stable and are unchanged.
+- DRF throttle callable attributes (`rate`, `cost`, `key_func`) are now
+  accessed through `type(self)` to bypass Python's method-binding so a
+  plain function assigned as a class attribute receives
+  `(throttle, request)` rather than an extra bound `self`.
+
+### Fixed
+
+- DRF throttle `wait()` now returns a non-`None` value on the block path
+  (it previously only cached `_last_reset_time` on the allow path).
+- DRF throttle `allow_request()` tolerates invalid rate strings and
+  backend exceptions instead of blowing up — invalid rate logs a warning
+  and allows the request; backend errors honor `fail_open` via
+  `getattr(backend, "fail_open", True)`.
+- DRF test state no longer leaks across test cases: `setUp`/`tearDown` now
+  clear the backend singleton and its counters.
+
+### Migration
+
+- **If you relied on empty keys being a valid bucket**, pick a concrete
+  placeholder (e.g. `"anonymous"`) or raise from your key function to
+  skip rate limiting explicitly.
+- **Nothing else is required.** All new parameters default to their
+  pre-v3 behavior.
+
 ## [2.2.1] - 2026-04-08
 
 ### Fixed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,205 @@
+# Migration Guide: v2.x → v3.0.0
+
+django-smart-ratelimit 3.0.0 is a **mostly additive** major release. All
+existing `@rate_limit(...)` and `RateLimitMiddleware` call-sites keep
+working as-is. This guide covers the one behavioral change you should
+verify and walks through the new features you may want to adopt.
+
+## TL;DR
+
+```bash
+pip install django-smart-ratelimit==3.0.0
+```
+
+For 95% of deployments that's the entire migration. Read the **Breaking
+change** section below to make sure you're not in the remaining 5%.
+
+---
+
+## Breaking change: empty keys now raise
+
+**Before (v2.x):** a key function that returned `""` or `None` silently
+worked — every matching request collapsed onto the same bucket.
+
+**After (v3.0.0):** that path raises `KeyGenerationError` so the bug is
+loud instead of silent.
+
+### Why
+
+An empty key meant every request shared a single rate-limit bucket. Under
+load this looked like "my service is being rate-limited to nothing" even
+though the intent was per-user limiting. We'd rather surface the config
+bug than silently turn your limiter into a global kill-switch.
+
+### What to do
+
+Audit custom key functions and make sure they always return a
+non-empty string:
+
+```python
+from django_smart_ratelimit.exceptions import RateLimitException
+
+def key_for_authenticated_user(request):
+    user_id = getattr(request.user, "id", None)
+    if user_id is None:
+        # Choose one of the two options below:
+        return "anonymous"           # put all anons in the same bucket
+        # raise RateLimitException   # skip rate limiting entirely
+    return f"user:{user_id}"
+```
+
+If you have a bespoke pipeline that genuinely needs the old behavior,
+call `resolve_effective_rate(..., validate_key=False)` from
+`django_smart_ratelimit.pipeline`.
+
+---
+
+## New features you can opt into
+
+All optional — your existing code runs unchanged without touching any of
+these.
+
+### Shadow mode (validate a new limit without blocking)
+
+```python
+from django_smart_ratelimit import rate_limit
+
+@rate_limit(key="ip", rate="10/m", shadow=True)
+def view(request):
+    ...
+```
+
+Requests over the limit still succeed, but emit a structured log line
+(`SHADOW_RATE_LIMIT_BLOCK`) and an OpenTelemetry attribute. Run this
+for a day, inspect the logs, then flip `shadow=False`.
+
+Middleware equivalent:
+
+```python
+RATELIMIT_MIDDLEWARE = {
+    "DEFAULT_RATE": "100/m",
+    "SHADOW": True,
+}
+```
+
+### Cost-based (weighted) limiting
+
+```python
+@rate_limit(key="ip", rate="100/m", cost=5)
+def expensive_op(request):
+    ...
+
+# Or dynamically:
+@rate_limit(key="ip", rate="100/m", cost=lambda r: 5 if r.method == "POST" else 1)
+def view(request):
+    ...
+```
+
+`cost` is clamped to a minimum of 1, so you can't use `cost=0` to bypass
+the limiter. Backends that don't natively support cost fall back to a
+loop of single-token increments.
+
+### CIDR allow/deny lists
+
+```python
+@rate_limit(
+    key="ip",
+    rate="100/m",
+    allow_list=["10.0.0.0/8"],            # internal traffic, skip the limit
+    deny_list=["/etc/ratelimit/block.txt"], # explicit blocks (deny wins)
+)
+def view(request):
+    ...
+```
+
+Accepts:
+
+- an `IPList` instance,
+- an iterable of CIDR strings,
+- a filesystem path to a file with one CIDR per line,
+- a URL that returns the same.
+
+Middleware equivalent:
+
+```python
+RATELIMIT_MIDDLEWARE = {
+    "ALLOW_LIST": ["10.0.0.0/8"],
+    "DENY_LIST": "https://internal/badguys.txt",
+}
+```
+
+### DRF throttle adapter
+
+```python
+# settings.py
+REST_FRAMEWORK = {
+    "DEFAULT_THROTTLE_CLASSES": [
+        "django_smart_ratelimit.integrations.drf.UserRateLimitThrottle",
+        "django_smart_ratelimit.integrations.drf.AnonRateLimitThrottle",
+    ],
+    "DEFAULT_THROTTLE_RATES": {
+        "user": "1000/hour",
+        "anon": "100/hour",
+    },
+}
+```
+
+Or subclass `SmartRateLimitThrottle` for full control.
+
+### pytest fixtures
+
+The `django-smart-ratelimit` package now registers a `pytest11` entry
+point. Any test that `import django_smart_ratelimit.testing` (or just
+runs in a project that depends on the package) picks up fixtures for
+clearing backend state between tests.
+
+### OpenTelemetry exporter
+
+Install the optional dep:
+
+```bash
+pip install "django-smart-ratelimit[opentelemetry]"
+```
+
+Every rate-limit check emits a span (`ratelimit.check`) and metrics
+(`ratelimit.requests`, `ratelimit.blocks`). Shadow decisions show up as
+span attributes, not separate blocks.
+
+### Shared evaluation pipeline
+
+Third-party adapters can now reuse the same evaluation primitives the
+built-in decorator uses:
+
+```python
+from django_smart_ratelimit import (
+    POLICY_ALLOW, POLICY_DENY, POLICY_CONTINUE,
+    apply_policy_lists, handle_shadow_decision, resolve_effective_rate,
+)
+```
+
+See `django_smart_ratelimit/pipeline.py` for the full contract.
+
+---
+
+## Other behavior changes worth knowing
+
+- **Reset times for first-request-aligned windows are now stable per key**
+  inside a single process. Repeat callers in the same window see the
+  same `X-RateLimit-Reset`. Clock-aligned reset times were already
+  stable and are unchanged. No action needed; your `Retry-After`
+  headers just got more honest.
+- **Generic token-bucket fallback is now serialized within-process** via
+  a per-key lock. For multi-process production use, backends must
+  implement atomic `token_bucket_check` — this was already the expected
+  contract, now it's documented explicitly in the algorithm source.
+- **DRF `wait()` now returns a non-`None` value** on the throttled path,
+  so clients get an accurate `Retry-After`.
+
+---
+
+## Questions, issues, regressions
+
+Open an issue on GitHub: <https://github.com/YasserShkeir/django-smart-ratelimit/issues>
+
+Please include the v2.x version you're upgrading from and a minimal
+reproduction if you hit something unexpected.

--- a/django_smart_ratelimit/__init__.py
+++ b/django_smart_ratelimit/__init__.py
@@ -5,7 +5,7 @@ with support for multiple backends, algorithms (including token bucket),
 and comprehensive rate limiting strategies.
 """
 
-__version__ = "2.2.1"
+__version__ = "3.0.0"
 __author__ = "Yasser Shkeir"
 
 # Optional backend imports (may not be available)
@@ -81,6 +81,10 @@ def ratelimit(
     settings: Optional[Any] = None,
     adaptive: Optional[Union[str, "AdaptiveRateLimiter"]] = None,
     response_callback: Optional[Callable] = None,
+    cost: Union[int, Callable[..., int]] = 1,
+    shadow: bool = False,
+    allow_list: Any = None,
+    deny_list: Any = None,
 ) -> Callable:
     """Alias for rate_limit decorator.
 
@@ -98,6 +102,10 @@ def ratelimit(
         settings=settings,
         adaptive=adaptive,
         response_callback=response_callback,
+        cost=cost,
+        shadow=shadow,
+        allow_list=allow_list,
+        deny_list=deny_list,
     )
 
 
@@ -123,6 +131,20 @@ from .middleware import RateLimitMiddleware
 
 # Performance utilities
 from .performance import RateLimitCache
+
+# v3 pipeline — shared rate-limit evaluation primitives. Exported so advanced
+# users can compose their own middleware/throttle adapters on top of the
+# same logic the built-in decorator uses.
+from .pipeline import (
+    POLICY_ALLOW,
+    POLICY_CONTINUE,
+    POLICY_DENY,
+    ResolvedLimit,
+    ShadowDecision,
+    apply_policy_lists,
+    handle_shadow_decision,
+    resolve_effective_rate,
+)
 
 # Utilities
 from .utils import is_ratelimited  # noqa: F401
@@ -240,6 +262,15 @@ __all__ = [
     "RateLimitConfigManager",
     # Performance
     "RateLimitCache",
+    # v3 Pipeline (shared evaluation primitives)
+    "POLICY_ALLOW",
+    "POLICY_CONTINUE",
+    "POLICY_DENY",
+    "ResolvedLimit",
+    "ShadowDecision",
+    "apply_policy_lists",
+    "handle_shadow_decision",
+    "resolve_effective_rate",
     # Utility functions
     "get_ip_key",
     "get_user_key",

--- a/django_smart_ratelimit/algorithms/token_bucket.py
+++ b/django_smart_ratelimit/algorithms/token_bucket.py
@@ -12,11 +12,47 @@ as it allows temporary bursts while maintaining an average rate over time.
 import json
 import logging
 import math
+import threading
 from typing import Any, Dict, Optional, Tuple
 
 from .base import RateLimitAlgorithm
 
 logger = logging.getLogger(__name__)
+
+
+# Per-key locks used by the generic (non-atomic) token bucket fallback.
+#
+# Backend contract:
+#   Backends intended for multi-process production use MUST implement an
+#   atomic ``token_bucket_check`` method. The generic fallback below
+#   read-modifies-writes JSON state and is therefore NOT safe across
+#   concurrent workers even with these locks, which serialize *within-process*
+#   only. They exist so that tests and single-worker deployments don't see
+#   obvious races; they do NOT promise correctness across processes.
+_bucket_locks_guard = threading.Lock()
+_bucket_locks: Dict[str, threading.Lock] = {}
+
+
+def _get_bucket_lock(bucket_key: str) -> threading.Lock:
+    """Return a per-bucket-key lock, creating it on first use.
+
+    A module-level dict under a guard lock is intentionally simple: the working
+    set of keys is bounded by the number of distinct rate-limit buckets in
+    flight, which is small compared to request volume. We don't evict entries
+    because a stale Lock costs a few hundred bytes and evicting during use
+    would reintroduce the race we're trying to avoid.
+    """
+    # Fast path — hit the dict without holding the guard if possible. We only
+    # need the guard to create a new lock safely.
+    lock = _bucket_locks.get(bucket_key)
+    if lock is not None:
+        return lock
+    with _bucket_locks_guard:
+        lock = _bucket_locks.get(bucket_key)
+        if lock is None:
+            lock = threading.Lock()
+            _bucket_locks[bucket_key] = lock
+        return lock
 
 
 class TokenBucketAlgorithm(RateLimitAlgorithm):
@@ -153,93 +189,106 @@ class TokenBucketAlgorithm(RateLimitAlgorithm):
         """
         Implement generic token bucket for backends without native support.
 
-        Note: This implementation is not atomic and should only be used as a fallback.
-        For production use, backends should implement atomic token bucket operations.
+        This implementation performs a read-modify-write of the bucket state.
+        It is serialized WITHIN a single process via a per-key ``threading.Lock``
+        so tests and single-worker deployments are correct, but it is NOT safe
+        across multiple processes or machines. Backends for production use
+        (Redis, MongoDB, etc.) MUST implement an atomic ``token_bucket_check``
+        method that does the compare-and-swap in the backend itself. The
+        algorithm will prefer that implementation when present — see
+        :meth:`is_allowed` above.
         """
         current_time = self.get_current_time()
         bucket_key = f"{key}:token_bucket"
 
-        # Get current bucket state
-        try:
-            bucket_data_str = backend.get(bucket_key)
-            if bucket_data_str:
-                bucket_data = json.loads(bucket_data_str)
-            else:
+        with _get_bucket_lock(bucket_key):
+            # Get current bucket state
+            try:
+                bucket_data_str = backend.get(bucket_key)
+                if bucket_data_str:
+                    bucket_data = json.loads(bucket_data_str)
+                else:
+                    bucket_data = {
+                        "tokens": initial_tokens,
+                        "last_refill": current_time,
+                    }
+            except (json.JSONDecodeError, AttributeError):
                 bucket_data = {"tokens": initial_tokens, "last_refill": current_time}
-        except (json.JSONDecodeError, AttributeError):
-            bucket_data = {"tokens": initial_tokens, "last_refill": current_time}
 
-        # Calculate tokens to add based on time elapsed
-        # Formula: elapsed_time * refill_rate
-        # This implements the "leaky bucket" refill pattern where tokens drip in
-        time_elapsed = current_time - bucket_data["last_refill"]
-        tokens_to_add = time_elapsed * refill_rate
+            # Calculate tokens to add based on time elapsed
+            # Formula: elapsed_time * refill_rate
+            # This implements the "leaky bucket" refill pattern where tokens drip in
+            time_elapsed = current_time - bucket_data["last_refill"]
+            tokens_to_add = time_elapsed * refill_rate
 
-        # Update token count (cannot exceed bucket size)
-        # Cap tokens at bucket size (bucket can't overflow)
-        current_tokens = min(bucket_size, bucket_data["tokens"] + tokens_to_add)
+            # Update token count (cannot exceed bucket size)
+            # Cap tokens at bucket size (bucket can't overflow)
+            current_tokens = min(bucket_size, bucket_data["tokens"] + tokens_to_add)
 
-        # Check if request can be served
-        if current_tokens >= tokens_requested:
-            # Consume tokens
-            remaining_tokens = current_tokens - tokens_requested
+            # Check if request can be served
+            if current_tokens >= tokens_requested:
+                # Consume tokens
+                remaining_tokens = current_tokens - tokens_requested
 
-            # Update bucket state
-            new_bucket_data = {"tokens": remaining_tokens, "last_refill": current_time}
+                # Update bucket state
+                new_bucket_data = {
+                    "tokens": remaining_tokens,
+                    "last_refill": current_time,
+                }
 
-            # Set expiration time (tokens expire after bucket could be
-            # completely refilled + buffer)
-            expiration = (
-                int(math.ceil(bucket_size / refill_rate) + 60)
-                if refill_rate > 0
-                else 3600
-            )
-
-            try:
-                backend.set(bucket_key, json.dumps(new_bucket_data), expiration)
-            except Exception:
-                # If backend doesn't support expiration, try without it
-                backend.set(bucket_key, json.dumps(new_bucket_data))
-
-            return True, {
-                "tokens_remaining": remaining_tokens,
-                "tokens_requested": tokens_requested,
-                "bucket_size": bucket_size,
-                "refill_rate": refill_rate,
-                "time_to_refill": (
-                    (bucket_size - remaining_tokens) / refill_rate
+                # Set expiration time (tokens expire after bucket could be
+                # completely refilled + buffer)
+                expiration = (
+                    int(math.ceil(bucket_size / refill_rate) + 60)
                     if refill_rate > 0
-                    else 0
-                ),
-            }
-        else:
-            # Request cannot be served - update last_refill time but don't
-            # consume tokens
-            bucket_data["tokens"] = current_tokens
-            bucket_data["last_refill"] = current_time
+                    else 3600
+                )
 
-            expiration = (
-                int(math.ceil(bucket_size / refill_rate) + 60)
-                if refill_rate > 0
-                else 3600
-            )
+                try:
+                    backend.set(bucket_key, json.dumps(new_bucket_data), expiration)
+                except Exception:
+                    # If backend doesn't support expiration, try without it
+                    backend.set(bucket_key, json.dumps(new_bucket_data))
 
-            try:
-                backend.set(bucket_key, json.dumps(bucket_data), expiration)
-            except Exception:
-                backend.set(bucket_key, json.dumps(bucket_data))
+                return True, {
+                    "tokens_remaining": remaining_tokens,
+                    "tokens_requested": tokens_requested,
+                    "bucket_size": bucket_size,
+                    "refill_rate": refill_rate,
+                    "time_to_refill": (
+                        (bucket_size - remaining_tokens) / refill_rate
+                        if refill_rate > 0
+                        else 0
+                    ),
+                }
+            else:
+                # Request cannot be served - update last_refill time but don't
+                # consume tokens
+                bucket_data["tokens"] = current_tokens
+                bucket_data["last_refill"] = current_time
 
-            return False, {
-                "tokens_remaining": current_tokens,
-                "tokens_requested": tokens_requested,
-                "bucket_size": bucket_size,
-                "refill_rate": refill_rate,
-                "time_to_refill": (
-                    (tokens_requested - current_tokens) / refill_rate
+                expiration = (
+                    int(math.ceil(bucket_size / refill_rate) + 60)
                     if refill_rate > 0
-                    else 0
-                ),
-            }
+                    else 3600
+                )
+
+                try:
+                    backend.set(bucket_key, json.dumps(bucket_data), expiration)
+                except Exception:
+                    backend.set(bucket_key, json.dumps(bucket_data))
+
+                return False, {
+                    "tokens_remaining": current_tokens,
+                    "tokens_requested": tokens_requested,
+                    "bucket_size": bucket_size,
+                    "refill_rate": refill_rate,
+                    "time_to_refill": (
+                        (tokens_requested - current_tokens) / refill_rate
+                        if refill_rate > 0
+                        else 0
+                    ),
+                }
 
     def _generic_token_bucket_info(
         self, backend: Any, key: str, bucket_size: int, refill_rate: float

--- a/django_smart_ratelimit/backends/utils.py
+++ b/django_smart_ratelimit/backends/utils.py
@@ -285,9 +285,17 @@ def parse_rate(rate: str) -> Tuple[int, int]:
             "m": 60,  # minute
             "h": 3600,  # hour
             "d": 86400,  # day
+            # v3: long-form aliases for DRF/API-Gateway compatibility
+            "sec": 1,
+            "second": 1,
+            "min": 60,
+            "minute": 60,
+            "hr": 3600,
+            "hour": 3600,
+            "day": 86400,
         }
 
-        # Simple format: "10/m"
+        # Simple format: "10/m", "10/minute"
         if period_str in period_map:
             period = period_map[period_str]
             return limit, period

--- a/django_smart_ratelimit/decorator.py
+++ b/django_smart_ratelimit/decorator.py
@@ -583,11 +583,11 @@ def rate_limit(
                 try:
                     # Use async increment if available
                     if hasattr(backend_instance, "aincr"):
-                        current_count = await backend_instance.aincr(
+                        current_count = await backend_instance.aincr(  # type: ignore[call-arg]
                             limit_key, period, request_cost
                         )
                     else:
-                        current_count = await sync_to_async(backend_instance.incr)(
+                        current_count = await sync_to_async(backend_instance.incr)(  # type: ignore[call-arg]
                             limit_key, period, request_cost
                         )
                 except TypeError:

--- a/django_smart_ratelimit/decorator.py
+++ b/django_smart_ratelimit/decorator.py
@@ -20,10 +20,17 @@ from .algorithms import TokenBucketAlgorithm
 from .backends import get_async_backend, get_backend
 from .backends.utils import parse_rate, validate_rate_config
 from .context import RateLimitContext
-from .exceptions import BackendError
+from .exceptions import BackendError, KeyGenerationError
 from .key_functions import generate_key
 from .messages import ERROR_RATE_LIMIT_EXCEEDED
 from .performance import get_metrics
+from .pipeline import (
+    POLICY_ALLOW,
+    POLICY_DENY,
+    apply_policy_lists,
+    handle_shadow_decision,
+    resolve_effective_rate,
+)
 from .utils import (
     HttpResponseTooManyRequests,
     add_rate_limit_headers,
@@ -75,25 +82,85 @@ def _get_request_from_args(*args: Any, **kwargs: Any) -> Optional[Any]:
     return None
 
 
+# In-process cache for first-request-aligned reset times. When
+# ``align_window_to_clock`` is False, the very first request in a window
+# establishes a reset_time of ``now + period``; subsequent calls within that
+# window must return the SAME value, otherwise X-RateLimit-Reset drifts
+# forward on every call and clients can never sleep accurately. This dict
+# is keyed by ``limit_key`` and stores ``(reset_time, expires_at)``. Entries
+# are pruned when they're past their reset_time, which bounds the dict size
+# at roughly the number of currently-active rate-limit keys.
+_reset_time_guard = __import__("threading").Lock()
+_reset_time_cache: Dict[str, tuple] = {}
+
+
+def _get_first_aligned_reset_time(limit_key: str, period: int) -> int:
+    """Return the cached first-request reset time, computing it if absent.
+
+    Across calls within the same window we want the SAME timestamp returned —
+    that's what makes ``Retry-After`` and ``X-RateLimit-Reset`` honest. Across
+    workers, multiple workers may compute slightly different reset times for
+    the same key (each worker has its own cache); that's an acceptable price
+    for keeping this hot path lock-free per worker. Operators who need
+    cross-worker stability should switch to ``align_window_to_clock=True``,
+    which is the default.
+    """
+    now = time.time()
+    cached = _reset_time_cache.get(limit_key)
+    if cached and cached[0] > now:
+        return int(cached[0])
+
+    with _reset_time_guard:
+        # Re-check under the guard in case a concurrent caller filled it.
+        cached = _reset_time_cache.get(limit_key)
+        if cached and cached[0] > now:
+            return int(cached[0])
+
+        reset_time = int(now + period)
+        _reset_time_cache[limit_key] = (reset_time, reset_time)
+
+        # Opportunistic cleanup: drop any entries whose reset has already
+        # passed. We do this inside the guard while we hold it. Bounded at
+        # 64 evictions per call so a giant cache can't stall a single
+        # request.
+        if len(_reset_time_cache) > 256:
+            stale = [k for k, v in _reset_time_cache.items() if v[1] <= now][:64]
+            for k in stale:
+                _reset_time_cache.pop(k, None)
+
+        return reset_time
+
+
 def _calculate_stable_reset_time_sliding_window(
-    period: int, align_to_clock: bool = True
+    period: int,
+    align_to_clock: bool = True,
+    limit_key: Optional[str] = None,
 ) -> int:
     """
     Calculate a stable reset time for sliding window algorithm.
 
-    Instead of using the constantly moving window approach, we calculate a stable
-    reset time based on fixed time buckets. This provides users with predictable
-    reset times while maintaining the sliding window behavior for rate limiting.
+    Two stability modes are supported:
+
+    * ``align_to_clock=True`` (default): compute reset time from the current
+      clock-aligned bucket boundary. Stable across workers and processes
+      because everyone agrees on the wall clock; recommended for production.
+
+    * ``align_to_clock=False``: use first-request semantics — the reset time
+      is ``now + period`` for the first caller, and subsequent callers within
+      the same window get back the cached value. ``limit_key`` MUST be
+      provided in this mode; without it we cannot key the cache and would
+      regress to the old drifting behavior. If it's missing we fall back to
+      the clock-aligned calculation as a safer default.
 
     Args:
         period: Time period in seconds for the rate limit window
-        align_to_clock: If True, align to clock boundaries. If False, use request time.
+        align_to_clock: If True, align to clock boundaries. If False, use
+            first-request time anchored per ``limit_key``.
+        limit_key: Required when ``align_to_clock=False``; ignored otherwise.
 
     Returns:
         Stable reset time as Unix timestamp
     """
-    import time
-
     current_time = time.time()
 
     if align_to_clock:
@@ -106,11 +173,16 @@ def _calculate_stable_reset_time_sliding_window(
         # advance to the next bucket to give users reasonable time
         if reset_time - current_time < 5:
             reset_time += period
-    else:
-        # First-request aligned: reset time is simply current_time + period
-        reset_time = int(current_time + period)
+        return reset_time
 
-    return reset_time
+    if limit_key:
+        return _get_first_aligned_reset_time(limit_key, period)
+
+    # No key to anchor first-request alignment — return the drifting
+    # ``now + period`` value. This preserves backward compatibility for
+    # direct callers that pass no key; use _get_reset_time() or supply a
+    # limit_key to opt into stable Retry-After values.
+    return int(current_time + period)
 
 
 def _get_reset_time(backend_instance: Any, limit_key: str, period: int) -> int:
@@ -136,14 +208,20 @@ def _get_reset_time(backend_instance: Any, limit_key: str, period: int) -> int:
             hasattr(backend_instance, "_algorithm")
             and backend_instance._algorithm == "sliding_window"
         ):
-            return _calculate_stable_reset_time_sliding_window(period, align_to_clock)
+            return _calculate_stable_reset_time_sliding_window(
+                period, align_to_clock, limit_key=limit_key
+            )
 
         return reset_time
     except (AttributeError, NotImplementedError) as e:
         logger.debug(f"Failed to get reset time from backend: {e}. Using fallback.")
         if align_to_clock:
-            return _calculate_stable_reset_time_sliding_window(period, align_to_clock)
-        return int(time.time() + period)
+            return _calculate_stable_reset_time_sliding_window(
+                period, align_to_clock, limit_key=limit_key
+            )
+        # First-request-aligned fallback: cache by limit_key so repeat callers
+        # within the window see the same Retry-After.
+        return _get_first_aligned_reset_time(limit_key, period)
 
 
 def _create_rate_limit_response(
@@ -312,11 +390,19 @@ def rate_limit(
     settings: Optional[Any] = None,
     adaptive: Optional[Union[str, AdaptiveRateLimiter]] = None,
     response_callback: Optional[Callable] = None,
+    cost: Union[int, Callable[..., int]] = 1,
+    shadow: bool = False,
+    allow_list: Any = None,
+    deny_list: Any = None,
 ) -> Callable:
     """Apply rate limiting to a view or function.
 
     Args:
-        key: Rate limit key or callable that returns a key
+        key: Rate limit key or callable that returns a key. Since v3.0.0, a
+            callable that returns an empty string or None raises
+            ``KeyGenerationError`` instead of silently collapsing onto a
+            shared bucket. If you want to skip rate limiting for a specific
+            request, use ``skip_if=`` instead.
         rate: Rate limit in format "10/m" (10 requests per minute).
               If None, uses default. Note: When using adaptive rate limiting,
               this value is used as the period only; the limit is determined
@@ -334,6 +420,20 @@ def rate_limit(
         response_callback: Optional callable ``(request) -> HttpResponse`` for
             custom 429 responses. Overrides the global
             ``RATELIMIT_RESPONSE_HANDLER`` setting.
+        cost: **New in v3.0.0** — cost of each request (default 1). Accepts an
+            int or a callable ``(request) -> int``. Useful for weighted rate
+            limits where expensive operations consume more of the budget.
+            Currently honored by token_bucket algorithm natively and by
+            standard algorithms via repeated increments.
+        shadow: **New in v3.0.0** — when True, rate-limit decisions are
+            evaluated and logged (including OTel events) but never actually
+            enforced. Use this to roll out a new limit safely: observe what
+            would be blocked before flipping to enforcement.
+        allow_list: **New in v3.0.0** — CIDR allow-list of IPs that bypass
+            rate limiting entirely. Accepts an :class:`IPList`, iterable of
+            CIDRs, file path, or URL.
+        deny_list: **New in v3.0.0** — CIDR deny-list of IPs to block before
+            rate limiting runs. Takes precedence over allow_list.
 
 
     Returns:
@@ -362,6 +462,19 @@ def rate_limit(
         @rate_limit(key='ip', rate='100/m', adaptive='api')
         def api_view(_request):
             return JsonResponse({'status': 'ok'})
+
+        # Shadow mode for safe rollout (v3.0.0)
+        @rate_limit(key='ip', rate='10/m', shadow=True)
+        def my_view(_request):
+            ...
+
+        # Cost-based weighted limiting (v3.0.0)
+        @rate_limit(
+            key='user', rate='100/m',
+            cost=lambda req: 5 if req.path.startswith('/export') else 1,
+        )
+        def my_view(_request):
+            ...
     """
 
     def decorator(func: Callable) -> Callable:
@@ -408,6 +521,35 @@ def rate_limit(
                             str(e),
                         )
 
+                # Allow/deny list policy — evaluated before rate check so a
+                # deny-listed IP is blocked immediately and an allow-listed IP
+                # skips the backend entirely. In shadow mode a deny still logs
+                # but passes through so operators can tune the list safely.
+                policy = apply_policy_lists(
+                    _request, allow_list=allow_list, deny_list=deny_list
+                )
+                if policy == POLICY_ALLOW:
+                    return await func(*args, **kwargs)
+                if policy == POLICY_DENY:
+                    if shadow:
+                        handle_shadow_decision(
+                            allowed=False,
+                            shadow=True,
+                            request=_request,
+                            key="deny_list",
+                            limit=0,
+                            remaining=0,
+                            algorithm="policy",
+                            backend="decorator",
+                        )
+                    else:
+                        response = _create_rate_limit_response(
+                            request=_request,
+                            response_callback=response_callback,
+                        )
+                        add_rate_limit_headers(response, 0, 0, int(time.time()))
+                        return response
+
                 # Setup backend
                 _backend = backend
                 if _backend is None and settings is not None:
@@ -417,44 +559,60 @@ def rate_limit(
                 if algorithm and hasattr(backend_instance, "config"):
                     backend_instance.config["algorithm"] = algorithm
 
-                # Generate key
-                limit_key = generate_key(key, _request, *args, **kwargs)
-                if iscoroutinefunction(key):
-                    # If key generation was async (unlikely with current implementation but possible)
-                    # generate_key currently is sync.
-                    pass
+                # Resolve key + rate + cost + adaptive in one place (v3 pipeline)
+                try:
+                    resolved = resolve_effective_rate(
+                        key=key,
+                        rate=_rate,
+                        request=_request,
+                        args=args,
+                        kwargs=kwargs,
+                        adaptive=adaptive,
+                        cost=cost,
+                    )
+                except KeyGenerationError:
+                    # Configuration error — let it surface so callers fix it.
+                    raise
 
-                # Resolve rate
-                resolved_rate = _rate
-                if callable(resolved_rate):
-                    try:
-                        resolved_rate = resolved_rate(None, _request)
-                        if iscoroutinefunction(_rate):
-                            resolved_rate = await resolved_rate
-                    except TypeError:
-                        resolved_rate = resolved_rate(_request)
-                        if iscoroutinefunction(_rate):
-                            resolved_rate = await resolved_rate
-
-                limit, period = parse_rate(resolved_rate)
-
-                # Apply adaptive rate limiting if configured
-                limit = _apply_adaptive_limit(adaptive, limit)
+                limit_key = resolved.key
+                limit = resolved.limit
+                period = resolved.period
+                request_cost = resolved.cost
 
                 # Check limit
                 try:
                     # Use async increment if available
+                    if hasattr(backend_instance, "aincr"):
+                        current_count = await backend_instance.aincr(
+                            limit_key, period, request_cost
+                        )
+                    else:
+                        current_count = await sync_to_async(backend_instance.incr)(
+                            limit_key, period, request_cost
+                        )
+                except TypeError:
+                    # Backend's incr doesn't accept cost yet (pre-v3 custom
+                    # backend). Fall back to single-token incr and repeat if
+                    # cost > 1 so weighted limiting still works.
                     if hasattr(backend_instance, "aincr"):
                         current_count = await backend_instance.aincr(limit_key, period)
                     else:
                         current_count = await sync_to_async(backend_instance.incr)(
                             limit_key, period
                         )
+                    for _ in range(request_cost - 1):
+                        if hasattr(backend_instance, "aincr"):
+                            current_count = await backend_instance.aincr(
+                                limit_key, period
+                            )
+                        else:
+                            current_count = await sync_to_async(backend_instance.incr)(
+                                limit_key, period
+                            )
                 except BackendError as e:
                     # Handle backend errors
                     if not backend_instance.fail_open:
                         if _settings and _settings.exception_handler:
-                            # Async handler support? Standard handler returns HttpResponse
                             handler = get_exception_handler()
                             return handler(_request, e)
                         else:
@@ -465,16 +623,27 @@ def rate_limit(
                             )
                     current_count = 0
 
-                # Check if limited
-                if current_count > limit:
+                # Check if limited, apply shadow mode
+                is_allowed = current_count <= limit
+                remaining = max(0, limit - current_count)
+                decision = handle_shadow_decision(
+                    allowed=is_allowed,
+                    shadow=shadow,
+                    request=_request,
+                    key=limit_key,
+                    limit=limit,
+                    remaining=remaining,
+                    algorithm=algorithm or "sliding_window",
+                    backend=type(backend_instance).__name__,
+                    cost=request_cost,
+                )
+
+                if not decision.allow:
                     if block:
                         response = _create_rate_limit_response(
                             request=_request,
                             response_callback=response_callback,
                         )
-                        # We need reset time.
-                        # backend.get_reset_time might be sync. Safe to call if it's just math/cache lookup?
-                        # Ideally use async version if exists, or sync_to_async
                         reset_time = int(time.time() + period)
                         add_rate_limit_headers(response, limit, 0, reset_time)
                         return response
@@ -483,7 +652,6 @@ def rate_limit(
                 response = await func(*args, **kwargs)
 
                 # Add headers
-                remaining = max(0, limit - current_count)
                 reset_time = int(time.time() + period)
 
                 if (
@@ -528,6 +696,34 @@ def rate_limit(
                             str(e),
                         )
 
+                # Allow/deny list policy check (v3) — evaluated before any
+                # backend work so deny-listed IPs never touch the cache. In
+                # shadow mode a deny still logs but passes through.
+                policy = apply_policy_lists(
+                    _request, allow_list=allow_list, deny_list=deny_list
+                )
+                if policy == POLICY_ALLOW:
+                    return func(*args, **kwargs)
+                if policy == POLICY_DENY:
+                    if shadow:
+                        handle_shadow_decision(
+                            allowed=False,
+                            shadow=True,
+                            request=_request,
+                            key="deny_list",
+                            limit=0,
+                            remaining=0,
+                            algorithm="policy",
+                            backend="decorator",
+                        )
+                    else:
+                        response = _create_rate_limit_response(
+                            request=_request,
+                            response_callback=response_callback,
+                        )
+                        add_rate_limit_headers(response, 0, 0, int(time.time()))
+                        return response
+
                 # Get the backend and configure algorithm
                 _backend = backend
                 if _backend is None and settings is not None:
@@ -537,30 +733,24 @@ def rate_limit(
                 if algorithm and hasattr(backend_instance, "config"):
                     backend_instance.config["algorithm"] = algorithm
 
-                # Generate the rate limit key and parse rate
-                limit_key = generate_key(key, _request, *args, **kwargs)
+                # Resolve key, rate, cost, adaptive via the v3 pipeline.
+                try:
+                    resolved = resolve_effective_rate(
+                        key=key,
+                        rate=_rate,
+                        request=_request,
+                        args=args,
+                        kwargs=kwargs,
+                        adaptive=adaptive,
+                        cost=cost,
+                    )
+                except KeyGenerationError:
+                    raise
 
-                # Handle dynamic rate (callable)
-                resolved_rate = _rate
-                if callable(resolved_rate):
-                    # Helper to call rate function with appropriate arguments
-                    # Compatibility with django-ratelimit: func(group, request)
-                    # But we don't strictly have 'group'. potentially pass key or None.
-                    # Inspecting views.py: get_tier_rate(grupo, request)
-                    try:
-                        resolved_rate = resolved_rate(None, _request)
-                    except TypeError:
-                        # Fallback if function only takes one argument
-                        try:
-                            resolved_rate = resolved_rate(_request)
-                        except TypeError:
-                            # Last resort, maybe no args?
-                            resolved_rate = resolved_rate()
-
-                limit, period = parse_rate(resolved_rate)
-
-                # Apply adaptive rate limiting if configured
-                limit = _apply_adaptive_limit(adaptive, limit)
+                limit_key = resolved.key
+                limit = resolved.limit
+                period = resolved.period
+                request_cost = resolved.cost
 
                 # Handle middleware vs decorator scenarios
                 if middleware_processed:
@@ -575,6 +765,8 @@ def rate_limit(
                         period,
                         block,
                         response_callback=response_callback,
+                        shadow=shadow,
+                        cost=request_cost,
                     )
 
                 # Handle algorithm-specific logic
@@ -591,6 +783,8 @@ def rate_limit(
                         block,
                         algorithm_config,
                         response_callback=response_callback,
+                        shadow=shadow,
+                        cost=request_cost,
                     )
 
                 # Standard rate limiting (sliding_window or fixed_window)
@@ -605,6 +799,8 @@ def rate_limit(
                     period,
                     block,
                     response_callback=response_callback,
+                    shadow=shadow,
+                    cost=request_cost,
                 )
 
         return wrapper
@@ -623,6 +819,8 @@ def _handle_middleware_processed_request(
     period: int,
     block: bool,
     response_callback: Optional[Callable] = None,
+    shadow: bool = False,
+    cost: int = 1,
 ) -> Any:
     """Handle request when middleware has already processed it."""
     # Even though middleware processed the request, the decorator should still
@@ -636,14 +834,29 @@ def _handle_middleware_processed_request(
     )
 
     try:
-        ctx = check_rate_limit(ctx, backend_instance)
+        ctx = check_rate_limit(ctx, backend_instance, cost=cost)
     except BackendError as e:
         # Handle backend errors based on configuration
         handler = get_exception_handler()
         return handler(_request, e)
 
+    # Apply shadow mode: if shadow=True and the request would have been
+    # blocked, flip the decision to allow but emit a structured log line.
+    decision = handle_shadow_decision(
+        allowed=ctx.allowed,
+        shadow=shadow,
+        request=_request,
+        key=limit_key,
+        limit=limit,
+        remaining=ctx.remaining,
+        algorithm=getattr(backend_instance, "_algorithm", "sliding_window"),
+        backend=type(backend_instance).__name__,
+        cost=cost,
+    )
+    ctx_allowed = decision.allow
+
     # Check if the decorator's limit is exceeded
-    if not ctx.allowed:
+    if not ctx_allowed:
         if block:
             # Block the request and return 429
             return _handle_rate_limit_exceeded(
@@ -691,13 +904,37 @@ def _handle_token_bucket_algorithm(
     block: bool,
     algorithm_config: Optional[Dict[str, Any]],
     response_callback: Optional[Callable] = None,
+    shadow: bool = False,
+    cost: int = 1,
 ) -> Any:
     """Handle token bucket algorithm logic."""
     try:
         algorithm_instance = TokenBucketAlgorithm(algorithm_config)
-        is_allowed, metadata = algorithm_instance.is_allowed(
-            backend_instance, limit_key, limit, period
+        # Token bucket natively supports cost via its ``tokens_requested`` arg.
+        try:
+            is_allowed, metadata = algorithm_instance.is_allowed(
+                backend_instance, limit_key, limit, period, tokens_requested=cost
+            )
+        except TypeError:
+            # Older algorithm signature without tokens_requested kwarg —
+            # fall back to 1 token per request.
+            is_allowed, metadata = algorithm_instance.is_allowed(
+                backend_instance, limit_key, limit, period
+            )
+
+        # Apply shadow mode.
+        decision = handle_shadow_decision(
+            allowed=is_allowed,
+            shadow=shadow,
+            request=_request,
+            key=limit_key,
+            limit=limit,
+            remaining=int(metadata.get("tokens_remaining", 0)) if metadata else 0,
+            algorithm="token_bucket",
+            backend=type(backend_instance).__name__,
+            cost=cost,
         )
+        is_allowed = decision.allow
 
         if not is_allowed:
             if block:
@@ -728,7 +965,7 @@ def _handle_token_bucket_algorithm(
             "Falling back to standard rate limiting.",
             str(e),
         )
-        # Fall back to standard algorithm
+        # Fall back to standard algorithm, preserving shadow + cost
         return _handle_standard_rate_limiting(
             func,
             _request,
@@ -739,16 +976,25 @@ def _handle_token_bucket_algorithm(
             limit,
             period,
             block,
+            response_callback=response_callback,
+            shadow=shadow,
+            cost=cost,
         )
 
 
-def check_rate_limit(ctx: RateLimitContext, backend_instance: Any) -> RateLimitContext:
+def check_rate_limit(
+    ctx: RateLimitContext,
+    backend_instance: Any,
+    cost: int = 1,
+) -> RateLimitContext:
     """
     Check rate limit using context and backend.
 
     Args:
         ctx: The rate limit context
         backend_instance: The backend to use
+        cost: Number of tokens / increments to consume for this request.
+              New in v3.0.0 — defaults to 1 for backwards compatibility.
 
     Returns:
         Updated context with result
@@ -760,11 +1006,24 @@ def check_rate_limit(ctx: RateLimitContext, backend_instance: Any) -> RateLimitC
             current_count, remaining = backend_instance.increment(
                 ctx.key, ctx.period, ctx.limit
             )
+            # Cost > 1 with a backend that doesn't support cost natively:
+            # repeat the increment so weighted limiting still works. This is
+            # non-atomic per-token; backends that care should implement a
+            # native incr(..., cost=N).
+            for _ in range(cost - 1):
+                current_count, remaining = backend_instance.increment(
+                    ctx.key, ctx.period, ctx.limit
+                )
             ctx.current_count = current_count
             ctx.remaining = remaining
         else:
-            # Basic incr
-            current_count = backend_instance.incr(ctx.key, ctx.period)
+            # Basic incr — try passing cost kwarg first (v3 backend contract)
+            try:
+                current_count = backend_instance.incr(ctx.key, ctx.period, cost)
+            except TypeError:
+                current_count = backend_instance.incr(ctx.key, ctx.period)
+                for _ in range(cost - 1):
+                    current_count = backend_instance.incr(ctx.key, ctx.period)
             ctx.current_count = current_count
             ctx.remaining = max(0, ctx.limit - ctx.current_count)
 
@@ -805,6 +1064,8 @@ def _handle_standard_rate_limiting(
     period: int,
     block: bool,
     response_callback: Optional[Callable] = None,
+    shadow: bool = False,
+    cost: int = 1,
 ) -> Any:
     """Handle standard rate limiting (sliding_window or fixed_window)."""
     # Create context
@@ -817,10 +1078,26 @@ def _handle_standard_rate_limiting(
     )
 
     try:
-        ctx = check_rate_limit(ctx, backend_instance)
+        ctx = check_rate_limit(ctx, backend_instance, cost=cost)
     except BackendError as e:
         handler = get_exception_handler()
         return handler(_request, e)
+
+    # Apply shadow mode and observability in one place.
+    decision = handle_shadow_decision(
+        allowed=ctx.allowed,
+        shadow=shadow,
+        request=_request,
+        key=limit_key,
+        limit=limit,
+        remaining=ctx.remaining,
+        algorithm=getattr(backend_instance, "_algorithm", "sliding_window"),
+        backend=type(backend_instance).__name__,
+        cost=cost,
+    )
+    ctx.allowed = decision.allow
+    if decision.shadowed:
+        ctx.metadata["shadow"] = True
 
     # Attach context to request
     if _request:

--- a/django_smart_ratelimit/integrations/__init__.py
+++ b/django_smart_ratelimit/integrations/__init__.py
@@ -1,0 +1,24 @@
+"""
+Integrations with external frameworks and libraries.
+
+This package provides adapters that integrate django-smart-ratelimit with
+popular Django packages like Django REST Framework.
+"""
+
+__all__ = [
+    "SmartRateLimitThrottle",
+    "UserRateLimitThrottle",
+    "AnonRateLimitThrottle",
+    "ScopedRateLimitThrottle",
+]
+
+try:
+    from .drf import (
+        AnonRateLimitThrottle,
+        ScopedRateLimitThrottle,
+        SmartRateLimitThrottle,
+        UserRateLimitThrottle,
+    )
+except ImportError:
+    # DRF not installed; classes won't be available but package won't fail
+    pass

--- a/django_smart_ratelimit/integrations/drf.py
+++ b/django_smart_ratelimit/integrations/drf.py
@@ -1,0 +1,436 @@
+"""
+Django REST Framework throttle adapter for django-smart-ratelimit.
+
+This module provides BaseThrottle subclasses that integrate django-smart-ratelimit
+with DRF's throttling system, allowing you to use smart rate limiting algorithms
+and backends within standard DRF throttle_classes configuration.
+
+Example:
+    In your DRF view:
+
+        from rest_framework.views import APIView
+        from django_smart_ratelimit.integrations.drf import UserRateLimitThrottle
+
+        class MyAPIView(APIView):
+            throttle_classes = [UserRateLimitThrottle]
+
+            def get(self, request):
+                return Response({"message": "ok"})
+
+    In settings.py:
+
+        REST_FRAMEWORK = {
+            "DEFAULT_THROTTLE_CLASSES": [
+                "django_smart_ratelimit.integrations.drf.UserRateLimitThrottle",
+                "django_smart_ratelimit.integrations.drf.AnonRateLimitThrottle",
+            ],
+            "DEFAULT_THROTTLE_RATES": {
+                "user": "1000/hour",
+                "anon": "100/hour",
+            },
+        }
+"""
+
+import logging
+import time
+from typing import Any, Optional, Tuple
+
+from django.http import HttpRequest
+
+from django_smart_ratelimit.backends import get_backend
+
+logger = logging.getLogger(__name__)
+
+# Graceful DRF import with helpful error
+try:
+    from rest_framework.throttling import BaseThrottle
+except ImportError:
+    BaseThrottle = None  # type: ignore
+
+
+class SmartRateLimitThrottle(BaseThrottle):  # type: ignore
+    """
+    BaseThrottle adapter for django-smart-ratelimit.
+
+    This class bridges DRF's throttling interface with django-smart-ratelimit's
+    flexible rate limiting backends and algorithms.
+
+    Attributes:
+        scope: DRF-style throttle scope (e.g., 'user', 'anon'). Used to look up
+               rate from DRF's THROTTLE_RATES setting.
+        rate: Optional rate override (format: "10/m", "100/hour"). If not set,
+              uses THROTTLE_RATES[scope]. Supports callable for dynamic rates.
+        algorithm: Rate limiting algorithm: 'sliding_window' (default), 'fixed_window',
+                  or 'token_bucket'.
+        cost: Weight of each request (default: 1). Can be overridden by
+              get_cost(request, view) method.
+        key_func: Optional callable that returns a cache key from (request, view).
+                 If not set, defaults to get_cache_key().
+
+    Example:
+        class MyThrottle(SmartRateLimitThrottle):
+            scope = "my_scope"
+            rate = "50/hour"
+            algorithm = "sliding_window"
+
+            def get_cache_key(self, request, view):
+                if request.user.is_authenticated:
+                    return f"user:{request.user.id}"
+                return self.get_ident(request)
+    """
+
+    def __init__(self):
+        """Initialize throttle, raising helpful error if DRF not installed."""
+        if BaseThrottle is None:
+            raise ImportError(
+                "django-rest-framework is required for SmartRateLimitThrottle. "
+                "Install it with: pip install djangorestframework"
+            )
+        super().__init__()
+
+        # Check attributes exist
+        if not hasattr(self, "scope"):
+            self.scope = None
+
+        self.algorithm = getattr(self, "algorithm", "sliding_window")
+        self.cost = getattr(self, "cost", 1)
+        self.key_func = getattr(self, "key_func", None)
+
+        # Rate will be resolved in allow_request from either:
+        # 1. self.rate attribute
+        # 2. DRF settings THROTTLE_RATES[scope]
+        self.rate = getattr(self, "rate", None)
+
+        # Cache for reset time
+        self._last_reset_time: Optional[int] = None
+
+    def get_cache_key(self, request: HttpRequest, view: Any) -> Optional[str]:
+        """
+        Generate the cache key for rate limiting.
+
+        Default implementation: user ID if authenticated, else IP address.
+        Override to customize key generation.
+
+        Args:
+            request: DRF request object
+            view: The view being throttled
+
+        Returns:
+            Cache key string, or None to skip throttling
+        """
+        from django_smart_ratelimit.key_functions import get_ip_key
+
+        if hasattr(request, "user") and request.user.is_authenticated:
+            user_id = getattr(request.user, "id", None)
+            if user_id:
+                return f"user:{user_id}"
+
+        return get_ip_key(request)
+
+    def _parse_rate(self, rate: Optional[str]) -> Tuple[int, int]:
+        """
+        Parse rate string into (limit, period_seconds).
+
+        Args:
+            rate: Rate string (e.g., "10/m", "100/hour")
+
+        Returns:
+            Tuple of (limit, period_in_seconds)
+
+        Raises:
+            ValueError: If rate format is invalid
+        """
+        from django_smart_ratelimit.backends.utils import parse_rate
+
+        if not rate:
+            raise ValueError("Rate must be specified")
+        return parse_rate(rate)
+
+    def _get_rate(self, request: HttpRequest, view: Any) -> str:
+        """
+        Resolve the rate limit string for this request.
+
+        Priority:
+        1. self.rate attribute (if not None)
+        2. DRF's REST_FRAMEWORK['THROTTLE_RATES'][scope]
+
+        Args:
+            request: DRF request
+            view: The view being throttled
+
+        Returns:
+            Rate string (e.g., "100/hour")
+
+        Raises:
+            ValueError: If no rate can be resolved
+        """
+        # Support callable rate. Use type(self) to bypass method binding so
+        # a plain function attribute receives (throttle, request) rather than
+        # an extra bound self argument.
+        rate = getattr(type(self), "rate", self.rate)
+        if callable(rate):
+            rate = rate(self, request)
+
+        if rate:
+            return rate
+
+        # Fall back to DRF settings
+        if self.scope:
+            from django.conf import settings
+
+            throttle_rates = getattr(settings, "REST_FRAMEWORK", {}).get(
+                "DEFAULT_THROTTLE_RATES", {}
+            )
+
+            if self.scope in throttle_rates:
+                return throttle_rates[self.scope]
+
+        raise ValueError(
+            f"No rate configured for scope '{self.scope}'. "
+            "Set 'rate' attribute or add to REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']."
+        )
+
+    def get_cost(self, request: HttpRequest, view: Any) -> int:
+        """
+        Get the cost (weight) of this request.
+
+        Override to implement weighted rate limiting (e.g., expensive operations
+        cost more tokens).
+
+        Args:
+            request: DRF request
+            view: The view being throttled
+
+        Returns:
+            Cost in tokens (default: 1)
+        """
+        # Support callable cost attribute. Access via the class to avoid
+        # method binding when users assign a plain function.
+        cost = getattr(type(self), "cost", self.cost)
+        if callable(cost):
+            return cost(request, view)
+        return cost
+
+    def allow_request(self, request: HttpRequest, view: Any) -> bool:
+        """
+        Check if request should be allowed (implements DRF throttle interface).
+
+        Args:
+            request: DRF request object
+            view: The view being throttled
+
+        Returns:
+            True if request is allowed, False to trigger throttle response
+        """
+        # Get cache key. Access key_func via class to avoid method binding
+        # when the user assigns a plain function as a class attribute.
+        key_func = getattr(type(self), "key_func", None) or self.key_func
+        if key_func and callable(key_func):
+            key = key_func(request, view)
+        else:
+            key = self.get_cache_key(request, view)
+
+        if not key:
+            return True  # No key = skip throttling
+
+        # Get rate
+        try:
+            rate_str = self._get_rate(request, view)
+            limit, period = self._parse_rate(rate_str)
+        except Exception as e:
+            logger.warning(f"Failed to parse rate: {e}. Allowing request.")
+            return True
+
+        # Get backend and check rate limit
+        backend = get_backend()
+
+        try:
+            cost = self.get_cost(request, view)
+            # Prefer backends that accept a cost kwarg (v3 contract). Older
+            # backends fall back to a loop of single-token increments so
+            # weighted throttling still works end-to-end.
+            try:
+                count = backend.incr(key, period, cost)
+            except TypeError:
+                count = backend.incr(key, period)
+                for _ in range(max(0, cost - 1)):
+                    count = backend.incr(key, period)
+
+            # ``count`` is the post-incr value; the request is allowed iff the
+            # count BEFORE this request (count - cost) was below the limit.
+            # Using ``< limit`` (not ``<= limit``) because a count equal to
+            # limit means this request pushed us to the boundary — it should
+            # be the last allowed one.
+            allowed = (count - cost) < limit
+
+            # Always store reset time for wait() method — both success & denial
+            # paths may need Retry-After information.
+            reset_time = None
+            try:
+                reset_time = backend.get_reset_time(key)
+            except Exception:
+                reset_time = None
+            if reset_time:
+                self._last_reset_time = reset_time
+            else:
+                self._last_reset_time = int(time.time() + period)
+
+            return allowed
+
+        except Exception as e:
+            # If backend fails and fail_open is True, allow request.
+            # Catch broadly because third-party backends raise varied types.
+            fail_open = getattr(backend, "fail_open", True)
+            if fail_open:
+                logger.warning(f"Backend error, allowing request: {e}")
+                return True
+            logger.error(f"Backend error: {e}")
+            return False
+
+    def throttle_success(self) -> bool:
+        """
+        Called when request is allowed. Required by BaseThrottle interface.
+
+        Returns:
+            Always True
+        """
+        return True
+
+    def throttle_failure(self) -> bool:
+        """
+        Called when request is throttled. Required by BaseThrottle interface.
+
+        Returns:
+            Always False
+        """
+        return False
+
+    def wait(self) -> Optional[float]:
+        """
+        Return seconds until the throttle is reset (for Retry-After header).
+
+        Required by BaseThrottle interface.
+
+        Returns:
+            Seconds to wait, or None
+        """
+        if self._last_reset_time is None:
+            return None
+
+        now = int(time.time())
+        seconds_to_wait = max(0, self._last_reset_time - now)
+
+        return float(seconds_to_wait) if seconds_to_wait > 0 else None
+
+
+class UserRateLimitThrottle(SmartRateLimitThrottle):
+    """
+    Rate limit by authenticated user.
+
+    Scope: 'user'
+    Key: user.id if authenticated, else IP
+
+    Usage in settings.py:
+        REST_FRAMEWORK = {
+            'DEFAULT_THROTTLE_CLASSES': [
+                'django_smart_ratelimit.integrations.drf.UserRateLimitThrottle',
+            ],
+            'DEFAULT_THROTTLE_RATES': {
+                'user': '1000/hour',
+            },
+        }
+    """
+
+    scope = "user"
+
+    def get_cache_key(self, request: HttpRequest, view: Any) -> Optional[str]:
+        """Return user ID if authenticated, else IP address."""
+        from django_smart_ratelimit.key_functions import get_ip_key
+
+        if hasattr(request, "user") and request.user.is_authenticated:
+            user_id = getattr(request.user, "id", None)
+            if user_id:
+                return f"user:{user_id}"
+
+        return get_ip_key(request)
+
+
+class AnonRateLimitThrottle(SmartRateLimitThrottle):
+    """
+    Rate limit anonymous users by IP address.
+
+    Scope: 'anon'
+    Key: IP address
+
+    Usage in settings.py:
+        REST_FRAMEWORK = {
+            'DEFAULT_THROTTLE_CLASSES': [
+                'django_smart_ratelimit.integrations.drf.AnonRateLimitThrottle',
+            ],
+            'DEFAULT_THROTTLE_RATES': {
+                'anon': '100/hour',
+            },
+        }
+    """
+
+    scope = "anon"
+
+    def get_cache_key(self, request: HttpRequest, view: Any) -> Optional[str]:
+        """Return IP address."""
+        from django_smart_ratelimit.key_functions import get_ip_key
+
+        return get_ip_key(request)
+
+
+class ScopedRateLimitThrottle(SmartRateLimitThrottle):
+    """
+    Rate limit based on view's throttle_scope attribute.
+
+    This class allows per-view rate limit configuration without subclassing.
+    Each view can set its own throttle_scope, and the rate is looked up from
+    REST_FRAMEWORK['DEFAULT_THROTTLE_RATES'].
+
+    Usage:
+        class MyView(APIView):
+            throttle_classes = [ScopedRateLimitThrottle]
+            throttle_scope = 'my_api'
+
+            def get(self, request):
+                return Response({"message": "ok"})
+
+        In settings.py:
+            REST_FRAMEWORK = {
+                'DEFAULT_THROTTLE_RATES': {
+                    'my_api': '500/hour',
+                },
+            }
+    """
+
+    def __init__(self):
+        """Initialize without a fixed scope."""
+        super().__init__()
+        self.scope = None  # Will be set from view's throttle_scope
+
+    def allow_request(self, request: HttpRequest, view: Any) -> bool:
+        """
+        Override to set scope from view's throttle_scope attribute.
+
+        Args:
+            request: DRF request
+            view: The view being throttled
+
+        Returns:
+            True if allowed, False to throttle
+        """
+        # Resolve scope from view's throttle_scope attribute
+        if hasattr(view, "throttle_scope"):
+            self.scope = view.throttle_scope
+        else:
+            logger.warning(
+                f"View {view.__class__.__name__} has no 'throttle_scope' attribute. "
+                "Set 'throttle_scope' on the view."
+            )
+            return True
+
+        # Call parent implementation
+        return super().allow_request(request, view)

--- a/django_smart_ratelimit/integrations/drf.py
+++ b/django_smart_ratelimit/integrations/drf.py
@@ -45,10 +45,10 @@ logger = logging.getLogger(__name__)
 try:
     from rest_framework.throttling import BaseThrottle
 except ImportError:
-    BaseThrottle = None  # type: ignore
+    BaseThrottle = None
 
 
-class SmartRateLimitThrottle(BaseThrottle):  # type: ignore
+class SmartRateLimitThrottle(BaseThrottle):
     """
     BaseThrottle adapter for django-smart-ratelimit.
 
@@ -79,7 +79,7 @@ class SmartRateLimitThrottle(BaseThrottle):  # type: ignore
                 return self.get_ident(request)
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize throttle, raising helpful error if DRF not installed."""
         if BaseThrottle is None:
             raise ImportError(
@@ -90,7 +90,7 @@ class SmartRateLimitThrottle(BaseThrottle):  # type: ignore
 
         # Check attributes exist
         if not hasattr(self, "scope"):
-            self.scope = None
+            self.scope: Optional[str] = None
 
         self.algorithm = getattr(self, "algorithm", "sliding_window")
         self.cost = getattr(self, "cost", 1)
@@ -250,7 +250,7 @@ class SmartRateLimitThrottle(BaseThrottle):  # type: ignore
             # backends fall back to a loop of single-token increments so
             # weighted throttling still works end-to-end.
             try:
-                count = backend.incr(key, period, cost)
+                count = backend.incr(key, period, cost)  # type: ignore[call-arg]
             except TypeError:
                 count = backend.incr(key, period)
                 for _ in range(max(0, cost - 1)):
@@ -406,7 +406,7 @@ class ScopedRateLimitThrottle(SmartRateLimitThrottle):
             }
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize without a fixed scope."""
         super().__init__()
         self.scope = None  # Will be set from view's throttle_scope

--- a/django_smart_ratelimit/middleware.py
+++ b/django_smart_ratelimit/middleware.py
@@ -69,6 +69,12 @@ class RateLimitMiddleware:
         self.block = middleware_config.get("BLOCK", True)
         self.skip_paths = middleware_config.get("SKIP_PATHS", [])
         self.rate_limits = middleware_config.get("RATE_LIMITS", {})
+        # v3: optional CIDR-based allow/deny lists. Accept any of:
+        # an IPList instance, iterable of CIDR strings, file path, or URL.
+        self.allow_list = middleware_config.get("ALLOW_LIST", None)
+        self.deny_list = middleware_config.get("DENY_LIST", None)
+        # v3: when True, rate-limit decisions are logged but not enforced.
+        self.shadow = bool(middleware_config.get("SHADOW", False))
 
         # Initialize backend
         self.backend = get_backend(self.backend_name)
@@ -92,6 +98,38 @@ class RateLimitMiddleware:
         # Check if path should be skipped based on configured patterns
         if should_skip_path(request.path, self.skip_paths):
             return self.get_response(request)
+
+        # v3: CIDR allow/deny list check. Deny wins over allow.
+        from .pipeline import (
+            POLICY_ALLOW,
+            POLICY_DENY,
+            apply_policy_lists,
+            handle_shadow_decision,
+        )
+
+        policy = apply_policy_lists(
+            request, allow_list=self.allow_list, deny_list=self.deny_list
+        )
+        if policy == POLICY_ALLOW:
+            return self.get_response(request)
+        if policy == POLICY_DENY:
+            if self.shadow:
+                # Log the block but don't enforce.
+                handle_shadow_decision(
+                    allowed=False,
+                    shadow=True,
+                    request=request,
+                    key="deny_list",
+                    limit=0,
+                    remaining=0,
+                    algorithm="policy",
+                    backend="middleware",
+                )
+            else:
+                message = get_rate_limit_error_message(include_details=True)
+                response = HttpResponseTooManyRequests(message)
+                add_rate_limit_headers(response, 0, 0, int(time.time()))
+                return response
 
         # Get rate limit for this path
         rate = get_rate_for_path(request.path, self.rate_limits, self.default_rate)
@@ -128,7 +166,18 @@ class RateLimitMiddleware:
         )
 
         if current_count > limit:
-            if self.block:
+            # v3: shadow mode downgrades a real block to a log line.
+            decision = handle_shadow_decision(
+                allowed=False,
+                shadow=self.shadow,
+                request=request,
+                key=key,
+                limit=limit,
+                remaining=0,
+                algorithm=getattr(self.backend, "_algorithm", "sliding_window"),
+                backend=type(self.backend).__name__,
+            )
+            if not decision.allow and self.block:
                 message = get_rate_limit_error_message(include_details=True)
                 response = HttpResponseTooManyRequests(message)
                 add_rate_limit_headers(response, limit, 0, int(time.time() + period))
@@ -184,6 +233,37 @@ class RateLimitMiddleware:
         if should_skip_path(request.path, self.skip_paths):
             return await self.get_response(request)
 
+        # v3: CIDR allow/deny list check. Deny wins over allow.
+        from .pipeline import (
+            POLICY_ALLOW,
+            POLICY_DENY,
+            apply_policy_lists,
+            handle_shadow_decision,
+        )
+
+        policy = apply_policy_lists(
+            request, allow_list=self.allow_list, deny_list=self.deny_list
+        )
+        if policy == POLICY_ALLOW:
+            return await self.get_response(request)
+        if policy == POLICY_DENY:
+            if self.shadow:
+                handle_shadow_decision(
+                    allowed=False,
+                    shadow=True,
+                    request=request,
+                    key="deny_list",
+                    limit=0,
+                    remaining=0,
+                    algorithm="policy",
+                    backend="middleware",
+                )
+            else:
+                message = get_rate_limit_error_message(include_details=True)
+                response = HttpResponseTooManyRequests(message)
+                add_rate_limit_headers(response, 0, 0, int(time.time()))
+                return response
+
         # Get rate limit for this path
         rate = get_rate_for_path(request.path, self.rate_limits, self.default_rate)
 
@@ -219,9 +299,18 @@ class RateLimitMiddleware:
         )
 
         if current_count > limit:
-            if self.block:
+            decision = handle_shadow_decision(
+                allowed=False,
+                shadow=self.shadow,
+                request=request,
+                key=key,
+                limit=limit,
+                remaining=0,
+                algorithm=getattr(self.backend, "_algorithm", "sliding_window"),
+                backend=type(self.backend).__name__,
+            )
+            if not decision.allow and self.block:
                 message = get_rate_limit_error_message(include_details=True)
-                # HttpResponseTooManyRequests is a subclass of HttpResponse, which is safe to return in async views
                 response = HttpResponseTooManyRequests(message)
                 add_rate_limit_headers(response, limit, 0, int(time.time() + period))
                 return response

--- a/django_smart_ratelimit/observability/__init__.py
+++ b/django_smart_ratelimit/observability/__init__.py
@@ -1,0 +1,45 @@
+"""
+OpenTelemetry observability integration for Django Smart Ratelimit.
+
+This package provides OpenTelemetry instrumentation for rate limiting operations,
+including spans and metrics collection.
+
+Usage:
+    1. Install optional dependencies:
+        pip install django-smart-ratelimit[opentelemetry]
+
+    2. Initialize at application startup (e.g., in Django AppConfig.ready()):
+        from django_smart_ratelimit.observability import instrument_rate_limit
+        instrument_rate_limit()
+
+    3. The library will emit spans for each rate-limit check and record metrics
+       for allowed/denied requests, token consumption, and backend performance.
+
+Example:
+    In your Django app config:
+
+        from django.apps import AppConfig
+        from django_smart_ratelimit.observability import instrument_rate_limit
+
+        class MyAppConfig(AppConfig):
+            name = 'myapp'
+
+            def ready(self):
+                instrument_rate_limit()
+"""
+
+from .otel import (
+    RateLimitMeter,
+    RateLimitTracer,
+    instrument_rate_limit,
+    record_check,
+    record_rate_limit_decision,
+)
+
+__all__ = [
+    "instrument_rate_limit",
+    "record_check",
+    "record_rate_limit_decision",
+    "RateLimitTracer",
+    "RateLimitMeter",
+]

--- a/django_smart_ratelimit/observability/otel.py
+++ b/django_smart_ratelimit/observability/otel.py
@@ -53,14 +53,14 @@ from typing import Any, Dict, Optional
 # Try to import OpenTelemetry
 try:
     from opentelemetry import metrics, trace
-    from opentelemetry.trace import Status, StatusCode, Tracer
     from opentelemetry.metrics import Meter
+    from opentelemetry.trace import Status, StatusCode, Tracer
 
     HAS_OTEL = True
 except ImportError:
     HAS_OTEL = False
-    Tracer = Any  # type: ignore
-    Meter = Any  # type: ignore
+    Tracer = Any
+    Meter = Any
 
 
 # Global tracer and meter (set by instrument_rate_limit)
@@ -92,19 +92,15 @@ class NoOpSpanContext:
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """Exit context manager."""
-        pass
 
     def set_attribute(self, key: str, value: Any) -> None:
         """No-op set_attribute."""
-        pass
 
     def add_event(self, name: str, attributes: Optional[Dict[str, Any]] = None) -> None:
         """No-op add_event."""
-        pass
 
     def set_status(self, status: Any) -> None:
         """No-op set_status."""
-        pass
 
 
 class NoOpMeter:
@@ -128,31 +124,22 @@ class NoOpMeter:
 class NoOpCounter:
     """No-op counter."""
 
-    def add(
-        self, value: float, attributes: Optional[Dict[str, Any]] = None
-    ) -> None:
+    def add(self, value: float, attributes: Optional[Dict[str, Any]] = None) -> None:
         """No-op add."""
-        pass
 
 
 class NoOpHistogram:
     """No-op histogram."""
 
-    def record(
-        self, value: float, attributes: Optional[Dict[str, Any]] = None
-    ) -> None:
+    def record(self, value: float, attributes: Optional[Dict[str, Any]] = None) -> None:
         """No-op record."""
-        pass
 
 
 class NoOpUpDownCounter:
     """No-op up-down counter."""
 
-    def add(
-        self, value: float, attributes: Optional[Dict[str, Any]] = None
-    ) -> None:
+    def add(self, value: float, attributes: Optional[Dict[str, Any]] = None) -> None:
         """No-op add."""
-        pass
 
 
 class RateLimitTracer:

--- a/django_smart_ratelimit/observability/otel.py
+++ b/django_smart_ratelimit/observability/otel.py
@@ -1,0 +1,504 @@
+"""
+OpenTelemetry instrumentation for rate limiting.
+
+Provides span and metrics instrumentation for rate limit checks. Works with or
+without opentelemetry libraries installed by providing no-op fallbacks.
+
+Spans:
+    - ratelimit.check: Created for each rate limit check with attributes:
+        - ratelimit.key: The rate limit key
+        - ratelimit.limit: Configured limit
+        - ratelimit.remaining: Remaining count after request
+        - ratelimit.algorithm: Algorithm name (sliding_window, token_bucket, etc.)
+        - ratelimit.backend: Backend class name
+        - ratelimit.decision: "allowed" or "denied"
+        - ratelimit.shadow: True if shadow mode
+        - ratelimit.cost: Tokens consumed (default 1)
+
+Metrics:
+    - ratelimit.requests.total (Counter): Total checks with attributes:
+        decision (allowed/denied), backend, algorithm, shadow
+    - ratelimit.tokens.consumed (Counter): Sum of tokens consumed with attributes:
+        backend, algorithm
+    - ratelimit.check.duration_ms (Histogram): Check duration in milliseconds
+        with attributes: backend, algorithm
+    - ratelimit.backend.errors (UpDownCounter): Backend errors with attribute:
+        error_type
+
+Example:
+    from django_smart_ratelimit.observability import (
+        instrument_rate_limit,
+        record_check,
+    )
+
+    # Initialize at app startup
+    instrument_rate_limit()
+
+    # Record a rate limit decision
+    record_check(
+        key="user:123",
+        limit=100,
+        remaining=42,
+        algorithm="sliding_window",
+        backend="RedisBackend",
+        allowed=True,
+        cost=1,
+        duration_ms=2.5,
+    )
+"""
+
+import threading
+from typing import Any, Dict, Optional
+
+# Try to import OpenTelemetry
+try:
+    from opentelemetry import metrics, trace
+    from opentelemetry.trace import Status, StatusCode, Tracer
+    from opentelemetry.metrics import Meter
+
+    HAS_OTEL = True
+except ImportError:
+    HAS_OTEL = False
+    Tracer = Any  # type: ignore
+    Meter = Any  # type: ignore
+
+
+# Global tracer and meter (set by instrument_rate_limit)
+_global_tracer: Optional["RateLimitTracer"] = None
+_global_meter: Optional["RateLimitMeter"] = None
+_lock = threading.Lock()
+
+
+class NoOpTracer:
+    """No-op tracer when OpenTelemetry is not installed."""
+
+    def start_span(
+        self,
+        name: str,
+        attributes: Optional[Dict[str, Any]] = None,
+        record_exception: bool = False,
+        set_status_on_exception: bool = True,
+    ) -> "NoOpSpanContext":
+        """Return a no-op span context."""
+        return NoOpSpanContext()
+
+
+class NoOpSpanContext:
+    """No-op span context manager."""
+
+    def __enter__(self) -> "NoOpSpanContext":
+        """Enter context manager."""
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Exit context manager."""
+        pass
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        """No-op set_attribute."""
+        pass
+
+    def add_event(self, name: str, attributes: Optional[Dict[str, Any]] = None) -> None:
+        """No-op add_event."""
+        pass
+
+    def set_status(self, status: Any) -> None:
+        """No-op set_status."""
+        pass
+
+
+class NoOpMeter:
+    """No-op meter when OpenTelemetry is not installed."""
+
+    def create_counter(self, name: str, description: str = "") -> "NoOpCounter":
+        """Create a no-op counter."""
+        return NoOpCounter()
+
+    def create_histogram(self, name: str, description: str = "") -> "NoOpHistogram":
+        """Create a no-op histogram."""
+        return NoOpHistogram()
+
+    def create_up_down_counter(
+        self, name: str, description: str = ""
+    ) -> "NoOpUpDownCounter":
+        """Create a no-op up-down counter."""
+        return NoOpUpDownCounter()
+
+
+class NoOpCounter:
+    """No-op counter."""
+
+    def add(
+        self, value: float, attributes: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """No-op add."""
+        pass
+
+
+class NoOpHistogram:
+    """No-op histogram."""
+
+    def record(
+        self, value: float, attributes: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """No-op record."""
+        pass
+
+
+class NoOpUpDownCounter:
+    """No-op up-down counter."""
+
+    def add(
+        self, value: float, attributes: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """No-op add."""
+        pass
+
+
+class RateLimitTracer:
+    """
+    OpenTelemetry tracer for rate limiting operations.
+
+    Wraps OTel's Tracer and provides rate-limit-specific span creation.
+    Falls back to no-op implementations if OpenTelemetry is not installed.
+    """
+
+    def __init__(self, tracer: Optional[Tracer] = None) -> None:
+        """
+        Initialize RateLimitTracer.
+
+        Args:
+            tracer: Optional OTel Tracer. If None and OTel is available,
+                   gets the default tracer from trace provider.
+        """
+        if HAS_OTEL and tracer is None:
+            tracer = trace.get_tracer(__name__)
+
+        self._tracer: Any = tracer or NoOpTracer()
+        self._has_otel = HAS_OTEL
+
+    def start_check_span(
+        self,
+        key: str,
+        limit: int,
+        remaining: int,
+        algorithm: str,
+        backend: str,
+        allowed: bool,
+        shadow: bool = False,
+        cost: int = 1,
+    ) -> Any:
+        """
+        Start a span for a rate limit check.
+
+        Args:
+            key: Rate limit key
+            limit: Configured limit
+            remaining: Remaining count after this check
+            algorithm: Algorithm name
+            backend: Backend class name
+            allowed: Whether request was allowed
+            shadow: Whether in shadow mode
+            cost: Tokens consumed
+
+        Returns:
+            Span context manager (yields the span)
+        """
+        if self._has_otel:
+            span = self._tracer.start_span(
+                "ratelimit.check",
+                kind=trace.SpanKind.INTERNAL,
+            )
+            span.set_attribute("ratelimit.key", key)
+            span.set_attribute("ratelimit.limit", limit)
+            span.set_attribute("ratelimit.remaining", remaining)
+            span.set_attribute("ratelimit.algorithm", algorithm)
+            span.set_attribute("ratelimit.backend", backend)
+            span.set_attribute("ratelimit.decision", "allowed" if allowed else "denied")
+            span.set_attribute("ratelimit.shadow", shadow)
+            span.set_attribute("ratelimit.cost", cost)
+
+            if not allowed:
+                span.add_event("ratelimit.denied", {"ratelimit.key": key})
+                span.set_status(Status(StatusCode.ERROR))
+
+            return _SpanContextManager(span)
+        else:
+            return NoOpSpanContext()
+
+
+class _SpanContextManager:
+    """Context manager for OTel spans."""
+
+    def __init__(self, span: Any) -> None:
+        """Initialize with span."""
+        self._span = span
+
+    def __enter__(self) -> Any:
+        """Enter context."""
+        if hasattr(self._span, "__enter__"):
+            return self._span.__enter__()
+        return self._span
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Exit context."""
+        if hasattr(self._span, "__exit__"):
+            self._span.__exit__(exc_type, exc_val, exc_tb)
+        elif hasattr(self._span, "end"):
+            self._span.end()
+
+
+class RateLimitMeter:
+    """
+    OpenTelemetry meter for rate limiting metrics.
+
+    Provides counters, histograms, and up-down counters for rate limit operations.
+    Falls back to no-op implementations if OpenTelemetry is not installed.
+    """
+
+    def __init__(self, meter: Optional[Meter] = None) -> None:
+        """
+        Initialize RateLimitMeter.
+
+        Args:
+            meter: Optional OTel Meter. If None and OTel is available,
+                  gets the default meter from metric provider.
+        """
+        if HAS_OTEL and meter is None:
+            meter = metrics.get_meter(__name__)
+
+        self._meter: Any = meter or NoOpMeter()
+        self._has_otel = HAS_OTEL
+
+        # Initialize metrics
+        self._requests_total = self._meter.create_counter(
+            "ratelimit.requests.total",
+            "Total number of rate limit checks",
+        )
+        self._tokens_consumed = self._meter.create_counter(
+            "ratelimit.tokens.consumed",
+            "Total tokens consumed across all rate limit checks",
+        )
+        self._check_duration = self._meter.create_histogram(
+            "ratelimit.check.duration_ms",
+            "Duration of rate limit checks in milliseconds",
+        )
+        self._backend_errors = self._meter.create_up_down_counter(
+            "ratelimit.backend.errors",
+            "Number of backend errors",
+        )
+
+    def record_decision(
+        self,
+        allowed: bool,
+        backend: str,
+        algorithm: str,
+        shadow: bool = False,
+        cost: int = 1,
+        duration_ms: float = 0.0,
+    ) -> None:
+        """
+        Record a rate limit decision with metrics.
+
+        Args:
+            allowed: Whether request was allowed
+            backend: Backend name
+            algorithm: Algorithm name
+            shadow: Whether in shadow mode
+            cost: Tokens consumed
+            duration_ms: Check duration in milliseconds
+        """
+        decision = "allowed" if allowed else "denied"
+        attrs_decision = {
+            "decision": decision,
+            "backend": backend,
+            "algorithm": algorithm,
+            "shadow": shadow,
+        }
+
+        # Record request total
+        self._requests_total.add(1, attributes=attrs_decision)
+
+        # Record tokens consumed
+        attrs_tokens = {
+            "backend": backend,
+            "algorithm": algorithm,
+        }
+        self._tokens_consumed.add(cost, attributes=attrs_tokens)
+
+        # Record check duration
+        attrs_duration = {
+            "backend": backend,
+            "algorithm": algorithm,
+        }
+        self._check_duration.record(duration_ms, attributes=attrs_duration)
+
+    def record_backend_error(self, error_type: str) -> None:
+        """
+        Record a backend error.
+
+        Args:
+            error_type: Type of error (e.g., "connection", "timeout")
+        """
+        self._backend_errors.add(1, attributes={"error_type": error_type})
+
+
+def record_check(
+    *,
+    key: str,
+    limit: int,
+    remaining: int,
+    algorithm: str,
+    backend: str,
+    allowed: bool,
+    shadow: bool = False,
+    cost: int = 1,
+    duration_ms: float = 0.0,
+) -> None:
+    """
+    Record a rate limit check with OTel spans and metrics.
+
+    This is the primary public API for recording rate limit decisions.
+    Should be called after a rate limit check completes.
+
+    Args:
+        key: The rate limit key
+        limit: Configured limit
+        remaining: Remaining count after this check
+        algorithm: Algorithm name (sliding_window, token_bucket, etc.)
+        backend: Backend class name
+        allowed: Whether request was allowed
+        shadow: Whether in shadow mode (default: False)
+        cost: Tokens consumed (default: 1)
+        duration_ms: Check duration in milliseconds (default: 0.0)
+
+    Example:
+        from django_smart_ratelimit.observability import record_check
+
+        allowed = rate_limit_check(...)
+        record_check(
+            key="user:123",
+            limit=100,
+            remaining=42,
+            algorithm="sliding_window",
+            backend="RedisBackend",
+            allowed=allowed,
+            cost=1,
+            duration_ms=2.5,
+        )
+    """
+    # Use global instances if available (read-only module-level access).
+    tracer = _global_tracer or RateLimitTracer()
+    meter = _global_meter or RateLimitMeter()
+
+    # Record span
+    with tracer.start_check_span(
+        key=key,
+        limit=limit,
+        remaining=remaining,
+        algorithm=algorithm,
+        backend=backend,
+        allowed=allowed,
+        shadow=shadow,
+        cost=cost,
+    ):
+        # Record metrics
+        meter.record_decision(
+            allowed=allowed,
+            backend=backend,
+            algorithm=algorithm,
+            shadow=shadow,
+            cost=cost,
+            duration_ms=duration_ms,
+        )
+
+
+def record_rate_limit_decision(
+    *,
+    key: str,
+    limit: int,
+    remaining: int,
+    algorithm: str,
+    backend: str,
+    allowed: bool,
+    shadow: bool = False,
+    cost: int = 1,
+    duration_ms: float = 0.0,
+) -> None:
+    """
+    Alias for record_check. Records a rate limit decision with spans and metrics.
+
+    See record_check for parameter documentation.
+    """
+    record_check(
+        key=key,
+        limit=limit,
+        remaining=remaining,
+        algorithm=algorithm,
+        backend=backend,
+        allowed=allowed,
+        shadow=shadow,
+        cost=cost,
+        duration_ms=duration_ms,
+    )
+
+
+def instrument_rate_limit(
+    tracer_provider: Optional[Any] = None,
+    meter_provider: Optional[Any] = None,
+) -> None:
+    """
+    Initialize OpenTelemetry instrumentation for rate limiting.
+
+    Should be called once at application startup to enable OTel spans and metrics.
+    Safe to call multiple times (idempotent).
+
+    Args:
+        tracer_provider: Optional TracerProvider. If None, uses global tracer provider.
+        meter_provider: Optional MeterProvider. If None, uses global meter provider.
+
+    Example:
+        In Django AppConfig.ready():
+
+            from django_smart_ratelimit.observability import instrument_rate_limit
+
+            class MyAppConfig(AppConfig):
+                name = 'myapp'
+
+                def ready(self):
+                    instrument_rate_limit()
+
+        Or with custom providers:
+
+            from opentelemetry.sdk.trace import TracerProvider
+            from opentelemetry.sdk.metrics import MeterProvider
+
+            tp = TracerProvider()
+            mp = MeterProvider()
+
+            instrument_rate_limit(tracer_provider=tp, meter_provider=mp)
+    """
+    global _global_tracer, _global_meter
+
+    if not HAS_OTEL:
+        # OpenTelemetry not installed, use no-ops
+        if _global_tracer is None:
+            _global_tracer = RateLimitTracer()
+        if _global_meter is None:
+            _global_meter = RateLimitMeter()
+        return
+
+    with _lock:
+        if _global_tracer is None:
+            if tracer_provider is None:
+                tracer = trace.get_tracer(__name__)
+            else:
+                tracer = tracer_provider.get_tracer(__name__)
+            _global_tracer = RateLimitTracer(tracer=tracer)
+
+        if _global_meter is None:
+            if meter_provider is None:
+                meter = metrics.get_meter(__name__)
+            else:
+                meter = meter_provider.get_meter(__name__)
+            _global_meter = RateLimitMeter(meter=meter)

--- a/django_smart_ratelimit/pipeline.py
+++ b/django_smart_ratelimit/pipeline.py
@@ -288,7 +288,8 @@ def handle_shadow_decision(
             shadow=shadow,
             cost=cost,
         )
-    except Exception:  # pragma: no cover - observability must never break limits
+    except Exception:  # pragma: no cover  # nosec B110
+        # Observability must never break rate-limit enforcement.
         pass
 
     if allowed:

--- a/django_smart_ratelimit/pipeline.py
+++ b/django_smart_ratelimit/pipeline.py
@@ -1,0 +1,326 @@
+"""
+Shared rate-limit evaluation pipeline.
+
+This module centralizes the logic that is invariant between the sync decorator,
+the async decorator, middleware, and the DRF throttle adapter. Historically that
+logic was duplicated in several places, which meant bug fixes and new features
+had to be applied three or four times in parallel. v3.0.0 consolidates it here.
+
+The pipeline exposes two key helpers:
+
+    * ``resolve_effective_rate(...)``  — turn a (key, rate, adaptive, cost)
+      config into a concrete (limit, period, cost, generated_key) tuple,
+      raising :class:`KeyGenerationError` instead of failing silently.
+
+    * ``apply_policy_lists(...)`` — evaluate CIDR allow/deny policy for the
+      request and return one of ``{"deny", "allow", "continue"}``.
+
+    * ``handle_shadow_decision(...)`` — given an "actually would-have-been
+      blocked" decision, either escalate it to a real block or downgrade it
+      to an allow-with-log (shadow mode).
+
+These helpers are intentionally side-effect light so they can be reused from
+both sync and async call-sites without sync_to_async gymnastics.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional, Tuple, Union
+
+from django.http import HttpRequest
+
+from .adaptive import AdaptiveRateLimiter
+from .backends.utils import parse_rate
+from .exceptions import KeyGenerationError
+from .key_functions import generate_key
+from .observability import record_check
+
+logger = logging.getLogger(__name__)
+
+
+# Sentinel used by apply_policy_lists to indicate the request should bypass
+# rate limiting entirely (matched an allow-list entry).
+POLICY_ALLOW = "allow"
+# Matched a deny-list entry — caller should return a block response immediately.
+POLICY_DENY = "deny"
+# No list hit — caller should proceed with normal rate-limit evaluation.
+POLICY_CONTINUE = "continue"
+
+
+@dataclass
+class ResolvedLimit:
+    """Fully resolved rate-limit parameters for a single request."""
+
+    key: str
+    limit: int
+    period: int
+    cost: int = 1
+    # The original rate string after resolution (post-callable, pre-parse). Kept
+    # around so observability spans and error messages can reference it.
+    rate_string: str = ""
+
+
+def _resolve_rate(
+    rate: Union[str, Callable[..., str]],
+    request: HttpRequest,
+) -> str:
+    """Resolve a rate that may be a string or a callable.
+
+    The callable may accept either ``(self_or_none, request)`` (django-ratelimit
+    compatibility) or ``(request,)`` or zero arguments. We try them in that
+    order so existing user code keeps working.
+    """
+    if isinstance(rate, str):
+        return rate
+
+    if not callable(rate):
+        raise TypeError(f"Rate must be str or callable, got {type(rate)!r}")
+
+    try:
+        return rate(None, request)
+    except TypeError:
+        pass
+    try:
+        return rate(request)
+    except TypeError:
+        pass
+    return rate()
+
+
+def _resolve_cost(
+    cost: Union[int, Callable[[HttpRequest], int], None],
+    request: HttpRequest,
+) -> int:
+    """Resolve a cost that may be an int or callable returning an int.
+
+    Costs < 1 are clamped to 1 — a free request is indistinguishable from no
+    request at all, and allowing cost=0 would let callers bypass limits.
+    """
+    if cost is None:
+        return 1
+    if callable(cost):
+        try:
+            value = cost(request)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("cost callable raised %s; falling back to 1", exc)
+            return 1
+    else:
+        value = cost
+    try:
+        ivalue = int(value)
+    except (TypeError, ValueError):
+        logger.warning("cost resolved to non-int %r; falling back to 1", value)
+        return 1
+    return max(1, ivalue)
+
+
+def _apply_adaptive(
+    adaptive: Optional[Union[str, AdaptiveRateLimiter]], base_limit: int
+) -> int:
+    """Apply adaptive rate-limiting if configured. Mirrors decorator helper."""
+    if adaptive is None:
+        return base_limit
+
+    limiter: Optional[AdaptiveRateLimiter]
+    if isinstance(adaptive, str):
+        from .adaptive import get_adaptive_limiter
+
+        limiter = get_adaptive_limiter(adaptive)
+        if limiter is None:
+            logger.warning(
+                "Adaptive rate limiter '%s' not found; using base limit %d",
+                adaptive,
+                base_limit,
+            )
+            return base_limit
+    elif isinstance(adaptive, AdaptiveRateLimiter):
+        limiter = adaptive
+    else:
+        logger.warning(
+            "Invalid adaptive parameter type %s; using base limit %d",
+            type(adaptive),
+            base_limit,
+        )
+        return base_limit
+
+    try:
+        return limiter.get_effective_limit()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "Adaptive limiter failed: %s; using base limit %d", exc, base_limit
+        )
+        return base_limit
+
+
+def resolve_effective_rate(
+    *,
+    key: Union[str, Callable[..., str]],
+    rate: Union[str, Callable[..., str]],
+    request: HttpRequest,
+    args: Tuple[Any, ...] = (),
+    kwargs: Optional[Dict[str, Any]] = None,
+    adaptive: Optional[Union[str, AdaptiveRateLimiter]] = None,
+    cost: Union[int, Callable[[HttpRequest], int], None] = 1,
+    validate_key: bool = True,
+) -> ResolvedLimit:
+    """Resolve a rate-limit config to concrete (key, limit, period, cost).
+
+    Raises
+    ------
+    KeyGenerationError
+        If ``validate_key`` is True and the key function returns an empty
+        string or ``None``. Prior to v3 these were silently treated as valid
+        keys which caused the entire limiter to collapse onto the literal key
+        ``""`` under load — a footgun that is now upgraded to a loud failure.
+
+    ValueError / ImproperlyConfigured
+        If the rate string cannot be parsed.
+    """
+    kwargs = kwargs or {}
+
+    generated_key = generate_key(key, request, *args, **kwargs)
+    if validate_key and not generated_key:
+        raise KeyGenerationError(
+            f"Key function {key!r} returned empty key for request {request!r}. "
+            "An empty key would cause all requests to share the same bucket. "
+            "Return a stable non-empty string, or raise an explicit exception "
+            "to indicate rate limiting should be skipped."
+        )
+
+    rate_str = _resolve_rate(rate, request)
+    limit, period = parse_rate(rate_str)
+    limit = _apply_adaptive(adaptive, limit)
+    cost_int = _resolve_cost(cost, request)
+
+    return ResolvedLimit(
+        key=generated_key,
+        limit=limit,
+        period=period,
+        cost=cost_int,
+        rate_string=rate_str,
+    )
+
+
+def apply_policy_lists(
+    request: HttpRequest,
+    *,
+    allow_list: Any = None,
+    deny_list: Any = None,
+) -> str:
+    """Evaluate allow/deny lists for a request.
+
+    Inputs may be :class:`~django_smart_ratelimit.policy.IPList` instances,
+    iterables of CIDR strings, file paths, or URLs — whatever
+    :func:`~django_smart_ratelimit.policy.parse_ip_list` accepts.
+
+    Returns one of ``POLICY_DENY``, ``POLICY_ALLOW`` or ``POLICY_CONTINUE``.
+    Deny always takes precedence over allow (fail-closed for explicit blocks).
+    """
+    if allow_list is None and deny_list is None:
+        return POLICY_CONTINUE
+
+    # Lazy import so users who don't use policy lists don't pay the cost.
+    from .policy import check_lists, parse_ip_list
+
+    try:
+        al = parse_ip_list(allow_list) if allow_list is not None else None
+    except Exception as exc:
+        logger.warning("Failed to parse allow_list (%s); skipping allow check", exc)
+        al = None
+    try:
+        dl = parse_ip_list(deny_list) if deny_list is not None else None
+    except Exception as exc:
+        logger.warning("Failed to parse deny_list (%s); skipping deny check", exc)
+        dl = None
+
+    should_skip, reason = check_lists(request, allow_list=al, deny_list=dl)
+
+    if reason == "deny_list":
+        return POLICY_DENY
+    if should_skip and reason == "allow_list":
+        return POLICY_ALLOW
+    return POLICY_CONTINUE
+
+
+@dataclass
+class ShadowDecision:
+    """Outcome after optionally applying shadow mode."""
+
+    # The decision the caller should honor (True = allow, False = block).
+    allow: bool
+    # Whether shadow mode converted a real block into an allow.
+    shadowed: bool = False
+    # Arbitrary metadata propagated for observability.
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+def handle_shadow_decision(
+    *,
+    allowed: bool,
+    shadow: bool,
+    request: HttpRequest,
+    key: str,
+    limit: int,
+    remaining: int,
+    algorithm: str,
+    backend: str,
+    cost: int = 1,
+) -> ShadowDecision:
+    """Apply shadow mode to an underlying decision.
+
+    When ``shadow=True`` and ``allowed=False``, the decision is flipped to
+    allow and a structured log line + OTel event is emitted so operators can
+    see what *would* have been blocked in production. This is the standard
+    rollout strategy for a new limit: run it in shadow for a day, look at the
+    logs, then turn enforcement on.
+    """
+    # Always record observability regardless of shadow state.
+    try:
+        record_check(
+            key=key,
+            limit=limit,
+            remaining=remaining,
+            algorithm=algorithm,
+            backend=backend,
+            allowed=allowed,
+            shadow=shadow,
+            cost=cost,
+        )
+    except Exception:  # pragma: no cover - observability must never break limits
+        pass
+
+    if allowed:
+        return ShadowDecision(allow=True, shadowed=False)
+
+    if shadow:
+        logger.info(
+            "SHADOW_RATE_LIMIT_BLOCK",
+            extra={
+                "event": "ratelimit.shadow.block",
+                "key": key,
+                "limit": limit,
+                "remaining": remaining,
+                "algorithm": algorithm,
+                "backend": backend,
+                "cost": cost,
+                "path": getattr(request, "path", None),
+                "method": getattr(request, "method", None),
+            },
+        )
+        return ShadowDecision(allow=True, shadowed=True, extra={"shadow": True})
+
+    return ShadowDecision(allow=False, shadowed=False)
+
+
+__all__ = [
+    "POLICY_ALLOW",
+    "POLICY_DENY",
+    "POLICY_CONTINUE",
+    "ResolvedLimit",
+    "ShadowDecision",
+    "apply_policy_lists",
+    "handle_shadow_decision",
+    "resolve_effective_rate",
+]

--- a/django_smart_ratelimit/policy/__init__.py
+++ b/django_smart_ratelimit/policy/__init__.py
@@ -1,0 +1,34 @@
+"""
+Policy module for django-smart-ratelimit.
+
+This module provides utilities for CIDR-based allow/deny lists to manage
+rate limiting policies based on IP addresses and network ranges.
+
+Key classes:
+    - IPList: In-memory CIDR-based IP list
+    - FileBackedIPList: IP list backed by a file with auto-refresh
+    - URLBackedIPList: IP list backed by a URL fetch with auto-refresh
+
+Key functions:
+    - parse_ip_list: Convert various input formats to IPList instances
+    - extract_client_ip: Extract client IP from request
+    - check_lists: Check if IP is in allow/deny lists
+"""
+
+from .lists import (
+    IPList,
+    FileBackedIPList,
+    URLBackedIPList,
+    parse_ip_list,
+    extract_client_ip,
+    check_lists,
+)
+
+__all__ = [
+    "IPList",
+    "FileBackedIPList",
+    "URLBackedIPList",
+    "parse_ip_list",
+    "extract_client_ip",
+    "check_lists",
+]

--- a/django_smart_ratelimit/policy/__init__.py
+++ b/django_smart_ratelimit/policy/__init__.py
@@ -16,12 +16,12 @@ Key functions:
 """
 
 from .lists import (
-    IPList,
     FileBackedIPList,
+    IPList,
     URLBackedIPList,
-    parse_ip_list,
-    extract_client_ip,
     check_lists,
+    extract_client_ip,
+    parse_ip_list,
 )
 
 __all__ = [

--- a/django_smart_ratelimit/policy/lists.py
+++ b/django_smart_ratelimit/policy/lists.py
@@ -1,0 +1,569 @@
+"""
+CIDR-based allow/deny list implementations for django-smart-ratelimit.
+
+This module provides classes for managing IP allowlists and denylists using CIDR notation.
+It supports IPv4 and IPv6 addresses, file-based configuration, and URL-based feeds.
+
+IMPORTANT SECURITY NOTE ON X-Forwarded-For:
+The `extract_client_ip` function respects X-Forwarded-For headers to support proxies and CDNs.
+However, this header can be spoofed if not properly validated. Only trust X-Forwarded-For
+if your application is behind a trusted proxy and you've configured Django's TRUSTED_PROXIES
+setting appropriately. Otherwise, clients can spoof their IP address and bypass IP-based
+rate limiting controls.
+
+Examples:
+    Basic IP list for allow/deny:
+
+        from django_smart_ratelimit.policy import IPList
+
+        internal_ips = IPList(['10.0.0.0/8', '192.168.1.0/24'])
+        if internal_ips.contains('10.0.0.5'):
+            # Skip rate limiting
+            pass
+
+    File-backed IP list with auto-refresh:
+
+        from django_smart_ratelimit.policy import FileBackedIPList
+
+        blocklist = FileBackedIPList('/etc/ratelimit/blocklist.txt', refresh_interval=300)
+        if blocklist.contains(client_ip):
+            # Force block this IP
+            return HttpResponse(status=429)
+
+    URL-based threat intelligence feed:
+
+        from django_smart_ratelimit.policy import URLBackedIPList
+
+        threat_feed = URLBackedIPList(
+            'https://example.com/threats/blocklist.txt',
+            refresh_interval=3600,
+            http_timeout=10
+        )
+        if threat_feed.contains(client_ip):
+            # Block based on threat intel
+            return HttpResponse(status=429)
+
+    Using parse_ip_list for flexible input:
+
+        from django_smart_ratelimit.policy import parse_ip_list, check_lists
+
+        allow_list = parse_ip_list('file:///etc/ratelimit/allowlist.txt')
+        deny_list = parse_ip_list(['10.0.0.0/8', '203.0.113.0/24'])
+
+        should_skip, reason = check_lists(request, allow_list, deny_list)
+        if should_skip:
+            # Skip rate limiting
+            pass
+        elif reason == 'deny_list':
+            # Force block
+            return HttpResponse(status=429)
+"""
+
+import ipaddress
+import logging
+import threading
+import time
+import urllib.request
+import urllib.error
+from pathlib import Path
+from typing import List, Optional, Tuple, Union
+
+from django.http import HttpRequest
+
+logger = logging.getLogger(__name__)
+
+
+class IPList:
+    """
+    In-memory CIDR-based IP list for checking if an IP is in a set of networks.
+
+    This class efficiently stores and checks IP addresses and CIDR ranges using
+    Python's ipaddress module. Single IP addresses are automatically promoted
+    to /32 (IPv4) or /128 (IPv6) CIDR notation.
+
+    Args:
+        cidrs: List of CIDR strings (e.g., ['10.0.0.0/8', '192.168.0.0/16', '203.0.113.42'])
+
+    Raises:
+        ValueError: If any CIDR string is invalid
+
+    Examples:
+        >>> allowed = IPList(['10.0.0.0/8', '192.168.1.0/24', '203.0.113.42'])
+        >>> allowed.contains('10.0.0.5')
+        True
+        >>> allowed.contains('192.168.1.100')
+        True
+        >>> allowed.contains('203.0.113.42')
+        True
+        >>> allowed.contains('8.8.8.8')
+        False
+    """
+
+    def __init__(self, cidrs: List[str]) -> None:
+        """Initialize IPList with CIDR ranges."""
+        self.networks: List[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+
+        for cidr in cidrs:
+            try:
+                # Handle single IPs by converting to /32 or /128
+                if "/" not in cidr:
+                    try:
+                        ip = ipaddress.ip_address(cidr)
+                        if isinstance(ip, ipaddress.IPv4Address):
+                            cidr = f"{cidr}/32"
+                        else:
+                            cidr = f"{cidr}/128"
+                    except ValueError as e:
+                        raise ValueError(f"Invalid IP address: {cidr}") from e
+
+                network = ipaddress.ip_network(cidr, strict=False)
+                self.networks.append(network)
+            except ValueError as e:
+                raise ValueError(
+                    f"Invalid CIDR notation: {cidr}. "
+                    f"Expected format like '10.0.0.0/8' or '192.168.1.1'. "
+                    f"Error: {e}"
+                ) from e
+
+    def contains(self, ip: str) -> bool:
+        """
+        Check if an IP address is in any of the networks.
+
+        Args:
+            ip: IP address string (e.g., '192.168.1.100')
+
+        Returns:
+            True if IP is in any network, False otherwise
+        """
+        try:
+            ip_obj = ipaddress.ip_address(ip)
+            for network in self.networks:
+                if ip_obj in network:
+                    return True
+            return False
+        except ValueError:
+            # Invalid IP format
+            logger.debug(f"Invalid IP address format: {ip}")
+            return False
+
+
+class FileBackedIPList(IPList):
+    """
+    File-backed CIDR-based IP list with automatic refresh capability.
+
+    This class reads IP ranges from a file and periodically refreshes the list
+    from disk. The refresh is lazy (only checked on lookup after the interval
+    has passed) and thread-safe.
+
+    File format:
+        - One CIDR range or IP per line
+        - Comments starting with '#' are ignored
+        - Blank lines are ignored
+        - Examples: 10.0.0.0/8, 192.168.1.0/24, 203.0.113.42
+
+    Args:
+        path: File path to read CIDRs from
+        refresh_interval: Seconds between file refreshes (default: 300)
+
+    Raises:
+        ValueError: If file cannot be read or contains invalid CIDRs
+        FileNotFoundError: If file does not exist initially
+
+    Examples:
+        >>> blocklist = FileBackedIPList('/etc/ratelimit/blocklist.txt', refresh_interval=300)
+        >>> if blocklist.contains('10.0.0.5'):
+        ...     # Handle blocked IP
+        ...     pass
+
+        >>> blocklist.force_refresh()  # Explicitly reload from disk
+    """
+
+    def __init__(self, path: str, refresh_interval: int = 300) -> None:
+        """Initialize FileBackedIPList."""
+        self.path = path
+        self.refresh_interval = refresh_interval
+        self.last_refresh = 0.0
+        self._lock = threading.RLock()
+        self.networks: List[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+
+        # Load initial list
+        self.force_refresh()
+
+    def _read_file(self) -> List[str]:
+        """
+        Read and parse CIDR list from file.
+
+        Returns:
+            List of valid CIDR strings
+
+        Raises:
+            FileNotFoundError: If file does not exist
+            ValueError: If file cannot be read
+        """
+        try:
+            path_obj = Path(self.path)
+            if not path_obj.exists():
+                raise FileNotFoundError(f"IP list file not found: {self.path}")
+
+            cidrs = []
+            with open(path_obj, "r", encoding="utf-8") as f:
+                for line_num, line in enumerate(f, 1):
+                    # Strip whitespace and skip empty lines/comments
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    cidrs.append(line)
+
+            return cidrs
+        except FileNotFoundError:
+            raise
+        except Exception as e:
+            raise ValueError(f"Failed to read IP list file {self.path}: {e}") from e
+
+    def force_refresh(self) -> None:
+        """Force an immediate refresh of the IP list from disk."""
+        with self._lock:
+            try:
+                cidrs = self._read_file()
+                # Validate all CIDRs before committing
+                networks = []
+                for cidr in cidrs:
+                    if "/" not in cidr:
+                        try:
+                            ip = ipaddress.ip_address(cidr)
+                            if isinstance(ip, ipaddress.IPv4Address):
+                                cidr = f"{cidr}/32"
+                            else:
+                                cidr = f"{cidr}/128"
+                        except ValueError as e:
+                            raise ValueError(f"Invalid IP address: {cidr}") from e
+
+                    network = ipaddress.ip_network(cidr, strict=False)
+                    networks.append(network)
+
+                self.networks = networks
+                self.last_refresh = time.time()
+                logger.debug(
+                    f"Refreshed IP list from {self.path}: {len(networks)} networks"
+                )
+            except FileNotFoundError:
+                logger.warning(
+                    f"IP list file {self.path} not found, keeping last loaded list"
+                )
+            except ValueError as e:
+                logger.error(f"Invalid CIDR in {self.path}: {e}, keeping last loaded list")
+
+    def _check_refresh(self) -> None:
+        """Check if refresh is needed and perform it if necessary."""
+        current_time = time.time()
+        if current_time - self.last_refresh > self.refresh_interval:
+            self.force_refresh()
+
+    def contains(self, ip: str) -> bool:
+        """
+        Check if an IP address is in any of the networks.
+
+        Performs a lazy refresh check before lookup.
+
+        Args:
+            ip: IP address string
+
+        Returns:
+            True if IP is in any network, False otherwise
+        """
+        with self._lock:
+            self._check_refresh()
+            return super().contains(ip)
+
+
+class URLBackedIPList(IPList):
+    """
+    URL-backed CIDR-based IP list with automatic refresh capability.
+
+    This class fetches IP ranges from a URL (e.g., a threat intelligence feed)
+    and periodically refreshes the list. The refresh is lazy (only checked on
+    lookup after the interval has passed) and thread-safe.
+
+    Expected response format:
+        - Newline-separated CIDR ranges or IP addresses
+        - Comments starting with '#' are ignored
+        - Blank lines are ignored
+
+    Args:
+        url: URL to fetch IP list from (must start with http:// or https://)
+        refresh_interval: Seconds between URL fetches (default: 3600)
+        http_timeout: Seconds to wait for HTTP response (default: 10)
+
+    Raises:
+        ValueError: If URL is invalid or contains invalid CIDRs
+
+    Examples:
+        >>> threat_feed = URLBackedIPList(
+        ...     'https://example.com/threats/blocklist.txt',
+        ...     refresh_interval=3600,
+        ...     http_timeout=10
+        ... )
+        >>> if threat_feed.contains('203.0.113.5'):
+        ...     # Handle threat IP
+        ...     pass
+    """
+
+    def __init__(
+        self,
+        url: str,
+        refresh_interval: int = 3600,
+        http_timeout: int = 10,
+    ) -> None:
+        """Initialize URLBackedIPList."""
+        if not url.startswith(("http://", "https://")):
+            raise ValueError(f"URL must start with http:// or https://: {url}")
+
+        self.url = url
+        self.refresh_interval = refresh_interval
+        self.http_timeout = http_timeout
+        self.last_refresh = 0.0
+        self._lock = threading.RLock()
+        self.networks: List[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+
+        # Load initial list
+        self.force_refresh()
+
+    def _fetch_url(self) -> List[str]:
+        """
+        Fetch and parse CIDR list from URL.
+
+        Returns:
+            List of valid CIDR strings
+
+        Raises:
+            ValueError: If URL fetch fails or response is invalid
+        """
+        try:
+            request = urllib.request.Request(self.url)
+            request.add_header("User-Agent", "django-smart-ratelimit/3.0.0")
+
+            with urllib.request.urlopen(request, timeout=self.http_timeout) as response:
+                content = response.read().decode("utf-8")
+
+            cidrs = []
+            for line in content.splitlines():
+                # Strip whitespace and skip empty lines/comments
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                cidrs.append(line)
+
+            return cidrs
+        except (urllib.error.URLError, urllib.error.HTTPError) as e:
+            raise ValueError(f"Failed to fetch IP list from {self.url}: {e}") from e
+        except Exception as e:
+            raise ValueError(f"Error fetching IP list from {self.url}: {e}") from e
+
+    def force_refresh(self) -> None:
+        """Force an immediate refresh of the IP list from the URL."""
+        with self._lock:
+            try:
+                cidrs = self._fetch_url()
+                # Validate all CIDRs before committing
+                networks = []
+                for cidr in cidrs:
+                    if "/" not in cidr:
+                        try:
+                            ip = ipaddress.ip_address(cidr)
+                            if isinstance(ip, ipaddress.IPv4Address):
+                                cidr = f"{cidr}/32"
+                            else:
+                                cidr = f"{cidr}/128"
+                        except ValueError as e:
+                            raise ValueError(f"Invalid IP address: {cidr}") from e
+
+                    network = ipaddress.ip_network(cidr, strict=False)
+                    networks.append(network)
+
+                self.networks = networks
+                self.last_refresh = time.time()
+                logger.debug(
+                    f"Refreshed IP list from {self.url}: {len(networks)} networks"
+                )
+            except ValueError as e:
+                logger.error(
+                    f"Failed to refresh IP list from {self.url}: {e}, "
+                    f"keeping last loaded list"
+                )
+
+    def _check_refresh(self) -> None:
+        """Check if refresh is needed and perform it if necessary."""
+        current_time = time.time()
+        if current_time - self.last_refresh > self.refresh_interval:
+            self.force_refresh()
+
+    def contains(self, ip: str) -> bool:
+        """
+        Check if an IP address is in any of the networks.
+
+        Performs a lazy refresh check before lookup.
+
+        Args:
+            ip: IP address string
+
+        Returns:
+            True if IP is in any network, False otherwise
+        """
+        with self._lock:
+            self._check_refresh()
+            return super().contains(ip)
+
+
+def parse_ip_list(
+    source: Union[str, List[str], IPList, None]
+) -> Optional[IPList]:
+    """
+    Parse various input formats into an IPList instance.
+
+    Supports:
+        - None -> returns None
+        - IPList instance -> returns as-is
+        - List[str] -> wraps in IPList
+        - str starting with 'file://' -> wraps in FileBackedIPList
+        - str that is an existing file path -> wraps in FileBackedIPList
+        - str starting with 'http://' or 'https://' -> wraps in URLBackedIPList
+        - str single CIDR/IP -> wraps in IPList
+
+    Args:
+        source: Input source (various formats)
+
+    Returns:
+        IPList instance or None
+
+    Examples:
+        >>> allow = parse_ip_list(['10.0.0.0/8', '192.168.0.0/16'])
+        >>> allow = parse_ip_list('file:///etc/ratelimit/allowlist.txt')
+        >>> allow = parse_ip_list('https://example.com/ips.txt')
+        >>> allow = parse_ip_list('203.0.113.42')
+        >>> allow = parse_ip_list(None)  # Returns None
+    """
+    if source is None:
+        return None
+
+    if isinstance(source, IPList):
+        return source
+
+    if isinstance(source, list):
+        return IPList(source)
+
+    if isinstance(source, str):
+        # File-backed list
+        if source.startswith("file://"):
+            path = source[7:]  # Remove 'file://' prefix
+            return FileBackedIPList(path)
+
+        # Check if it's an existing file path
+        if Path(source).exists():
+            return FileBackedIPList(source)
+
+        # URL-backed list
+        if source.startswith(("http://", "https://")):
+            return URLBackedIPList(source)
+
+        # Single CIDR/IP
+        return IPList([source])
+
+    # Unsupported type, return None
+    logger.warning(f"Unsupported IP list source type: {type(source)}")
+    return None
+
+
+def extract_client_ip(request: HttpRequest) -> str:
+    """
+    Extract client IP address from a Django request.
+
+    Respects proxy headers (X-Forwarded-For, X-Real-IP, CF-Connecting-IP) to
+    support requests through load balancers and CDNs.
+
+    SECURITY WARNING:
+    This function trusts X-Forwarded-For and other proxy headers. These headers
+    can be spoofed if the request doesn't come from a trusted proxy. Only rely
+    on this function if your application is deployed behind a trusted reverse
+    proxy and you've configured Django's TRUSTED_PROXIES appropriately.
+
+    Args:
+        request: Django HTTP request object
+
+    Returns:
+        Client IP address string or "unknown" if unable to extract
+
+    Examples:
+        >>> ip = extract_client_ip(request)
+        >>> if blocklist.contains(ip):
+        ...     # Handle blocked IP
+        ...     pass
+    """
+    # Order of preference for IP headers
+    ip_headers = [
+        "HTTP_CF_CONNECTING_IP",  # Cloudflare
+        "HTTP_X_FORWARDED_FOR",  # Standard proxy header
+        "HTTP_X_REAL_IP",  # Nginx
+        "REMOTE_ADDR",  # Direct connection (always available)
+    ]
+
+    for header in ip_headers:
+        ip = request.META.get(header, "").strip()
+        if ip and ip != "unknown":
+            # Handle comma-separated IPs (X-Forwarded-For)
+            if "," in ip:
+                ip = ip.split(",")[0].strip()
+            if ip:
+                return ip
+
+    return "unknown"
+
+
+def check_lists(
+    request: HttpRequest,
+    allow_list: Optional[IPList] = None,
+    deny_list: Optional[IPList] = None,
+) -> Tuple[bool, str]:
+    """
+    Check if request IP is in allow/deny lists.
+
+    Checks precedence:
+        1. If IP is in deny_list -> returns (False, "deny_list") [force block]
+        2. If IP is in allow_list -> returns (True, "allow_list") [skip rate limiting]
+        3. Otherwise -> returns (False, "") [continue normal rate limiting]
+
+    Args:
+        request: Django HTTP request object
+        allow_list: IPList of IPs to allow (bypass rate limiting)
+        deny_list: IPList of IPs to deny (force block)
+
+    Returns:
+        Tuple of (should_skip_rate_limit, reason):
+            - (True, "allow_list") if IP should skip rate limiting
+            - (False, "deny_list") if IP should be force-blocked
+            - (False, "") if neither list matches (normal rate limiting applies)
+
+    Examples:
+        >>> allow = IPList(['10.0.0.0/8'])
+        >>> deny = IPList(['10.0.0.5'])
+        >>> should_skip, reason = check_lists(request, allow, deny)
+        >>> if reason == 'deny_list':
+        ...     return HttpResponse('Blocked', status=429)
+        >>> elif should_skip:
+        ...     # Skip rate limiting
+        ...     pass
+        >>> else:
+        ...     # Apply normal rate limiting
+        ...     pass
+    """
+    client_ip = extract_client_ip(request)
+
+    # Deny takes precedence
+    if deny_list and deny_list.contains(client_ip):
+        return (False, "deny_list")
+
+    # Then check allow list
+    if allow_list and allow_list.contains(client_ip):
+        return (True, "allow_list")
+
+    # Neither list matched
+    return (False, "")

--- a/django_smart_ratelimit/policy/lists.py
+++ b/django_smart_ratelimit/policy/lists.py
@@ -63,8 +63,8 @@ import ipaddress
 import logging
 import threading
 import time
-import urllib.request
 import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
@@ -251,7 +251,9 @@ class FileBackedIPList(IPList):
                     f"IP list file {self.path} not found, keeping last loaded list"
                 )
             except ValueError as e:
-                logger.error(f"Invalid CIDR in {self.path}: {e}, keeping last loaded list")
+                logger.error(
+                    f"Invalid CIDR in {self.path}: {e}, keeping last loaded list"
+                )
 
     def _check_refresh(self) -> None:
         """Check if refresh is needed and perform it if necessary."""
@@ -416,9 +418,7 @@ class URLBackedIPList(IPList):
             return super().contains(ip)
 
 
-def parse_ip_list(
-    source: Union[str, List[str], IPList, None]
-) -> Optional[IPList]:
+def parse_ip_list(source: Union[str, List[str], IPList, None]) -> Optional[IPList]:
     """
     Parse various input formats into an IPList instance.
 

--- a/django_smart_ratelimit/policy/lists.py
+++ b/django_smart_ratelimit/policy/lists.py
@@ -342,7 +342,9 @@ class URLBackedIPList(IPList):
             request = urllib.request.Request(self.url)
             request.add_header("User-Agent", "django-smart-ratelimit/3.0.0")
 
-            with urllib.request.urlopen(request, timeout=self.http_timeout) as response:
+            with urllib.request.urlopen(  # nosec B310 - URL is opt-in by caller via source=
+                request, timeout=self.http_timeout
+            ) as response:
                 content = response.read().decode("utf-8")
 
             cidrs = []

--- a/django_smart_ratelimit/testing.py
+++ b/django_smart_ratelimit/testing.py
@@ -34,7 +34,7 @@ from typing import Any, Dict, Optional, Tuple
 try:
     import pytest
 except ImportError:
-    pytest = None  # type: ignore
+    pytest = None  # type: ignore[assignment]
 
 
 def _get_pytest() -> Any:
@@ -52,7 +52,7 @@ def _get_pytest() -> Any:
 
 if pytest is not None:
 
-    @pytest.fixture  # type: ignore
+    @pytest.fixture
     def ratelimit_memory_backend(monkeypatch: Any) -> Any:
         """
         Fixture that swaps the rate limiter backend to use MemoryBackend.
@@ -90,8 +90,8 @@ if pytest is not None:
         if hasattr(backend, "shutdown"):
             backend.shutdown()
 
-    @pytest.fixture  # type: ignore
-    def disable_ratelimit(settings: Any) -> None:  # type: ignore
+    @pytest.fixture
+    def disable_ratelimit(settings: Any) -> None:
         """
         Fixture that disables rate limiting globally for the test.
 
@@ -107,8 +107,8 @@ if pytest is not None:
         """
         settings.RATELIMIT_ENABLE = False
 
-    @pytest.fixture  # type: ignore
-    def ratelimit_redis_backend(monkeypatch: Any) -> Any:  # type: ignore
+    @pytest.fixture
+    def ratelimit_redis_backend(monkeypatch: Any) -> Any:
         """
         Fixture that uses a real Redis backend if available.
 
@@ -154,8 +154,8 @@ if pytest is not None:
         except Exception as e:
             pytest.skip(f"Redis backend unavailable: {e}")
 
-    @pytest.fixture  # type: ignore
-    def frozen_ratelimit_time(monkeypatch: Any) -> Any:  # type: ignore
+    @pytest.fixture
+    def frozen_ratelimit_time(monkeypatch: Any) -> Any:
         """
         Fixture for simulated time advancement in rate limit tests.
 
@@ -227,7 +227,6 @@ if pytest is not None:
 
             def __exit__(self, *args: Any) -> None:
                 """Context manager exit."""
-                pass
 
         return FrozenTime(monkeypatch)
 
@@ -266,13 +265,15 @@ def assert_rate_limited(
 
     if expected_limit is not None:
         actual = headers.get("limit")
-        assert actual == expected_limit, (  # nosec B101
-            f"Expected X-RateLimit-Limit={expected_limit}, got {actual}"
-        )
+        assert (
+            actual == expected_limit
+        ), f"Expected X-RateLimit-Limit={expected_limit}, got {actual}"  # nosec B101
 
     if expected_remaining is not None:
         actual = headers.get("remaining")
-        assert actual == expected_remaining, (  # nosec B101
+        assert (
+            actual == expected_remaining
+        ), (  # nosec B101
             f"Expected X-RateLimit-Remaining={expected_remaining}, got {actual}"
         )
 
@@ -298,7 +299,9 @@ def assert_not_rate_limited(response: Any) -> None:
     ), "Expected status != 429, but got 429 (rate limited)"
 
     headers = read_rate_limit_headers(response)
-    assert headers.get("remaining") is not None, (  # nosec B101
+    assert (
+        headers.get("remaining") is not None
+    ), (  # nosec B101
         "X-RateLimit-Remaining header missing from non-rate-limited response"
     )
 
@@ -320,14 +323,12 @@ def assert_remaining(response: Any, expected: int) -> None:
     """
     headers = read_rate_limit_headers(response)
     actual = headers.get("remaining")
-    assert actual == expected, (  # nosec B101
-        f"Expected X-RateLimit-Remaining={expected}, got {actual}"
-    )
+    assert (
+        actual == expected
+    ), f"Expected X-RateLimit-Remaining={expected}, got {actual}"  # nosec B101
 
 
-def assert_retry_after(
-    response: Any, expected: int, tolerance: int = 1
-) -> None:
+def assert_retry_after(response: Any, expected: int, tolerance: int = 1) -> None:
     """
     Assert that Retry-After header is within tolerance.
 
@@ -390,7 +391,11 @@ def read_rate_limit_headers(response: Any) -> Dict[str, Optional[int]]:
     # Or use response.headers for test client >= Django 3.2
     try:
         # Django test client response supports dict-like access
-        for header_key in ("X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset"):
+        for header_key in (
+            "X-RateLimit-Limit",
+            "X-RateLimit-Remaining",
+            "X-RateLimit-Reset",
+        ):
             val = response.get(header_key)
             if val is not None:
                 try:
@@ -531,8 +536,7 @@ def clear_rate_limit_cache(key_pattern: str = "*") -> None:
                 import fnmatch
 
                 keys_to_delete = [
-                    k for k in backend._data.keys()
-                    if fnmatch.fnmatch(k, key_pattern)
+                    k for k in backend._data.keys() if fnmatch.fnmatch(k, key_pattern)
                 ]
                 for k in keys_to_delete:
                     backend.reset(k)

--- a/django_smart_ratelimit/testing.py
+++ b/django_smart_ratelimit/testing.py
@@ -258,7 +258,7 @@ def assert_rate_limited(
         response = client.get("/api/endpoint/")
         assert_rate_limited(response, expected_limit=10, expected_remaining=0)
     """
-    assert (
+    assert (  # nosec B101
         response.status_code == 429
     ), f"Expected status 429, got {response.status_code}"
 
@@ -266,13 +266,13 @@ def assert_rate_limited(
 
     if expected_limit is not None:
         actual = headers.get("limit")
-        assert actual == expected_limit, (
+        assert actual == expected_limit, (  # nosec B101
             f"Expected X-RateLimit-Limit={expected_limit}, got {actual}"
         )
 
     if expected_remaining is not None:
         actual = headers.get("remaining")
-        assert actual == expected_remaining, (
+        assert actual == expected_remaining, (  # nosec B101
             f"Expected X-RateLimit-Remaining={expected_remaining}, got {actual}"
         )
 
@@ -293,12 +293,12 @@ def assert_not_rate_limited(response: Any) -> None:
         response = client.get("/api/endpoint/")
         assert_not_rate_limited(response)
     """
-    assert (
+    assert (  # nosec B101
         response.status_code != 429
     ), "Expected status != 429, but got 429 (rate limited)"
 
     headers = read_rate_limit_headers(response)
-    assert headers.get("remaining") is not None, (
+    assert headers.get("remaining") is not None, (  # nosec B101
         "X-RateLimit-Remaining header missing from non-rate-limited response"
     )
 
@@ -320,7 +320,7 @@ def assert_remaining(response: Any, expected: int) -> None:
     """
     headers = read_rate_limit_headers(response)
     actual = headers.get("remaining")
-    assert actual == expected, (
+    assert actual == expected, (  # nosec B101
         f"Expected X-RateLimit-Remaining={expected}, got {actual}"
     )
 
@@ -346,7 +346,7 @@ def assert_retry_after(
         assert_retry_after(response, expected=60, tolerance=5)
     """
     retry_after_header = response.get("Retry-After")
-    assert retry_after_header is not None, "Retry-After header missing"
+    assert retry_after_header is not None, "Retry-After header missing"  # nosec B101
 
     try:
         actual = int(retry_after_header)
@@ -354,7 +354,7 @@ def assert_retry_after(
         raise AssertionError(f"Retry-After header not an integer: {retry_after_header}")
 
     diff = abs(actual - expected)
-    assert diff <= tolerance, (
+    assert diff <= tolerance, (  # nosec B101
         f"Expected Retry-After ~{expected}s (tolerance {tolerance}), "
         f"got {actual}s (diff: {diff}s)"
     )
@@ -399,7 +399,7 @@ def read_rate_limit_headers(response: Any) -> Dict[str, Optional[int]]:
                     result[key] = int_val
                 except (ValueError, TypeError):
                     pass
-    except Exception:
+    except Exception:  # nosec B110
         # Fallback: try response.__getitem__ or response.headers attribute
         pass
 
@@ -537,6 +537,6 @@ def clear_rate_limit_cache(key_pattern: str = "*") -> None:
                 for k in keys_to_delete:
                     backend.reset(k)
 
-    except Exception:
+    except Exception:  # nosec B110
         # If backend isn't available, fail silently (likely wrong test setup)
         pass

--- a/django_smart_ratelimit/testing.py
+++ b/django_smart_ratelimit/testing.py
@@ -1,0 +1,542 @@
+"""
+Pytest testing utilities for django-smart-ratelimit.
+
+This module provides pytest fixtures and assertion helpers to simplify testing
+of rate-limited Django views and functions. It reduces boilerplate by handling
+backend setup, mocking, and time control.
+
+Example usage:
+
+    from django_smart_ratelimit.testing import (
+        assert_rate_limited,
+        assert_not_rate_limited,
+        RateLimitClient,
+    )
+
+    def test_rate_limit_exhaustion(client, ratelimit_memory_backend):
+        '''Test that rate limit is enforced after N requests.'''
+        # ratelimit_memory_backend fixture auto-wires memory backend
+        rate_limit_client = RateLimitClient(client)
+        responses, final_response = rate_limit_client.exhaust_limit(
+            "/api/endpoint/", limit=5
+        )
+
+        assert len(responses) == 5
+        assert_rate_limited(final_response, expected_limit=5)
+        assert_remaining(final_response, expected=0)
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional, Tuple
+
+try:
+    import pytest
+except ImportError:
+    pytest = None  # type: ignore
+
+
+def _get_pytest() -> Any:
+    """Get pytest module or raise helpful error if not installed."""
+    if pytest is None:
+        raise ImportError(
+            "pytest is required for django_smart_ratelimit.testing fixtures. "
+            "Install with: pip install 'django-smart-ratelimit[dev]'"
+        )
+    return pytest
+
+
+# Pytest Fixtures (conditional on pytest being available)
+
+
+if pytest is not None:
+
+    @pytest.fixture  # type: ignore
+    def ratelimit_memory_backend(monkeypatch: Any) -> Any:
+        """
+        Fixture that swaps the rate limiter backend to use MemoryBackend.
+
+        Automatically patches `get_backend()` to return a fresh MemoryBackend
+        for each test, clearing state between tests.
+
+        Usage:
+            def test_my_view(client, ratelimit_memory_backend):
+                # Backend is already wired; just use your view
+                response = client.get("/api/endpoint/")
+                assert response.status_code == 200
+
+        Returns:
+            MemoryBackend: A fresh memory backend instance for the test.
+        """
+        from django_smart_ratelimit.backends.memory import MemoryBackend
+
+        backend = MemoryBackend()
+
+        def mock_get_backend(backend_name: Optional[str] = None) -> Any:
+            return backend
+
+        monkeypatch.setattr(
+            "django_smart_ratelimit.backends.get_backend", mock_get_backend
+        )
+        monkeypatch.setattr(
+            "django_smart_ratelimit.decorator.get_backend", mock_get_backend
+        )
+
+        yield backend
+
+        # Cleanup: clear and shutdown backend
+        backend.clear_all()
+        if hasattr(backend, "shutdown"):
+            backend.shutdown()
+
+    @pytest.fixture  # type: ignore
+    def disable_ratelimit(settings: Any) -> None:  # type: ignore
+        """
+        Fixture that disables rate limiting globally for the test.
+
+        Sets RATELIMIT_ENABLE = False, allowing all requests through
+        without rate limit checks.
+
+        Usage:
+            def test_with_ratelimit_disabled(client, disable_ratelimit):
+                # All requests pass; no rate limiting
+                for _ in range(100):
+                    response = client.get("/api/endpoint/")
+                    assert response.status_code == 200
+        """
+        settings.RATELIMIT_ENABLE = False
+
+    @pytest.fixture  # type: ignore
+    def ratelimit_redis_backend(monkeypatch: Any) -> Any:  # type: ignore
+        """
+        Fixture that uses a real Redis backend if available.
+
+        Skips the test with a clear message if Redis is unavailable or
+        not configured. Generates a unique key namespace per test to avoid
+        cross-test pollution.
+
+        Usage:
+            def test_redis_backend(client, ratelimit_redis_backend):
+                # Backend is wired; uses actual Redis
+                response = client.get("/api/endpoint/")
+                assert response.status_code == 200
+
+        Returns:
+            RedisBackend: A Redis backend instance.
+
+        Raises:
+            pytest.skip: If Redis is unavailable.
+        """
+        from django_smart_ratelimit.backends import get_backend
+
+        try:
+            # Try to get or create a Redis backend
+            backend = get_backend("redis")
+
+            # Test connectivity
+            if hasattr(backend, "health_check"):
+                health = backend.health_check()
+                if health.get("status") != "healthy":
+                    pytest.skip("Redis backend unhealthy")
+
+            # Generate unique namespace per test
+            test_id = id(backend)
+            if hasattr(backend, "_key_prefix"):
+                backend._key_prefix = f"test_{test_id}_"
+
+            yield backend
+
+            # Cleanup
+            if hasattr(backend, "clear_all"):
+                backend.clear_all()
+
+        except Exception as e:
+            pytest.skip(f"Redis backend unavailable: {e}")
+
+    @pytest.fixture  # type: ignore
+    def frozen_ratelimit_time(monkeypatch: Any) -> Any:  # type: ignore
+        """
+        Fixture for simulated time advancement in rate limit tests.
+
+        Patches `time.time()` in rate limiter modules to allow
+        deterministic time control without waiting for real time to pass.
+
+        Usage:
+            def test_rate_limit_reset(client, ratelimit_memory_backend, frozen_ratelimit_time):
+                # Exhaust limit at t=0
+                client.get("/api/endpoint/")
+                client.get("/api/endpoint/")
+                response = client.get("/api/endpoint/")
+                assert response.status_code == 429
+
+                # Advance time by 61 seconds (past default 60s period)
+                frozen_ratelimit_time.advance(61)
+
+                # Now we have quota again
+                response = client.get("/api/endpoint/")
+                assert response.status_code == 200
+
+        Returns:
+            FrozenTime: A context manager / object for time control.
+        """
+
+        class FrozenTime:
+            """Simulate time advancement for rate limit tests."""
+
+            def __init__(self, monkeypatch: Any) -> None:
+                self.monkeypatch = monkeypatch
+                self.current_time = time.time()
+                self._patch_time()
+
+            def _patch_time(self) -> None:
+                """Patch time.time() across rate limiter modules."""
+
+                def mock_time() -> float:
+                    return self.current_time
+
+                self.monkeypatch.setattr("time.time", mock_time)
+                self.monkeypatch.setattr(
+                    "django_smart_ratelimit.backends.utils.get_current_timestamp",
+                    mock_time,
+                )
+                self.monkeypatch.setattr(
+                    "django_smart_ratelimit.decorator.time.time",
+                    mock_time,
+                )
+
+            def advance(self, seconds: float) -> None:
+                """Advance simulated time by N seconds.
+
+                Args:
+                    seconds: Number of seconds to advance.
+                """
+                self.current_time += seconds
+
+            def set_time(self, timestamp: float) -> None:
+                """Set simulated time to an absolute timestamp.
+
+                Args:
+                    timestamp: Unix timestamp to set.
+                """
+                self.current_time = timestamp
+
+            def __enter__(self) -> FrozenTime:
+                """Context manager entry."""
+                return self
+
+            def __exit__(self, *args: Any) -> None:
+                """Context manager exit."""
+                pass
+
+        return FrozenTime(monkeypatch)
+
+
+# Assertion Helpers (plain functions, always available)
+
+
+def assert_rate_limited(
+    response: Any,
+    *,
+    expected_limit: Optional[int] = None,
+    expected_remaining: Optional[int] = None,
+) -> None:
+    """
+    Assert that a response is rate-limited (status 429).
+
+    Validates response status and optional X-RateLimit-* headers.
+
+    Args:
+        response: Django test client response.
+        expected_limit: If provided, assert X-RateLimit-Limit == this value.
+        expected_remaining: If provided, assert X-RateLimit-Remaining == this value.
+
+    Raises:
+        AssertionError: If response is not 429 or headers don't match.
+
+    Example:
+        response = client.get("/api/endpoint/")
+        assert_rate_limited(response, expected_limit=10, expected_remaining=0)
+    """
+    assert (
+        response.status_code == 429
+    ), f"Expected status 429, got {response.status_code}"
+
+    headers = read_rate_limit_headers(response)
+
+    if expected_limit is not None:
+        actual = headers.get("limit")
+        assert actual == expected_limit, (
+            f"Expected X-RateLimit-Limit={expected_limit}, got {actual}"
+        )
+
+    if expected_remaining is not None:
+        actual = headers.get("remaining")
+        assert actual == expected_remaining, (
+            f"Expected X-RateLimit-Remaining={expected_remaining}, got {actual}"
+        )
+
+
+def assert_not_rate_limited(response: Any) -> None:
+    """
+    Assert that a response is NOT rate-limited (status != 429).
+
+    Validates that X-RateLimit-Remaining header is present.
+
+    Args:
+        response: Django test client response.
+
+    Raises:
+        AssertionError: If response is 429 or missing X-RateLimit-Remaining.
+
+    Example:
+        response = client.get("/api/endpoint/")
+        assert_not_rate_limited(response)
+    """
+    assert (
+        response.status_code != 429
+    ), "Expected status != 429, but got 429 (rate limited)"
+
+    headers = read_rate_limit_headers(response)
+    assert headers.get("remaining") is not None, (
+        "X-RateLimit-Remaining header missing from non-rate-limited response"
+    )
+
+
+def assert_remaining(response: Any, expected: int) -> None:
+    """
+    Assert that X-RateLimit-Remaining equals expected value.
+
+    Args:
+        response: Django test client response.
+        expected: Expected remaining requests.
+
+    Raises:
+        AssertionError: If header doesn't match.
+
+    Example:
+        response = client.get("/api/endpoint/")
+        assert_remaining(response, 9)
+    """
+    headers = read_rate_limit_headers(response)
+    actual = headers.get("remaining")
+    assert actual == expected, (
+        f"Expected X-RateLimit-Remaining={expected}, got {actual}"
+    )
+
+
+def assert_retry_after(
+    response: Any, expected: int, tolerance: int = 1
+) -> None:
+    """
+    Assert that Retry-After header is within tolerance.
+
+    Useful for testing that Retry-After is reasonable when rate-limited.
+
+    Args:
+        response: Django test client response.
+        expected: Expected Retry-After seconds.
+        tolerance: Allow +/- this many seconds.
+
+    Raises:
+        AssertionError: If header is outside tolerance.
+
+    Example:
+        response = client.get("/api/endpoint/")  # triggers 429
+        assert_retry_after(response, expected=60, tolerance=5)
+    """
+    retry_after_header = response.get("Retry-After")
+    assert retry_after_header is not None, "Retry-After header missing"
+
+    try:
+        actual = int(retry_after_header)
+    except (ValueError, TypeError):
+        raise AssertionError(f"Retry-After header not an integer: {retry_after_header}")
+
+    diff = abs(actual - expected)
+    assert diff <= tolerance, (
+        f"Expected Retry-After ~{expected}s (tolerance {tolerance}), "
+        f"got {actual}s (diff: {diff}s)"
+    )
+
+
+def read_rate_limit_headers(response: Any) -> Dict[str, Optional[int]]:
+    """
+    Extract all X-RateLimit-* headers from response.
+
+    Returns a dict mapping canonical names to integers:
+    - "limit" -> X-RateLimit-Limit
+    - "remaining" -> X-RateLimit-Remaining
+    - "reset" -> X-RateLimit-Reset
+
+    Args:
+        response: Django test client response.
+
+    Returns:
+        Dictionary of rate limit headers {name: value or None}.
+
+    Example:
+        headers = read_rate_limit_headers(response)
+        assert headers["limit"] == 10
+        assert headers["remaining"] == 5
+    """
+    result: Dict[str, Optional[int]] = {
+        "limit": None,
+        "remaining": None,
+        "reset": None,
+    }
+
+    # Django test responses: use response.get() or response[header_name]
+    # Or use response.headers for test client >= Django 3.2
+    try:
+        # Django test client response supports dict-like access
+        for header_key in ("X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset"):
+            val = response.get(header_key)
+            if val is not None:
+                try:
+                    int_val = int(val)
+                    key = header_key.split("-")[-1].lower()
+                    result[key] = int_val
+                except (ValueError, TypeError):
+                    pass
+    except Exception:
+        # Fallback: try response.__getitem__ or response.headers attribute
+        pass
+
+    return result
+
+
+# Helper Utilities
+
+
+class RateLimitClient:
+    """
+    Helper to exhaust rate limits by making requests until hitting 429.
+
+    Wraps a Django test client and provides methods to programmatically
+    exhaust a rate limit, useful for testing behavior when limits are hit.
+
+    Example:
+        def test_exhaust_limit(client, ratelimit_memory_backend):
+            rate_limit_client = RateLimitClient(client)
+            responses, final = rate_limit_client.exhaust_limit(
+                "/api/endpoint/", limit=5
+            )
+            assert len(responses) == 5
+            assert_rate_limited(final, expected_limit=5, expected_remaining=0)
+    """
+
+    def __init__(self, client: Any) -> None:
+        """
+        Initialize with a Django test client.
+
+        Args:
+            client: Django test.Client instance.
+        """
+        self.client = client
+        self.responses: list[Any] = []
+
+    def exhaust_limit(
+        self,
+        path: str,
+        limit: int = 10,
+        method: str = "GET",
+        **kwargs: Any,
+    ) -> Tuple[list[Any], Any]:
+        """
+        Make requests until rate limit is hit, then one more to trigger 429.
+
+        Args:
+            path: URL path (e.g., "/api/endpoint/").
+            limit: Expected rate limit value (used to determine how many
+                   requests to make).
+            method: HTTP method (GET, POST, etc.). Defaults to GET.
+            **kwargs: Additional arguments for client.get/post/etc.
+
+        Returns:
+            Tuple of (successful_responses, exceeded_response) where:
+            - successful_responses: List of responses before hitting limit
+            - exceeded_response: The 429 response (or last response if limit
+                                not triggered)
+
+        Example:
+            responses, rate_limited = client.exhaust_limit(
+                "/api/endpoint/", limit=5
+            )
+            assert len(responses) == 5
+            assert rate_limited.status_code == 429
+        """
+        client_method = getattr(self.client, method.lower())
+        responses = []
+
+        # Make limit+1 requests (limit should pass, +1 should fail)
+        for i in range(limit + 1):
+            response = client_method(path, **kwargs)
+            responses.append(response)
+
+            if response.status_code == 429:
+                # Hit the limit
+                return responses[:-1], response
+
+        # If we didn't hit 429, return all but last
+        return responses[:-1], responses[-1]
+
+    def clear_responses(self) -> None:
+        """Clear the stored responses list."""
+        self.responses = []
+
+
+def clear_rate_limit_cache(key_pattern: str = "*") -> None:
+    """
+    Clear rate limit entries matching a pattern from the active backend.
+
+    Gets the active backend and clears matching keys. Useful for cleaning
+    up between test runs or isolating specific test data.
+
+    Args:
+        key_pattern: Pattern to match. "*" (default) clears all.
+                    Supports simple glob patterns like "user_*".
+
+    Example:
+        # Clear all rate limits
+        clear_rate_limit_cache()
+
+        # Clear only user-related limits
+        clear_rate_limit_cache("user_*")
+
+    Note:
+        Requires that a backend is available (e.g., via ratelimit_memory_backend
+        fixture). This is primarily for test cleanup.
+    """
+    try:
+        from django_smart_ratelimit.backends import get_backend
+
+        backend = get_backend()
+
+        if key_pattern == "*":
+            # Clear all
+            if hasattr(backend, "clear_all"):
+                backend.clear_all()
+            else:
+                # Fallback: try to enumerate and delete
+                if hasattr(backend, "_data"):
+                    backend._data.clear()
+                if hasattr(backend, "_token_buckets"):
+                    backend._token_buckets.clear()
+                if hasattr(backend, "_storage"):
+                    backend._storage.clear()
+        else:
+            # Pattern-based deletion (limited support for memory backend)
+            if hasattr(backend, "_data"):
+                import fnmatch
+
+                keys_to_delete = [
+                    k for k in backend._data.keys()
+                    if fnmatch.fnmatch(k, key_pattern)
+                ]
+                for k in keys_to_delete:
+                    backend.reset(k)
+
+    except Exception:
+        # If backend isn't available, fail silently (likely wrong test setup)
+        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-smart-ratelimit"
-version = "2.2.1"
+version = "3.0.0"
 dynamic = []
 description = "A flexible and efficient rate limiting library for Django applications"
 readme = "README.md"
@@ -57,12 +57,18 @@ jwt = [
 prometheus = [
     "prometheus-client>=0.14.0",
 ]
+opentelemetry = [
+    "opentelemetry-api>=1.20.0",
+    "opentelemetry-sdk>=1.20.0",
+]
 all = [
     "redis>=4.0",
     "hiredis>=2.0",
     "pymongo>=4.0",
     "PyJWT>=2.0",
     "prometheus-client>=0.14.0",
+    "opentelemetry-api>=1.20.0",
+    "opentelemetry-sdk>=1.20.0",
 ]
 dev = [
     "pytest>=7.0",
@@ -94,6 +100,9 @@ Repository = "https://github.com/YasserShkeir/django-smart-ratelimit"
 Issues = "https://github.com/YasserShkeir/django-smart-ratelimit/issues"
 Discussions = "https://github.com/YasserShkeir/django-smart-ratelimit/discussions"
 Changelog = "https://github.com/YasserShkeir/django-smart-ratelimit/blob/main/CHANGELOG.md"
+
+[project.entry-points."pytest11"]
+django_smart_ratelimit = "django_smart_ratelimit.testing"
 
 [tool.hatch.version]
 path = "django_smart_ratelimit/__init__.py"

--- a/tests/integration/test_drf_throttle.py
+++ b/tests/integration/test_drf_throttle.py
@@ -1,0 +1,621 @@
+"""
+Tests for django-smart-ratelimit DRF throttle adapter.
+
+Tests the SmartRateLimitThrottle and related classes that integrate
+django-smart-ratelimit with Django REST Framework's throttling system.
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase, override_settings
+
+try:
+    from rest_framework import status
+    from rest_framework.response import Response
+    from rest_framework.test import APITestCase, APIClient
+    from rest_framework.views import APIView
+
+    DRF_AVAILABLE = True
+except ImportError:
+    DRF_AVAILABLE = False
+
+
+pytestmark = pytest.mark.skipif(
+    not DRF_AVAILABLE, reason="Django REST Framework not installed"
+)
+
+
+@unittest.skipUnless(DRF_AVAILABLE, "DRF not available")
+@override_settings(
+    INSTALLED_APPS=[
+        "django.contrib.auth",
+        "django.contrib.contenttypes",
+        "django.contrib.sessions",
+        "django.contrib.messages",
+        "django_smart_ratelimit",
+        "rest_framework",
+    ],
+    REST_FRAMEWORK={
+        "DEFAULT_THROTTLE_RATES": {
+            "user": "5/minute",
+            "anon": "3/minute",
+            "custom": "10/minute",
+        }
+    },
+    RATELIMIT_BACKEND="django_smart_ratelimit.backends.memory.MemoryBackend",
+)
+class SmartRateLimitThrottleTestCase(APITestCase):
+    """Test SmartRateLimitThrottle basic functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Reset backend cache + state so each test sees a fresh MemoryBackend.
+        from django_smart_ratelimit.backends import (
+            clear_backend_cache,
+            get_backend,
+        )
+
+        clear_backend_cache()
+        backend = get_backend()
+        if hasattr(backend, "clear_all"):
+            backend.clear_all()
+
+        self.factory = RequestFactory()
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="testpass"
+        )
+        self.client = APIClient()
+
+    def tearDown(self):
+        """Tear down — reset backend state for isolation."""
+        from django_smart_ratelimit.backends import (
+            clear_backend_cache,
+            get_backend,
+        )
+
+        try:
+            backend = get_backend()
+            if hasattr(backend, "clear_all"):
+                backend.clear_all()
+        except Exception:
+            pass
+        clear_backend_cache()
+
+    def test_throttle_unavailable_without_drf(self):
+        """Test that throttle raises ImportError when DRF not installed."""
+        with patch(
+            "django_smart_ratelimit.integrations.drf.BaseThrottle", None
+        ):
+            from django_smart_ratelimit.integrations.drf import (
+                SmartRateLimitThrottle,
+            )
+
+            with pytest.raises(ImportError, match="django-rest-framework"):
+                SmartRateLimitThrottle()
+
+    def test_user_throttle_basic(self):
+        """Test UserRateLimitThrottle allows requests within limit."""
+        from django_smart_ratelimit.integrations.drf import (
+            UserRateLimitThrottle,
+        )
+
+        throttle = UserRateLimitThrottle()
+        request = self.factory.get("/api/test/")
+        request.user = self.user
+        view = Mock()
+
+        # First request should be allowed
+        assert throttle.allow_request(request, view) is True
+
+        # Wait() should return reasonable value
+        wait_time = throttle.wait()
+        assert wait_time is None or isinstance(wait_time, float)
+
+    def test_user_throttle_exceeds_limit(self):
+        """Test UserRateLimitThrottle blocks after limit exceeded."""
+        from django_smart_ratelimit.integrations.drf import (
+            UserRateLimitThrottle,
+        )
+
+        throttle = UserRateLimitThrottle()
+        request = self.factory.get("/api/test/")
+        request.user = self.user
+        view = Mock()
+
+        # Make requests up to limit
+        for i in range(5):
+            result = throttle.allow_request(request, view)
+            assert result is True, f"Request {i+1} should be allowed"
+
+        # 6th request should be blocked
+        throttle_6 = UserRateLimitThrottle()
+        result = throttle_6.allow_request(request, view)
+        assert result is False, "Request 6 should be blocked"
+
+    def test_anon_throttle_by_ip(self):
+        """Test AnonRateLimitThrottle uses IP for anonymous users."""
+        from django_smart_ratelimit.integrations.drf import (
+            AnonRateLimitThrottle,
+        )
+
+        throttle = AnonRateLimitThrottle()
+        request = self.factory.get("/api/test/")
+        request.user = Mock(is_authenticated=False)
+        request.META["REMOTE_ADDR"] = "192.168.1.1"
+        view = Mock()
+
+        # Should use IP-based key
+        key = throttle.get_cache_key(request, view)
+        assert "ip:" in key
+
+        # First request allowed
+        assert throttle.allow_request(request, view) is True
+
+    def test_anon_throttle_limit(self):
+        """Test AnonRateLimitThrottle blocks after limit (3/minute)."""
+        from django_smart_ratelimit.integrations.drf import (
+            AnonRateLimitThrottle,
+        )
+
+        request = self.factory.get("/api/test/")
+        request.user = Mock(is_authenticated=False)
+        request.META["REMOTE_ADDR"] = "192.168.1.1"
+        view = Mock()
+
+        # Make 3 requests
+        for i in range(3):
+            throttle = AnonRateLimitThrottle()
+            result = throttle.allow_request(request, view)
+            assert result is True, f"Request {i+1} should be allowed"
+
+        # 4th should be blocked
+        throttle = AnonRateLimitThrottle()
+        result = throttle.allow_request(request, view)
+        assert result is False, "Request 4 should be blocked"
+
+    def test_different_users_have_separate_limits(self):
+        """Test that different users have independent rate limits."""
+        from django_smart_ratelimit.integrations.drf import (
+            UserRateLimitThrottle,
+        )
+
+        User = get_user_model()
+        user2 = User.objects.create_user(
+            username="user2", email="user2@example.com", password="testpass"
+        )
+
+        # Request 1: user1
+        request1 = self.factory.get("/api/test/")
+        request1.user = self.user
+        view = Mock()
+
+        throttle = UserRateLimitThrottle()
+        assert throttle.allow_request(request1, view) is True
+
+        # Request 2: user2 (should have separate limit)
+        request2 = self.factory.get("/api/test/")
+        request2.user = user2
+        view = Mock()
+
+        throttle = UserRateLimitThrottle()
+        assert throttle.allow_request(request2, view) is True
+
+    def test_custom_rate_attribute(self):
+        """Test throttle with custom rate attribute."""
+        from django_smart_ratelimit.integrations.drf import (
+            SmartRateLimitThrottle,
+        )
+
+        class CustomThrottle(SmartRateLimitThrottle):
+            scope = "custom"
+            rate = "2/minute"
+
+        throttle = CustomThrottle()
+        request = self.factory.get("/api/test/")
+        request.user = self.user
+        view = Mock()
+
+        # First 2 should pass
+        assert throttle.allow_request(request, view) is True
+        throttle = CustomThrottle()
+        assert throttle.allow_request(request, view) is True
+
+        # 3rd should fail
+        throttle = CustomThrottle()
+        assert throttle.allow_request(request, view) is False
+
+    def test_custom_key_func(self):
+        """Test throttle with custom key_func."""
+        from django_smart_ratelimit.integrations.drf import (
+            SmartRateLimitThrottle,
+        )
+
+        def custom_key(request, view):
+            """Use a custom header as key."""
+            return request.META.get("HTTP_X_CUSTOM_KEY", "default")
+
+        class CustomKeyThrottle(SmartRateLimitThrottle):
+            scope = "custom"
+            rate = "3/minute"
+            key_func = custom_key
+
+        request = self.factory.get("/api/test/")
+        request.META["HTTP_X_CUSTOM_KEY"] = "special-key"
+        view = Mock()
+
+        throttle = CustomKeyThrottle()
+        assert throttle.allow_request(request, view) is True
+
+        # Verify it used custom key
+        key = custom_key(request, view)
+        assert key == "special-key"
+
+    def test_callable_rate(self):
+        """Test throttle with callable rate."""
+        from django_smart_ratelimit.integrations.drf import (
+            SmartRateLimitThrottle,
+        )
+
+        def get_rate(throttle, request):
+            """Return different rates based on user."""
+            if hasattr(request, "user") and request.user.is_staff:
+                return "100/minute"
+            return "5/minute"
+
+        class DynamicRateThrottle(SmartRateLimitThrottle):
+            scope = "dynamic"
+            rate = get_rate
+
+        request = self.factory.get("/api/test/")
+        request.user = self.user
+        view = Mock()
+
+        throttle = DynamicRateThrottle()
+        # Should get regular rate for non-staff
+        resolved_rate = throttle._get_rate(request, view)
+        assert resolved_rate == "5/minute"
+
+    def test_scoped_throttle_with_throttle_scope(self):
+        """Test ScopedRateLimitThrottle respects view's throttle_scope."""
+        from django_smart_ratelimit.integrations.drf import (
+            ScopedRateLimitThrottle,
+        )
+
+        throttle = ScopedRateLimitThrottle()
+        request = self.factory.get("/api/test/")
+        request.user = self.user
+
+        # Create view with throttle_scope
+        view = Mock()
+        view.throttle_scope = "custom"
+
+        assert throttle.allow_request(request, view) is True
+
+    def test_scoped_throttle_missing_scope_attribute(self):
+        """Test ScopedRateLimitThrottle handles missing throttle_scope."""
+        from django_smart_ratelimit.integrations.drf import (
+            ScopedRateLimitThrottle,
+        )
+
+        throttle = ScopedRateLimitThrottle()
+        request = self.factory.get("/api/test/")
+        request.user = self.user
+
+        # View without throttle_scope
+        view = Mock(spec=[])
+
+        # Should allow request and log warning
+        with patch(
+            "django_smart_ratelimit.integrations.drf.logger"
+        ) as mock_logger:
+            result = throttle.allow_request(request, view)
+            assert result is True
+            mock_logger.warning.assert_called()
+
+    def test_get_cache_key_defaults(self):
+        """Test get_cache_key defaults to user ID or IP."""
+        from django_smart_ratelimit.integrations.drf import (
+            SmartRateLimitThrottle,
+        )
+
+        throttle = SmartRateLimitThrottle()
+        request = self.factory.get("/api/test/")
+        request.user = self.user
+        view = Mock()
+
+        key = throttle.get_cache_key(request, view)
+        assert f"user:{self.user.id}" == key
+
+        # Anonymous user
+        request.user = Mock(is_authenticated=False)
+        request.META["REMOTE_ADDR"] = "10.0.0.1"
+
+        key = throttle.get_cache_key(request, view)
+        assert "ip:" in key
+
+    def test_wait_returns_none_initially(self):
+        """Test wait() returns None if not yet called."""
+        from django_smart_ratelimit.integrations.drf import (
+            SmartRateLimitThrottle,
+        )
+
+        throttle = SmartRateLimitThrottle()
+        throttle.scope = "user"
+        request = self.factory.get("/api/test/")
+        request.user = self.user
+        view = Mock()
+
+        # Before calling allow_request, wait should be None
+        assert throttle.wait() is None
+
+    def test_wait_returns_valid_seconds(self):
+        """Test wait() returns valid wait time after throttle."""
+        from django_smart_ratelimit.integrations.drf import (
+            UserRateLimitThrottle,
+        )
+
+        throttle = UserRateLimitThrottle()
+        request = self.factory.get("/api/test/")
+        request.user = self.user
+        view = Mock()
+
+        # Consume the limit
+        for _ in range(5):
+            throttle = UserRateLimitThrottle()
+            throttle.allow_request(request, view)
+
+        # Get a throttle that was throttled
+        throttle = UserRateLimitThrottle()
+        throttle.allow_request(request, view)  # This should fail
+
+        wait_time = throttle.wait()
+        assert wait_time is not None
+        assert isinstance(wait_time, float)
+        assert wait_time > 0
+
+    def test_throttle_success_and_failure(self):
+        """Test throttle_success and throttle_failure methods."""
+        from django_smart_ratelimit.integrations.drf import (
+            SmartRateLimitThrottle,
+        )
+
+        throttle = SmartRateLimitThrottle()
+
+        assert throttle.throttle_success() is True
+        assert throttle.throttle_failure() is False
+
+    def test_backend_error_fail_open(self):
+        """Test throttle allows request when backend fails with fail_open."""
+        from django_smart_ratelimit.integrations.drf import (
+            SmartRateLimitThrottle,
+        )
+
+        throttle = SmartRateLimitThrottle()
+        throttle.scope = "user"
+        request = self.factory.get("/api/test/")
+        request.user = self.user
+        view = Mock()
+
+        # Mock backend to raise error but with fail_open=True
+        with patch(
+            "django_smart_ratelimit.integrations.drf.get_backend"
+        ) as mock_get_backend:
+            mock_backend = Mock()
+            mock_backend.fail_open = True
+            mock_backend.incr.side_effect = Exception("Backend down")
+            mock_get_backend.return_value = mock_backend
+
+            # Should allow request
+            result = throttle.allow_request(request, view)
+            assert result is True
+
+    def test_invalid_rate_string(self):
+        """Test throttle handles invalid rate strings."""
+        from django_smart_ratelimit.integrations.drf import (
+            SmartRateLimitThrottle,
+        )
+
+        class BadRateThrottle(SmartRateLimitThrottle):
+            scope = "bad"
+            rate = "invalid"
+
+        throttle = BadRateThrottle()
+        request = self.factory.get("/api/test/")
+        request.user = self.user
+        view = Mock()
+
+        # Should allow request when rate parsing fails
+        result = throttle.allow_request(request, view)
+        assert result is True
+
+    def test_no_rate_configured(self):
+        """Test throttle when no rate is configured."""
+        from django_smart_ratelimit.integrations.drf import (
+            SmartRateLimitThrottle,
+        )
+
+        class NoRateThrottle(SmartRateLimitThrottle):
+            scope = "nonexistent_scope"
+
+        throttle = NoRateThrottle()
+        request = self.factory.get("/api/test/")
+        request.user = self.user
+        view = Mock()
+
+        # Should allow request (can't throttle without rate)
+        result = throttle.allow_request(request, view)
+        assert result is True
+
+    def test_get_cost_default(self):
+        """Test get_cost returns default cost of 1."""
+        from django_smart_ratelimit.integrations.drf import (
+            SmartRateLimitThrottle,
+        )
+
+        throttle = SmartRateLimitThrottle()
+        request = self.factory.get("/api/test/")
+        view = Mock()
+
+        cost = throttle.get_cost(request, view)
+        assert cost == 1
+
+    def test_get_cost_callable(self):
+        """Test get_cost with callable."""
+        from django_smart_ratelimit.integrations.drf import (
+            SmartRateLimitThrottle,
+        )
+
+        def cost_func(request, view):
+            return 5
+
+        class CustomCostThrottle(SmartRateLimitThrottle):
+            cost = cost_func
+
+        throttle = CustomCostThrottle()
+        request = self.factory.get("/api/test/")
+        view = Mock()
+
+        cost = throttle.get_cost(request, view)
+        assert cost == 5
+
+    def test_algorithm_attribute(self):
+        """Test algorithm attribute is set correctly."""
+        from django_smart_ratelimit.integrations.drf import (
+            SmartRateLimitThrottle,
+        )
+
+        class SlidingWindowThrottle(SmartRateLimitThrottle):
+            algorithm = "sliding_window"
+
+        throttle = SlidingWindowThrottle()
+        assert throttle.algorithm == "sliding_window"
+
+    def test_multiple_throttles_on_request(self):
+        """Test multiple throttles on same request (different scopes)."""
+        from django_smart_ratelimit.integrations.drf import (
+            UserRateLimitThrottle,
+            AnonRateLimitThrottle,
+        )
+
+        request = self.factory.get("/api/test/")
+        request.user = self.user
+        request.META["REMOTE_ADDR"] = "10.0.0.1"
+        view = Mock()
+
+        # Both should start independently
+        user_throttle = UserRateLimitThrottle()
+        anon_throttle = AnonRateLimitThrottle()
+
+        assert user_throttle.allow_request(request, view) is True
+        assert anon_throttle.allow_request(request, view) is True
+
+        # Keys should be different
+        user_key = user_throttle.get_cache_key(request, view)
+        anon_key = anon_throttle.get_cache_key(request, view)
+        assert user_key != anon_key
+
+
+@unittest.skipUnless(DRF_AVAILABLE, "DRF not available")
+@override_settings(
+    INSTALLED_APPS=[
+        "django.contrib.auth",
+        "django.contrib.contenttypes",
+        "rest_framework",
+        "django_smart_ratelimit",
+    ],
+    REST_FRAMEWORK={
+        "DEFAULT_THROTTLE_CLASSES": [
+            "django_smart_ratelimit.integrations.drf.UserRateLimitThrottle",
+            "django_smart_ratelimit.integrations.drf.AnonRateLimitThrottle",
+        ],
+        "DEFAULT_THROTTLE_RATES": {
+            "user": "3/minute",
+            "anon": "2/minute",
+        },
+    },
+    RATELIMIT_BACKEND="django_smart_ratelimit.backends.memory.MemoryBackend",
+)
+class DRFViewIntegrationTestCase(APITestCase):
+    """Test DRF throttles in actual DRF views."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        from django_smart_ratelimit.backends import (
+            clear_backend_cache,
+            get_backend,
+        )
+
+        clear_backend_cache()
+        backend = get_backend()
+        if hasattr(backend, "clear_all"):
+            backend.clear_all()
+
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="testpass"
+        )
+        self.client = APIClient()
+
+    def tearDown(self):
+        """Tear down — reset backend state for isolation."""
+        from django_smart_ratelimit.backends import (
+            clear_backend_cache,
+            get_backend,
+        )
+
+        try:
+            backend = get_backend()
+            if hasattr(backend, "clear_all"):
+                backend.clear_all()
+        except Exception:
+            pass
+        clear_backend_cache()
+
+    def test_throttle_in_apiview(self):
+        """Test throttle works in APIView."""
+        from django_smart_ratelimit.integrations.drf import (
+            UserRateLimitThrottle,
+        )
+
+        class TestView(APIView):
+            throttle_classes = [UserRateLimitThrottle]
+
+            def get(self, request):
+                return Response({"message": "ok"})
+
+        view = TestView.as_view()
+        request = RequestFactory().get("/test/")
+        request.user = self.user
+
+        # Should work
+        response = view(request)
+        assert response.status_code == 200
+
+    def test_throttle_in_viewset_integration(self):
+        """Test throttle works with viewset actions."""
+        from django_smart_ratelimit.integrations.drf import (
+            UserRateLimitThrottle,
+        )
+
+        try:
+            from rest_framework import viewsets
+        except ImportError:
+            self.skipTest("DRF viewsets not available")
+
+        class TestViewSet(viewsets.ViewSet):
+            throttle_classes = [UserRateLimitThrottle]
+
+            def list(self, request):
+                return Response([{"id": 1}])
+
+        factory = RequestFactory()
+        request = factory.get("/test/")
+        request.user = self.user
+        viewset = TestViewSet()
+
+        response = viewset.list(request)
+        assert response.status_code == 200

--- a/tests/integration/test_drf_throttle.py
+++ b/tests/integration/test_drf_throttle.py
@@ -9,13 +9,13 @@ import unittest
 from unittest.mock import Mock, patch
 
 import pytest
+
 from django.contrib.auth import get_user_model
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import RequestFactory, override_settings
 
 try:
-    from rest_framework import status
     from rest_framework.response import Response
-    from rest_framework.test import APITestCase, APIClient
+    from rest_framework.test import APIClient, APITestCase
     from rest_framework.views import APIView
 
     DRF_AVAILABLE = True
@@ -87,9 +87,7 @@ class SmartRateLimitThrottleTestCase(APITestCase):
 
     def test_throttle_unavailable_without_drf(self):
         """Test that throttle raises ImportError when DRF not installed."""
-        with patch(
-            "django_smart_ratelimit.integrations.drf.BaseThrottle", None
-        ):
+        with patch("django_smart_ratelimit.integrations.drf.BaseThrottle", None):
             from django_smart_ratelimit.integrations.drf import (
                 SmartRateLimitThrottle,
             )
@@ -309,9 +307,7 @@ class SmartRateLimitThrottleTestCase(APITestCase):
         view = Mock(spec=[])
 
         # Should allow request and log warning
-        with patch(
-            "django_smart_ratelimit.integrations.drf.logger"
-        ) as mock_logger:
+        with patch("django_smart_ratelimit.integrations.drf.logger") as mock_logger:
             result = throttle.allow_request(request, view)
             assert result is True
             mock_logger.warning.assert_called()
@@ -347,7 +343,7 @@ class SmartRateLimitThrottleTestCase(APITestCase):
         throttle.scope = "user"
         request = self.factory.get("/api/test/")
         request.user = self.user
-        view = Mock()
+        Mock()
 
         # Before calling allow_request, wait should be None
         assert throttle.wait() is None
@@ -497,8 +493,8 @@ class SmartRateLimitThrottleTestCase(APITestCase):
     def test_multiple_throttles_on_request(self):
         """Test multiple throttles on same request (different scopes)."""
         from django_smart_ratelimit.integrations.drf import (
-            UserRateLimitThrottle,
             AnonRateLimitThrottle,
+            UserRateLimitThrottle,
         )
 
         request = self.factory.get("/api/test/")

--- a/tests/integration/test_v3_features.py
+++ b/tests/integration/test_v3_features.py
@@ -1,0 +1,242 @@
+"""
+End-to-end integration tests for v3 decorator features.
+
+Covers the interactions between the decorator, the pipeline, and the memory
+backend — the paths a real application would exercise.
+"""
+
+import logging
+import unittest
+
+from django.http import HttpResponse
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+from django_smart_ratelimit import rate_limit
+from django_smart_ratelimit.backends import clear_backend_cache, get_backend
+from django_smart_ratelimit.exceptions import KeyGenerationError
+
+
+def _fresh_backend():
+    """Clear backend singleton + its stored state between tests.
+
+    The backend module caches a single MemoryBackend instance; tests that
+    exercise the decorator must both drop the cached instance (so fresh
+    config is picked up) AND reset any leftover counters on the previous
+    instance.
+    """
+    try:
+        backend = get_backend()
+        if hasattr(backend, "clear_all"):
+            backend.clear_all()
+    except Exception:
+        pass
+    clear_backend_cache()
+
+
+# All v3 integration tests run against the in-process MemoryBackend. The repo's
+# default test settings point at Redis, which isn't available in CI; forcing
+# memory here keeps these tests hermetic.
+_MEMORY_BACKEND_SETTINGS = dict(
+    RATELIMIT_BACKEND="memory",
+    RATELIMIT_MIDDLEWARE={
+        "DEFAULT_RATE": "100/m",
+        "BACKEND": "memory",
+        "BLOCK": True,
+        "SKIP_PATHS": ["/admin/", "/health/"],
+    },
+)
+
+
+@override_settings(**_MEMORY_BACKEND_SETTINGS)
+class ShadowModeTests(SimpleTestCase):
+    """A decorator with shadow=True should log but never block."""
+
+    def setUp(self):
+        _fresh_backend()
+        self.factory = RequestFactory()
+
+    def tearDown(self):
+        _fresh_backend()
+
+    def test_shadow_mode_does_not_block(self):
+        @rate_limit(key="ip", rate="2/m", shadow=True)
+        def view(request):
+            return HttpResponse("ok")
+
+        # Exceed the limit many times over — shadow=True means every call
+        # should succeed.
+        responses = []
+        with self.assertLogs(
+            "django_smart_ratelimit.pipeline", level=logging.INFO
+        ) as log:
+            for _ in range(10):
+                resp = view(self.factory.get("/", REMOTE_ADDR="10.0.0.1"))
+                responses.append(resp.status_code)
+
+        self.assertEqual(responses, [200] * 10, "shadow mode must never return 429")
+        # At least one shadow block event must have been logged.
+        self.assertTrue(
+            any("SHADOW_RATE_LIMIT_BLOCK" in m for m in log.output),
+            "shadow mode should emit a SHADOW_RATE_LIMIT_BLOCK log line",
+        )
+
+    def test_shadow_mode_off_still_blocks(self):
+        @rate_limit(key="ip", rate="2/m", shadow=False)
+        def view(request):
+            return HttpResponse("ok")
+
+        statuses = [
+            view(self.factory.get("/", REMOTE_ADDR="10.0.0.2")).status_code
+            for _ in range(5)
+        ]
+        # First 2 should pass, the rest should be blocked.
+        self.assertEqual(statuses.count(200), 2)
+        self.assertEqual(statuses.count(429), 3)
+
+
+@override_settings(**_MEMORY_BACKEND_SETTINGS)
+class CostBasedLimitingTests(SimpleTestCase):
+    """cost > 1 should consume proportionally more of the limit."""
+
+    def setUp(self):
+        _fresh_backend()
+        self.factory = RequestFactory()
+
+    def tearDown(self):
+        _fresh_backend()
+
+    def test_integer_cost_consumes_budget(self):
+        @rate_limit(key="ip", rate="6/m", cost=2)
+        def view(request):
+            return HttpResponse("ok")
+
+        # Each call consumes 2 of 6 → 3 calls succeed, 4th blocks.
+        statuses = [
+            view(self.factory.get("/", REMOTE_ADDR="10.0.0.3")).status_code
+            for _ in range(4)
+        ]
+        self.assertEqual(statuses[:3], [200, 200, 200])
+        self.assertEqual(statuses[3], 429)
+
+    def test_callable_cost_gets_request(self):
+        """Callable cost should receive the request and be used per-call."""
+        seen = []
+
+        def dynamic_cost(request):
+            seen.append(request.path)
+            # POST requests are more expensive.
+            return 3 if request.method == "POST" else 1
+
+        @rate_limit(key="ip", rate="5/m", cost=dynamic_cost)
+        def view(request):
+            return HttpResponse("ok")
+
+        get_resp = view(self.factory.get("/a", REMOTE_ADDR="10.0.0.4"))
+        post_resp = view(self.factory.post("/b", REMOTE_ADDR="10.0.0.4"))
+        self.assertEqual(get_resp.status_code, 200)
+        self.assertEqual(post_resp.status_code, 200)
+        # Next GET should fit (1 + 3 + 1 = 5 ≤ 5).
+        third = view(self.factory.get("/c", REMOTE_ADDR="10.0.0.4"))
+        self.assertEqual(third.status_code, 200)
+        # Next request exceeds budget.
+        fourth = view(self.factory.get("/d", REMOTE_ADDR="10.0.0.4"))
+        self.assertEqual(fourth.status_code, 429)
+        # Callable was invoked each time.
+        self.assertEqual(len(seen), 4)
+
+
+@override_settings(**_MEMORY_BACKEND_SETTINGS)
+class AllowDenyListTests(SimpleTestCase):
+    """Decorator-level CIDR lists — deny returns 429, allow bypasses limit."""
+
+    def setUp(self):
+        _fresh_backend()
+        self.factory = RequestFactory()
+
+    def tearDown(self):
+        _fresh_backend()
+
+    def test_deny_list_blocks_with_429(self):
+        @rate_limit(key="ip", rate="1000/m", deny_list=["1.2.3.0/24"])
+        def view(request):
+            return HttpResponse("ok")
+
+        resp = view(self.factory.get("/", REMOTE_ADDR="1.2.3.50"))
+        self.assertEqual(resp.status_code, 429)
+
+    def test_deny_list_honors_shadow_mode(self):
+        """Shadow mode must also suppress explicit deny-list blocks."""
+
+        @rate_limit(
+            key="ip",
+            rate="1000/m",
+            deny_list=["1.2.3.0/24"],
+            shadow=True,
+        )
+        def view(request):
+            return HttpResponse("ok")
+
+        resp = view(self.factory.get("/", REMOTE_ADDR="1.2.3.50"))
+        self.assertEqual(resp.status_code, 200)
+
+    def test_allow_list_bypasses_limit(self):
+        """Allow-list hits skip counting entirely."""
+
+        @rate_limit(
+            key="ip",
+            rate="1/m",
+            allow_list=["10.0.0.0/8"],
+        )
+        def view(request):
+            return HttpResponse("ok")
+
+        # 10 requests from an allow-listed IP should all succeed.
+        for _ in range(10):
+            resp = view(self.factory.get("/", REMOTE_ADDR="10.1.1.1"))
+            self.assertEqual(resp.status_code, 200)
+
+    def test_deny_wins_over_allow(self):
+        @rate_limit(
+            key="ip",
+            rate="1000/m",
+            allow_list=["10.0.0.0/8"],
+            deny_list=["10.0.0.99"],
+        )
+        def view(request):
+            return HttpResponse("ok")
+
+        # Allow-listed range, but explicit deny — deny wins.
+        resp = view(self.factory.get("/", REMOTE_ADDR="10.0.0.99"))
+        self.assertEqual(resp.status_code, 429)
+
+
+@override_settings(**_MEMORY_BACKEND_SETTINGS)
+class KeyValidationTests(SimpleTestCase):
+    """Empty keys should blow up loudly — they're a rate-limit-bypass bug."""
+
+    def setUp(self):
+        _fresh_backend()
+        self.factory = RequestFactory()
+
+    def tearDown(self):
+        _fresh_backend()
+
+    def test_empty_string_key_raises(self):
+        @rate_limit(key=lambda _req, *a, **kw: "", rate="10/m")
+        def view(request):
+            return HttpResponse("ok")
+
+        with self.assertRaises(KeyGenerationError):
+            view(self.factory.get("/"))
+
+    def test_none_key_raises(self):
+        @rate_limit(key=lambda _req, *a, **kw: None, rate="10/m")
+        def view(request):
+            return HttpResponse("ok")
+
+        with self.assertRaises(KeyGenerationError):
+            view(self.factory.get("/"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_otel.py
+++ b/tests/unit/test_otel.py
@@ -8,22 +8,20 @@ Skips if opentelemetry is not installed.
 import pytest
 
 try:
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import SimpleSpanProcessor
     from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
         InMemorySpanExporter,
     )
-    from opentelemetry.sdk.metrics import MeterProvider
-    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 
     HAS_OTEL = True
 except ImportError:
     HAS_OTEL = False
 
 
-pytestmark = pytest.mark.skipif(
-    not HAS_OTEL, reason="opentelemetry not installed"
-)
+pytestmark = pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed")
 
 
 @pytest.fixture
@@ -56,7 +54,9 @@ class TestRateLimitTracer:
         """Test that allowed request creates span with correct attributes."""
         from django_smart_ratelimit.observability.otel import RateLimitTracer
 
-        tracer = RateLimitTracer(tracer=otel_setup["tracer_provider"].get_tracer(__name__))
+        tracer = RateLimitTracer(
+            tracer=otel_setup["tracer_provider"].get_tracer(__name__)
+        )
 
         with tracer.start_check_span(
             key="user:123",
@@ -86,10 +86,13 @@ class TestRateLimitTracer:
 
     def test_denied_request_sets_error_status(self, otel_setup):
         """Test that denied request sets span status to ERROR."""
-        from django_smart_ratelimit.observability.otel import RateLimitTracer
         from opentelemetry.trace import StatusCode
 
-        tracer = RateLimitTracer(tracer=otel_setup["tracer_provider"].get_tracer(__name__))
+        from django_smart_ratelimit.observability.otel import RateLimitTracer
+
+        tracer = RateLimitTracer(
+            tracer=otel_setup["tracer_provider"].get_tracer(__name__)
+        )
 
         with tracer.start_check_span(
             key="user:456",
@@ -114,7 +117,9 @@ class TestRateLimitTracer:
         """Test that shadow mode is recorded in span attributes."""
         from django_smart_ratelimit.observability.otel import RateLimitTracer
 
-        tracer = RateLimitTracer(tracer=otel_setup["tracer_provider"].get_tracer(__name__))
+        tracer = RateLimitTracer(
+            tracer=otel_setup["tracer_provider"].get_tracer(__name__)
+        )
 
         with tracer.start_check_span(
             key="user:789",
@@ -136,7 +141,9 @@ class TestRateLimitTracer:
         """Test that cost > 1 is recorded in span attributes."""
         from django_smart_ratelimit.observability.otel import RateLimitTracer
 
-        tracer = RateLimitTracer(tracer=otel_setup["tracer_provider"].get_tracer(__name__))
+        tracer = RateLimitTracer(
+            tracer=otel_setup["tracer_provider"].get_tracer(__name__)
+        )
 
         with tracer.start_check_span(
             key="batch:op1",

--- a/tests/unit/test_otel.py
+++ b/tests/unit/test_otel.py
@@ -1,0 +1,394 @@
+"""
+Tests for OpenTelemetry instrumentation.
+
+Tests span and metric emission for rate limit checks.
+Skips if opentelemetry is not installed.
+"""
+
+import pytest
+
+try:
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+    HAS_OTEL = True
+except ImportError:
+    HAS_OTEL = False
+
+
+pytestmark = pytest.mark.skipif(
+    not HAS_OTEL, reason="opentelemetry not installed"
+)
+
+
+@pytest.fixture
+def otel_setup():
+    """Set up OTel providers with in-memory exporters."""
+    if not HAS_OTEL:
+        pytest.skip("opentelemetry not installed")
+
+    # Setup tracer
+    span_exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+
+    # Setup meter
+    metric_reader = InMemoryMetricReader()
+    meter_provider = MeterProvider(metric_readers=[metric_reader])
+
+    return {
+        "tracer_provider": tracer_provider,
+        "meter_provider": meter_provider,
+        "span_exporter": span_exporter,
+        "metric_reader": metric_reader,
+    }
+
+
+class TestRateLimitTracer:
+    """Tests for RateLimitTracer."""
+
+    def test_allowed_request_creates_span(self, otel_setup):
+        """Test that allowed request creates span with correct attributes."""
+        from django_smart_ratelimit.observability.otel import RateLimitTracer
+
+        tracer = RateLimitTracer(tracer=otel_setup["tracer_provider"].get_tracer(__name__))
+
+        with tracer.start_check_span(
+            key="user:123",
+            limit=100,
+            remaining=42,
+            algorithm="sliding_window",
+            backend="RedisBackend",
+            allowed=True,
+            shadow=False,
+            cost=1,
+        ):
+            pass
+
+        spans = otel_setup["span_exporter"].get_finished_spans()
+        assert len(spans) == 1
+
+        span = spans[0]
+        assert span.name == "ratelimit.check"
+        assert span.attributes["ratelimit.key"] == "user:123"
+        assert span.attributes["ratelimit.limit"] == 100
+        assert span.attributes["ratelimit.remaining"] == 42
+        assert span.attributes["ratelimit.algorithm"] == "sliding_window"
+        assert span.attributes["ratelimit.backend"] == "RedisBackend"
+        assert span.attributes["ratelimit.decision"] == "allowed"
+        assert span.attributes["ratelimit.shadow"] is False
+        assert span.attributes["ratelimit.cost"] == 1
+
+    def test_denied_request_sets_error_status(self, otel_setup):
+        """Test that denied request sets span status to ERROR."""
+        from django_smart_ratelimit.observability.otel import RateLimitTracer
+        from opentelemetry.trace import StatusCode
+
+        tracer = RateLimitTracer(tracer=otel_setup["tracer_provider"].get_tracer(__name__))
+
+        with tracer.start_check_span(
+            key="user:456",
+            limit=50,
+            remaining=0,
+            algorithm="token_bucket",
+            backend="MemoryBackend",
+            allowed=False,
+            shadow=False,
+            cost=1,
+        ):
+            pass
+
+        spans = otel_setup["span_exporter"].get_finished_spans()
+        assert len(spans) == 1
+
+        span = spans[0]
+        assert span.attributes["ratelimit.decision"] == "denied"
+        assert span.status.status_code == StatusCode.ERROR
+
+    def test_shadow_mode_attribute(self, otel_setup):
+        """Test that shadow mode is recorded in span attributes."""
+        from django_smart_ratelimit.observability.otel import RateLimitTracer
+
+        tracer = RateLimitTracer(tracer=otel_setup["tracer_provider"].get_tracer(__name__))
+
+        with tracer.start_check_span(
+            key="user:789",
+            limit=200,
+            remaining=150,
+            algorithm="sliding_window",
+            backend="RedisBackend",
+            allowed=True,
+            shadow=True,
+            cost=1,
+        ):
+            pass
+
+        spans = otel_setup["span_exporter"].get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].attributes["ratelimit.shadow"] is True
+
+    def test_cost_greater_than_one(self, otel_setup):
+        """Test that cost > 1 is recorded in span attributes."""
+        from django_smart_ratelimit.observability.otel import RateLimitTracer
+
+        tracer = RateLimitTracer(tracer=otel_setup["tracer_provider"].get_tracer(__name__))
+
+        with tracer.start_check_span(
+            key="batch:op1",
+            limit=1000,
+            remaining=750,
+            algorithm="token_bucket",
+            backend="RedisBackend",
+            allowed=True,
+            shadow=False,
+            cost=5,
+        ):
+            pass
+
+        spans = otel_setup["span_exporter"].get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].attributes["ratelimit.cost"] == 5
+
+
+class TestRateLimitMeter:
+    """Tests for RateLimitMeter."""
+
+    def test_allowed_request_increments_counter(self, otel_setup):
+        """Test that allowed request increments correct counters."""
+        from django_smart_ratelimit.observability.otel import RateLimitMeter
+
+        meter = RateLimitMeter(meter=otel_setup["meter_provider"].get_meter(__name__))
+
+        meter.record_decision(
+            allowed=True,
+            backend="RedisBackend",
+            algorithm="sliding_window",
+            shadow=False,
+            cost=1,
+            duration_ms=5.0,
+        )
+
+        metrics = otel_setup["metric_reader"].get_metrics_data()
+        assert metrics is not None
+
+    def test_denied_request_metrics(self, otel_setup):
+        """Test that denied request is recorded in metrics."""
+        from django_smart_ratelimit.observability.otel import RateLimitMeter
+
+        meter = RateLimitMeter(meter=otel_setup["meter_provider"].get_meter(__name__))
+
+        meter.record_decision(
+            allowed=False,
+            backend="MemoryBackend",
+            algorithm="fixed_window",
+            shadow=False,
+            cost=1,
+            duration_ms=3.0,
+        )
+
+        metrics = otel_setup["metric_reader"].get_metrics_data()
+        assert metrics is not None
+
+    def test_tokens_consumed_counter(self, otel_setup):
+        """Test that tokens consumed counter sums cost correctly."""
+        from django_smart_ratelimit.observability.otel import RateLimitMeter
+
+        meter = RateLimitMeter(meter=otel_setup["meter_provider"].get_meter(__name__))
+
+        # Record multiple decisions with different costs
+        meter.record_decision(
+            allowed=True,
+            backend="RedisBackend",
+            algorithm="token_bucket",
+            shadow=False,
+            cost=1,
+            duration_ms=2.0,
+        )
+
+        meter.record_decision(
+            allowed=True,
+            backend="RedisBackend",
+            algorithm="token_bucket",
+            shadow=False,
+            cost=3,
+            duration_ms=2.5,
+        )
+
+        meter.record_decision(
+            allowed=False,
+            backend="RedisBackend",
+            algorithm="token_bucket",
+            shadow=False,
+            cost=5,
+            duration_ms=1.5,
+        )
+
+        metrics = otel_setup["metric_reader"].get_metrics_data()
+        assert metrics is not None
+
+    def test_backend_error_recording(self, otel_setup):
+        """Test that backend errors are recorded."""
+        from django_smart_ratelimit.observability.otel import RateLimitMeter
+
+        meter = RateLimitMeter(meter=otel_setup["meter_provider"].get_meter(__name__))
+
+        meter.record_backend_error("connection_timeout")
+        meter.record_backend_error("connection_timeout")
+        meter.record_backend_error("auth_failed")
+
+        metrics = otel_setup["metric_reader"].get_metrics_data()
+        assert metrics is not None
+
+
+class TestRecordCheck:
+    """Tests for record_check function."""
+
+    def test_record_check_with_allowed_request(self, otel_setup):
+        """Test record_check with allowed request."""
+        from django_smart_ratelimit.observability import otel
+
+        # Reset globals to use our setup
+        otel._global_tracer = otel.RateLimitTracer(
+            tracer=otel_setup["tracer_provider"].get_tracer(__name__)
+        )
+        otel._global_meter = otel.RateLimitMeter(
+            meter=otel_setup["meter_provider"].get_meter(__name__)
+        )
+
+        otel.record_check(
+            key="api:key123",
+            limit=500,
+            remaining=250,
+            algorithm="sliding_window",
+            backend="RedisBackend",
+            allowed=True,
+            cost=1,
+            duration_ms=4.2,
+        )
+
+        spans = otel_setup["span_exporter"].get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].attributes["ratelimit.decision"] == "allowed"
+        assert spans[0].attributes["ratelimit.key"] == "api:key123"
+
+    def test_record_check_with_denied_request(self, otel_setup):
+        """Test record_check with denied request."""
+        from django_smart_ratelimit.observability import otel
+
+        # Reset globals to use our setup
+        otel._global_tracer = otel.RateLimitTracer(
+            tracer=otel_setup["tracer_provider"].get_tracer(__name__)
+        )
+        otel._global_meter = otel.RateLimitMeter(
+            meter=otel_setup["meter_provider"].get_meter(__name__)
+        )
+
+        otel.record_check(
+            key="user:blocked",
+            limit=10,
+            remaining=0,
+            algorithm="fixed_window",
+            backend="MemoryBackend",
+            allowed=False,
+            cost=1,
+            duration_ms=1.1,
+        )
+
+        spans = otel_setup["span_exporter"].get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].attributes["ratelimit.decision"] == "denied"
+
+    def test_record_check_shadow_mode(self, otel_setup):
+        """Test record_check with shadow mode."""
+        from django_smart_ratelimit.observability import otel
+
+        # Reset globals to use our setup
+        otel._global_tracer = otel.RateLimitTracer(
+            tracer=otel_setup["tracer_provider"].get_tracer(__name__)
+        )
+        otel._global_meter = otel.RateLimitMeter(
+            meter=otel_setup["meter_provider"].get_meter(__name__)
+        )
+
+        otel.record_check(
+            key="shadow:test",
+            limit=100,
+            remaining=75,
+            algorithm="sliding_window",
+            backend="RedisBackend",
+            allowed=False,  # Would be denied, but shadow mode
+            shadow=True,
+            cost=1,
+            duration_ms=2.0,
+        )
+
+        spans = otel_setup["span_exporter"].get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].attributes["ratelimit.shadow"] is True
+
+
+class TestImportWithoutOtel:
+    """Tests for importing when OpenTelemetry is not available."""
+
+    def test_import_without_otel_doesnt_crash(self):
+        """Test that importing observability module doesn't crash without OTel."""
+        # This test always runs; it verifies that imports are safe
+        from django_smart_ratelimit.observability import (
+            instrument_rate_limit,
+            record_check,
+        )
+
+        # Should not raise
+        assert instrument_rate_limit is not None
+        assert record_check is not None
+
+    def test_record_check_noop_without_otel(self):
+        """Test that record_check is a no-op when OTel not installed."""
+        from django_smart_ratelimit.observability import otel
+
+        # Reset to ensure we use no-op implementations if needed
+        otel._global_tracer = otel.RateLimitTracer()
+        otel._global_meter = otel.RateLimitMeter()
+
+        # Should not raise
+        otel.record_check(
+            key="test",
+            limit=100,
+            remaining=50,
+            algorithm="sliding_window",
+            backend="MemoryBackend",
+            allowed=True,
+            cost=1,
+            duration_ms=1.0,
+        )
+
+    def test_instrument_rate_limit_idempotent(self, otel_setup):
+        """Test that instrument_rate_limit is idempotent."""
+        from django_smart_ratelimit.observability import otel
+
+        # Reset state
+        otel._global_tracer = None
+        otel._global_meter = None
+
+        # Call multiple times - should only initialize once
+        otel.instrument_rate_limit(
+            tracer_provider=otel_setup["tracer_provider"],
+            meter_provider=otel_setup["meter_provider"],
+        )
+
+        first_tracer = otel._global_tracer
+        first_meter = otel._global_meter
+
+        otel.instrument_rate_limit(
+            tracer_provider=otel_setup["tracer_provider"],
+            meter_provider=otel_setup["meter_provider"],
+        )
+
+        # Should be the same instances
+        assert otel._global_tracer is first_tracer
+        assert otel._global_meter is first_meter

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1,0 +1,314 @@
+"""
+Unit tests for django_smart_ratelimit.pipeline module.
+
+Covers the v3 shared evaluation pipeline: resolve_effective_rate,
+apply_policy_lists, and handle_shadow_decision.
+"""
+
+import logging
+import unittest
+from unittest.mock import MagicMock, patch
+
+from django.test import RequestFactory, SimpleTestCase
+
+from django_smart_ratelimit.exceptions import KeyGenerationError
+from django_smart_ratelimit.pipeline import (
+    POLICY_ALLOW,
+    POLICY_CONTINUE,
+    POLICY_DENY,
+    ResolvedLimit,
+    apply_policy_lists,
+    handle_shadow_decision,
+    resolve_effective_rate,
+)
+
+
+class ResolveEffectiveRateTests(SimpleTestCase):
+    """Coverage for resolve_effective_rate — the pipeline entry point."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.request = self.factory.get("/", REMOTE_ADDR="10.0.0.1")
+
+    def test_string_key_and_rate_resolves_cleanly(self):
+        """Simple path: literal key + literal rate should produce a ResolvedLimit."""
+        resolved = resolve_effective_rate(
+            key="user:42",
+            rate="10/m",
+            request=self.request,
+        )
+        self.assertIsInstance(resolved, ResolvedLimit)
+        self.assertEqual(resolved.key, "user:42")
+        self.assertEqual(resolved.limit, 10)
+        self.assertEqual(resolved.period, 60)
+        self.assertEqual(resolved.cost, 1)
+        self.assertEqual(resolved.rate_string, "10/m")
+
+    def test_callable_rate_receives_request(self):
+        """A callable rate should be invoked and its return parsed."""
+        calls = []
+
+        def dynamic_rate(request):
+            calls.append(request)
+            return "50/h"
+
+        resolved = resolve_effective_rate(
+            key="k",
+            rate=dynamic_rate,
+            request=self.request,
+        )
+        self.assertEqual(resolved.limit, 50)
+        self.assertEqual(resolved.period, 3600)
+        self.assertEqual(len(calls), 1)
+
+    def test_callable_rate_django_ratelimit_compat(self):
+        """Callables with (self, request) signature should work too."""
+
+        def compat_rate(_self, request):  # django-ratelimit style
+            return "7/s"
+
+        resolved = resolve_effective_rate(
+            key="k", rate=compat_rate, request=self.request
+        )
+        self.assertEqual(resolved.limit, 7)
+        self.assertEqual(resolved.period, 1)
+
+    def test_callable_rate_zero_args(self):
+        """Callables with no args should also be accepted."""
+        resolved = resolve_effective_rate(
+            key="k", rate=lambda: "3/m", request=self.request
+        )
+        self.assertEqual(resolved.limit, 3)
+
+    def test_invalid_rate_type_raises(self):
+        """Non-str non-callable rates should raise TypeError."""
+        with self.assertRaises(TypeError):
+            resolve_effective_rate(
+                key="k", rate=12345, request=self.request  # type: ignore[arg-type]
+            )
+
+    def test_empty_key_raises_key_generation_error(self):
+        """Empty keys are a footgun — must raise instead of silently collapsing."""
+
+        def bad_key(_request):
+            return ""
+
+        with self.assertRaises(KeyGenerationError):
+            resolve_effective_rate(
+                key=bad_key,
+                rate="10/m",
+                request=self.request,
+            )
+
+    def test_none_key_raises_key_generation_error(self):
+        """None keys should also raise."""
+
+        def bad_key(_request):
+            return None
+
+        with self.assertRaises(KeyGenerationError):
+            resolve_effective_rate(
+                key=bad_key,
+                rate="10/m",
+                request=self.request,
+            )
+
+    def test_empty_key_passes_when_validate_disabled(self):
+        """validate_key=False preserves the old silent behavior for edge callers."""
+        resolved = resolve_effective_rate(
+            key=lambda _r: "",
+            rate="10/m",
+            request=self.request,
+            validate_key=False,
+        )
+        self.assertEqual(resolved.key, "")
+
+    def test_cost_int_is_applied(self):
+        resolved = resolve_effective_rate(
+            key="k", rate="10/m", request=self.request, cost=3
+        )
+        self.assertEqual(resolved.cost, 3)
+
+    def test_cost_callable_is_applied(self):
+        resolved = resolve_effective_rate(
+            key="k",
+            rate="10/m",
+            request=self.request,
+            cost=lambda _r: 5,
+        )
+        self.assertEqual(resolved.cost, 5)
+
+    def test_cost_is_clamped_to_minimum_one(self):
+        """cost=0 would let callers bypass limits; must clamp to 1."""
+        resolved = resolve_effective_rate(
+            key="k", rate="10/m", request=self.request, cost=0
+        )
+        self.assertEqual(resolved.cost, 1)
+
+        resolved = resolve_effective_rate(
+            key="k", rate="10/m", request=self.request, cost=-5
+        )
+        self.assertEqual(resolved.cost, 1)
+
+    def test_cost_callable_exception_falls_back_to_one(self):
+        """A misbehaving cost callable should not break the limiter."""
+
+        def raises(_r):
+            raise RuntimeError("boom")
+
+        resolved = resolve_effective_rate(
+            key="k", rate="10/m", request=self.request, cost=raises
+        )
+        self.assertEqual(resolved.cost, 1)
+
+    def test_cost_callable_non_int_falls_back_to_one(self):
+        resolved = resolve_effective_rate(
+            key="k", rate="10/m", request=self.request, cost=lambda _r: "not-int"
+        )
+        self.assertEqual(resolved.cost, 1)
+
+    def test_adaptive_limiter_string_applied(self):
+        """String adaptive names are resolved via registry."""
+        fake = MagicMock()
+        fake.get_effective_limit.return_value = 42
+        # get_adaptive_limiter is imported lazily inside pipeline; patch at
+        # its source module.
+        with patch(
+            "django_smart_ratelimit.adaptive.get_adaptive_limiter",
+            return_value=fake,
+        ):
+            resolved = resolve_effective_rate(
+                key="k",
+                rate="100/m",
+                request=self.request,
+                adaptive="my_limiter",
+            )
+        self.assertEqual(resolved.limit, 42)
+
+    def test_adaptive_missing_registry_entry_uses_base(self):
+        with patch(
+            "django_smart_ratelimit.adaptive.get_adaptive_limiter",
+            return_value=None,
+        ):
+            resolved = resolve_effective_rate(
+                key="k",
+                rate="100/m",
+                request=self.request,
+                adaptive="missing",
+            )
+        self.assertEqual(resolved.limit, 100)
+
+
+class ApplyPolicyListsTests(SimpleTestCase):
+    """Coverage for apply_policy_lists — the allow/deny pre-check."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_neither_list_returns_continue(self):
+        request = self.factory.get("/", REMOTE_ADDR="10.0.0.1")
+        self.assertEqual(apply_policy_lists(request), POLICY_CONTINUE)
+
+    def test_allow_list_hit_returns_allow(self):
+        request = self.factory.get("/", REMOTE_ADDR="10.0.0.5")
+        result = apply_policy_lists(request, allow_list=["10.0.0.0/8"])
+        self.assertEqual(result, POLICY_ALLOW)
+
+    def test_deny_list_hit_returns_deny(self):
+        request = self.factory.get("/", REMOTE_ADDR="1.2.3.4")
+        result = apply_policy_lists(request, deny_list=["1.2.3.0/24"])
+        self.assertEqual(result, POLICY_DENY)
+
+    def test_deny_wins_over_allow(self):
+        """Deny is the explicit block — always wins over allow-list membership."""
+        request = self.factory.get("/", REMOTE_ADDR="10.0.0.5")
+        result = apply_policy_lists(
+            request,
+            allow_list=["10.0.0.0/8"],
+            deny_list=["10.0.0.5"],
+        )
+        self.assertEqual(result, POLICY_DENY)
+
+    def test_no_list_hit_returns_continue(self):
+        request = self.factory.get("/", REMOTE_ADDR="192.168.1.1")
+        result = apply_policy_lists(
+            request,
+            allow_list=["10.0.0.0/8"],
+            deny_list=["1.2.3.0/24"],
+        )
+        self.assertEqual(result, POLICY_CONTINUE)
+
+    def test_malformed_allow_list_is_skipped(self):
+        """A bad allow-list shouldn't take down rate limiting."""
+        request = self.factory.get("/", REMOTE_ADDR="10.0.0.5")
+        # An invalid CIDR inside parse_ip_list will raise; we expect the
+        # function to log and continue.
+        result = apply_policy_lists(request, allow_list=["not-a-cidr!!!"])
+        self.assertEqual(result, POLICY_CONTINUE)
+
+
+class HandleShadowDecisionTests(SimpleTestCase):
+    """Coverage for handle_shadow_decision."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.request = self.factory.get("/some/path")
+
+    def _call(self, **overrides):
+        defaults = dict(
+            allowed=False,
+            shadow=False,
+            request=self.request,
+            key="test:key",
+            limit=10,
+            remaining=0,
+            algorithm="sliding_window",
+            backend="MemoryBackend",
+        )
+        defaults.update(overrides)
+        return handle_shadow_decision(**defaults)
+
+    def test_allowed_passes_through(self):
+        decision = self._call(allowed=True)
+        self.assertTrue(decision.allow)
+        self.assertFalse(decision.shadowed)
+
+    def test_block_without_shadow(self):
+        decision = self._call(allowed=False, shadow=False)
+        self.assertFalse(decision.allow)
+        self.assertFalse(decision.shadowed)
+
+    def test_block_with_shadow_becomes_allow(self):
+        """shadow=True converts a block into an allow with logging."""
+        with self.assertLogs(
+            "django_smart_ratelimit.pipeline", level=logging.INFO
+        ) as log:
+            decision = self._call(allowed=False, shadow=True)
+        self.assertTrue(decision.allow)
+        self.assertTrue(decision.shadowed)
+        self.assertTrue(
+            any("SHADOW_RATE_LIMIT_BLOCK" in m for m in log.output),
+            f"Expected shadow log line; got {log.output!r}",
+        )
+
+    def test_observability_always_called(self):
+        """record_check must be invoked on every call (allowed or blocked)."""
+        with patch("django_smart_ratelimit.pipeline.record_check") as rec:
+            self._call(allowed=True)
+            self._call(allowed=False, shadow=False)
+            self._call(allowed=False, shadow=True)
+        self.assertEqual(rec.call_count, 3)
+
+    def test_observability_failure_is_swallowed(self):
+        """record_check blowing up must never break the limiter."""
+        with patch(
+            "django_smart_ratelimit.pipeline.record_check",
+            side_effect=RuntimeError("telemetry down"),
+        ):
+            # Should not raise.
+            decision = self._call(allowed=False, shadow=False)
+        self.assertFalse(decision.allow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_policy_lists.py
+++ b/tests/unit/test_policy_lists.py
@@ -7,21 +7,18 @@ Tests cover IPList, FileBackedIPList, URLBackedIPList, and helper functions.
 import tempfile
 import threading
 import time
-import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-from django.http import HttpRequest
 from django.test import RequestFactory, SimpleTestCase
 
 from django_smart_ratelimit.policy.lists import (
-    IPList,
     FileBackedIPList,
+    IPList,
     URLBackedIPList,
-    parse_ip_list,
-    extract_client_ip,
     check_lists,
+    extract_client_ip,
+    parse_ip_list,
 )
 
 
@@ -78,9 +75,7 @@ class IPListTests(SimpleTestCase):
 
     def test_iplist_mixed_ipv4_ipv6(self):
         """Test IPList with mixed IPv4 and IPv6 ranges."""
-        ip_list = IPList(
-            ["10.0.0.0/8", "192.168.0.0/16", "2001:db8::/32", "fc00::/7"]
-        )
+        ip_list = IPList(["10.0.0.0/8", "192.168.0.0/16", "2001:db8::/32", "fc00::/7"])
         # IPv4 checks
         self.assertTrue(ip_list.contains("10.0.0.1"))
         self.assertTrue(ip_list.contains("192.168.1.1"))
@@ -353,7 +348,9 @@ class URLBackedIPListTests(SimpleTestCase):
     def test_url_backed_iplist_ignores_comments(self, mock_urlopen):
         """Test that URLBackedIPList ignores comments and blank lines."""
         mock_response = MagicMock()
-        mock_response.read.return_value = b"# Comment\n\n10.0.0.0/8\n# Another\n192.168.0.0/16\n\n"
+        mock_response.read.return_value = (
+            b"# Comment\n\n10.0.0.0/8\n# Another\n192.168.0.0/16\n\n"
+        )
         mock_response.__enter__ = MagicMock(return_value=mock_response)
         mock_response.__exit__ = MagicMock(return_value=None)
         mock_urlopen.return_value = mock_response
@@ -390,9 +387,7 @@ class URLBackedIPListTests(SimpleTestCase):
         mock_response.__exit__ = MagicMock(return_value=None)
         mock_urlopen.return_value = mock_response
 
-        ip_list = URLBackedIPList(
-            "https://example.com/ips.txt", refresh_interval=1
-        )
+        ip_list = URLBackedIPList("https://example.com/ips.txt", refresh_interval=1)
         self.assertTrue(ip_list.contains("10.0.0.1"))
         call_count_1 = mock_urlopen.call_count
 
@@ -629,7 +624,9 @@ class CheckListsTests(SimpleTestCase):
         request.META["REMOTE_ADDR"] = "10.0.0.1"
         allow_list = IPList(["10.0.0.0/8"])
         deny_list = IPList(["10.0.0.0/16"])
-        should_skip, reason = check_lists(request, allow_list=allow_list, deny_list=deny_list)
+        should_skip, reason = check_lists(
+            request, allow_list=allow_list, deny_list=deny_list
+        )
         self.assertFalse(should_skip)
         self.assertEqual(reason, "deny_list")
 
@@ -639,7 +636,9 @@ class CheckListsTests(SimpleTestCase):
         request.META["REMOTE_ADDR"] = "8.8.8.8"
         allow_list = IPList(["10.0.0.0/8"])
         deny_list = IPList(["203.0.113.0/24"])
-        should_skip, reason = check_lists(request, allow_list=allow_list, deny_list=deny_list)
+        should_skip, reason = check_lists(
+            request, allow_list=allow_list, deny_list=deny_list
+        )
         self.assertFalse(should_skip)
         self.assertEqual(reason, "")
 

--- a/tests/unit/test_policy_lists.py
+++ b/tests/unit/test_policy_lists.py
@@ -1,0 +1,672 @@
+"""
+Unit tests for django_smart_ratelimit.policy.lists module.
+
+Tests cover IPList, FileBackedIPList, URLBackedIPList, and helper functions.
+"""
+
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.http import HttpRequest
+from django.test import RequestFactory, SimpleTestCase
+
+from django_smart_ratelimit.policy.lists import (
+    IPList,
+    FileBackedIPList,
+    URLBackedIPList,
+    parse_ip_list,
+    extract_client_ip,
+    check_lists,
+)
+
+
+class IPListTests(SimpleTestCase):
+    """Test cases for IPList class."""
+
+    def test_iplist_ipv4_single_ip(self):
+        """Test IPList with single IPv4 address."""
+        ip_list = IPList(["192.168.1.100"])
+        self.assertTrue(ip_list.contains("192.168.1.100"))
+        self.assertFalse(ip_list.contains("192.168.1.101"))
+        self.assertFalse(ip_list.contains("10.0.0.1"))
+
+    def test_iplist_ipv4_cidr(self):
+        """Test IPList with IPv4 CIDR ranges."""
+        ip_list = IPList(["10.0.0.0/8", "192.168.0.0/16"])
+        # Test first range
+        self.assertTrue(ip_list.contains("10.0.0.1"))
+        self.assertTrue(ip_list.contains("10.255.255.255"))
+        # Test second range
+        self.assertTrue(ip_list.contains("192.168.0.0"))
+        self.assertTrue(ip_list.contains("192.168.255.255"))
+        # Test out of range
+        self.assertFalse(ip_list.contains("11.0.0.0"))
+        self.assertFalse(ip_list.contains("193.0.0.0"))
+
+    def test_iplist_ipv4_subnet_mask(self):
+        """Test IPList with various IPv4 subnet masks."""
+        ip_list = IPList(["192.168.1.0/24"])
+        self.assertTrue(ip_list.contains("192.168.1.0"))
+        self.assertTrue(ip_list.contains("192.168.1.1"))
+        self.assertTrue(ip_list.contains("192.168.1.254"))
+        self.assertTrue(ip_list.contains("192.168.1.255"))
+        self.assertFalse(ip_list.contains("192.168.0.255"))
+        self.assertFalse(ip_list.contains("192.168.2.0"))
+
+    def test_iplist_ipv6_single_ip(self):
+        """Test IPList with single IPv6 address."""
+        ip_list = IPList(["2001:db8::1"])
+        self.assertTrue(ip_list.contains("2001:db8::1"))
+        self.assertFalse(ip_list.contains("2001:db8::2"))
+
+    def test_iplist_ipv6_cidr(self):
+        """Test IPList with IPv6 CIDR ranges."""
+        ip_list = IPList(["2001:db8::/32", "fc00::/7"])
+        # Test first range
+        self.assertTrue(ip_list.contains("2001:db8::1"))
+        self.assertTrue(ip_list.contains("2001:db8:ffff:ffff:ffff:ffff:ffff:ffff"))
+        # Test second range (ULA)
+        self.assertTrue(ip_list.contains("fc00::1"))
+        self.assertTrue(ip_list.contains("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"))
+        # Out of range
+        self.assertFalse(ip_list.contains("2001:db9::1"))
+
+    def test_iplist_mixed_ipv4_ipv6(self):
+        """Test IPList with mixed IPv4 and IPv6 ranges."""
+        ip_list = IPList(
+            ["10.0.0.0/8", "192.168.0.0/16", "2001:db8::/32", "fc00::/7"]
+        )
+        # IPv4 checks
+        self.assertTrue(ip_list.contains("10.0.0.1"))
+        self.assertTrue(ip_list.contains("192.168.1.1"))
+        # IPv6 checks
+        self.assertTrue(ip_list.contains("2001:db8::1"))
+        self.assertTrue(ip_list.contains("fc00::1"))
+        # Out of range
+        self.assertFalse(ip_list.contains("8.8.8.8"))
+        self.assertFalse(ip_list.contains("2001:4860:4860::8888"))
+
+    def test_iplist_single_ip_promotion_ipv4(self):
+        """Test that single IPv4 addresses are promoted to /32."""
+        ip_list = IPList(["203.0.113.42"])
+        self.assertTrue(ip_list.contains("203.0.113.42"))
+        self.assertFalse(ip_list.contains("203.0.113.41"))
+        self.assertFalse(ip_list.contains("203.0.113.43"))
+
+    def test_iplist_single_ip_promotion_ipv6(self):
+        """Test that single IPv6 addresses are promoted to /128."""
+        ip_list = IPList(["2001:db8::42"])
+        self.assertTrue(ip_list.contains("2001:db8::42"))
+        self.assertFalse(ip_list.contains("2001:db8::41"))
+        self.assertFalse(ip_list.contains("2001:db8::43"))
+
+    def test_iplist_invalid_cidr_raises_valueerror(self):
+        """Test that invalid CIDR notation raises ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            IPList(["invalid-cidr"])
+        self.assertIn("Invalid", str(cm.exception))
+
+    def test_iplist_invalid_ip_address_raises_valueerror(self):
+        """Test that invalid IP address raises ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            IPList(["999.999.999.999"])
+        self.assertIn("Invalid", str(cm.exception))
+
+    def test_iplist_invalid_cidr_format_raises_valueerror(self):
+        """Test that invalid CIDR format raises ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            IPList(["10.0.0.0/33"])  # Max is /32 for IPv4
+        self.assertIn("Invalid", str(cm.exception))
+
+    def test_iplist_contains_invalid_ip(self):
+        """Test contains() with invalid IP returns False."""
+        ip_list = IPList(["10.0.0.0/8"])
+        self.assertFalse(ip_list.contains("invalid"))
+        self.assertFalse(ip_list.contains("999.999.999.999"))
+        self.assertFalse(ip_list.contains(""))
+
+    def test_iplist_empty_list(self):
+        """Test IPList with empty CIDR list."""
+        ip_list = IPList([])
+        self.assertFalse(ip_list.contains("10.0.0.1"))
+        self.assertFalse(ip_list.contains("192.168.1.1"))
+
+
+class FileBackedIPListTests(SimpleTestCase):
+    """Test cases for FileBackedIPList class."""
+
+    def test_file_backed_iplist_reads_file(self):
+        """Test that FileBackedIPList reads from file correctly."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as f:
+            f.write("10.0.0.0/8\n")
+            f.write("192.168.0.0/16\n")
+            f.write("203.0.113.42\n")
+            f.flush()
+            path = f.name
+
+        try:
+            ip_list = FileBackedIPList(path)
+            self.assertTrue(ip_list.contains("10.0.0.1"))
+            self.assertTrue(ip_list.contains("192.168.1.1"))
+            self.assertTrue(ip_list.contains("203.0.113.42"))
+            self.assertFalse(ip_list.contains("8.8.8.8"))
+        finally:
+            Path(path).unlink()
+
+    def test_file_backed_iplist_ignores_comments(self):
+        """Test that FileBackedIPList ignores comments and blank lines."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as f:
+            f.write("# This is a comment\n")
+            f.write("\n")
+            f.write("10.0.0.0/8\n")
+            f.write("# Another comment\n")
+            f.write("192.168.0.0/16\n")
+            f.write("\n")
+            f.flush()
+            path = f.name
+
+        try:
+            ip_list = FileBackedIPList(path)
+            self.assertTrue(ip_list.contains("10.0.0.1"))
+            self.assertTrue(ip_list.contains("192.168.1.1"))
+        finally:
+            Path(path).unlink()
+
+    def test_file_backed_iplist_strips_whitespace(self):
+        """Test that FileBackedIPList strips whitespace from lines."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as f:
+            f.write("  10.0.0.0/8  \n")
+            f.write("   192.168.0.0/16   \n")
+            f.flush()
+            path = f.name
+
+        try:
+            ip_list = FileBackedIPList(path)
+            self.assertTrue(ip_list.contains("10.0.0.1"))
+            self.assertTrue(ip_list.contains("192.168.1.1"))
+        finally:
+            Path(path).unlink()
+
+    def test_file_backed_iplist_nonexistent_file_at_init_logs_warning(self):
+        """Test that FileBackedIPList handles missing file gracefully with logging."""
+        # FileBackedIPList is resilient - it logs warning but initializes with empty list
+        # _read_file() raises FileNotFoundError which is caught by force_refresh()
+        path = "/tmp/nonexistent_" + str(time.time()) + ".txt"
+        ip_list = FileBackedIPList(path)
+        # Should have empty network list since file didn't exist
+        self.assertEqual(len(ip_list.networks), 0)
+        self.assertFalse(ip_list.contains("10.0.0.1"))
+
+    def test_file_backed_iplist_invalid_cidr_logs_error(self):
+        """Test that FileBackedIPList logs error on invalid CIDR during force_refresh."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as f:
+            f.write("10.0.0.0/8\n")
+            f.flush()
+            path = f.name
+
+        try:
+            ip_list = FileBackedIPList(path)
+            # Now update file with invalid CIDR
+            with open(path, "w") as f:
+                f.write("invalid-cidr\n")
+
+            # force_refresh should log error but keep old list
+            ip_list.force_refresh()
+            # Old list should still be available
+            self.assertTrue(ip_list.contains("10.0.0.1"))
+        finally:
+            Path(path).unlink()
+
+    def test_file_backed_iplist_force_refresh(self):
+        """Test force_refresh() reloads from file."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as f:
+            f.write("10.0.0.0/8\n")
+            f.flush()
+            path = f.name
+
+        try:
+            ip_list = FileBackedIPList(path)
+            self.assertTrue(ip_list.contains("10.0.0.1"))
+
+            # Update file
+            with open(path, "w") as f:
+                f.write("192.168.0.0/16\n")
+
+            # Before refresh, old list still in memory
+            self.assertTrue(ip_list.contains("10.0.0.1"))
+
+            # Force refresh
+            ip_list.force_refresh()
+
+            # Now new list is loaded
+            self.assertFalse(ip_list.contains("10.0.0.1"))
+            self.assertTrue(ip_list.contains("192.168.1.1"))
+        finally:
+            Path(path).unlink()
+
+    def test_file_backed_iplist_refresh_interval(self):
+        """Test that refresh happens after interval expires."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as f:
+            f.write("10.0.0.0/8\n")
+            f.flush()
+            path = f.name
+
+        try:
+            # Use very short refresh interval
+            ip_list = FileBackedIPList(path, refresh_interval=1)
+            self.assertTrue(ip_list.contains("10.0.0.1"))
+
+            # Update file
+            with open(path, "w") as f:
+                f.write("192.168.0.0/16\n")
+
+            # Wait for refresh interval
+            time.sleep(1.1)
+
+            # Next contains() call should trigger refresh
+            self.assertFalse(ip_list.contains("10.0.0.1"))
+            self.assertTrue(ip_list.contains("192.168.1.1"))
+        finally:
+            Path(path).unlink()
+
+    def test_file_backed_iplist_missing_file_keeps_last_list(self):
+        """Test that missing file after init keeps last loaded list."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as f:
+            f.write("10.0.0.0/8\n")
+            f.flush()
+            path = f.name
+
+        try:
+            ip_list = FileBackedIPList(path, refresh_interval=1)
+            self.assertTrue(ip_list.contains("10.0.0.1"))
+
+            # Delete file
+            Path(path).unlink()
+
+            # Wait for refresh interval
+            time.sleep(1.1)
+
+            # Next contains() call should attempt refresh but keep old list
+            self.assertTrue(ip_list.contains("10.0.0.1"))
+        except FileNotFoundError:
+            # This is expected in the constructor
+            pass
+
+    def test_file_backed_iplist_thread_safe(self):
+        """Test that FileBackedIPList is thread-safe."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as f:
+            f.write("10.0.0.0/8\n")
+            f.flush()
+            path = f.name
+
+        try:
+            ip_list = FileBackedIPList(path, refresh_interval=1)
+            results = []
+
+            def check_ip():
+                for _ in range(100):
+                    results.append(ip_list.contains("10.0.0.1"))
+
+            threads = [threading.Thread(target=check_ip) for _ in range(5)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            # All checks should have succeeded
+            self.assertEqual(len(results), 500)
+            self.assertTrue(all(results))
+        finally:
+            Path(path).unlink()
+
+
+class URLBackedIPListTests(SimpleTestCase):
+    """Test cases for URLBackedIPList class."""
+
+    def test_url_backed_iplist_invalid_url_raises_error(self):
+        """Test that URLBackedIPList raises error for invalid URL."""
+        with self.assertRaises(ValueError) as cm:
+            URLBackedIPList("ftp://example.com/ips.txt")
+        self.assertIn("http", str(cm.exception).lower())
+
+    @patch("urllib.request.urlopen")
+    def test_url_backed_iplist_fetches_from_url(self, mock_urlopen):
+        """Test that URLBackedIPList fetches and parses from URL."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"10.0.0.0/8\n192.168.0.0/16\n203.0.113.42\n"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+        mock_urlopen.return_value = mock_response
+
+        ip_list = URLBackedIPList("https://example.com/ips.txt")
+        self.assertTrue(ip_list.contains("10.0.0.1"))
+        self.assertTrue(ip_list.contains("192.168.1.1"))
+        self.assertTrue(ip_list.contains("203.0.113.42"))
+        self.assertFalse(ip_list.contains("8.8.8.8"))
+
+    @patch("urllib.request.urlopen")
+    def test_url_backed_iplist_ignores_comments(self, mock_urlopen):
+        """Test that URLBackedIPList ignores comments and blank lines."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"# Comment\n\n10.0.0.0/8\n# Another\n192.168.0.0/16\n\n"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+        mock_urlopen.return_value = mock_response
+
+        ip_list = URLBackedIPList("https://example.com/ips.txt")
+        self.assertTrue(ip_list.contains("10.0.0.1"))
+        self.assertTrue(ip_list.contains("192.168.1.1"))
+
+    @patch("urllib.request.urlopen")
+    def test_url_backed_iplist_http_error_keeps_old_list(self, mock_urlopen):
+        """Test that HTTP error keeps old list."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"10.0.0.0/8\n"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+        mock_urlopen.return_value = mock_response
+
+        ip_list = URLBackedIPList("https://example.com/ips.txt")
+        self.assertTrue(ip_list.contains("10.0.0.1"))
+
+        # Now simulate HTTP error
+        mock_urlopen.side_effect = Exception("Connection failed")
+
+        # Force refresh should fail but keep old list
+        ip_list.force_refresh()
+        self.assertTrue(ip_list.contains("10.0.0.1"))
+
+    @patch("urllib.request.urlopen")
+    def test_url_backed_iplist_refresh_interval(self, mock_urlopen):
+        """Test that refresh happens after interval expires."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"10.0.0.0/8\n"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+        mock_urlopen.return_value = mock_response
+
+        ip_list = URLBackedIPList(
+            "https://example.com/ips.txt", refresh_interval=1
+        )
+        self.assertTrue(ip_list.contains("10.0.0.1"))
+        call_count_1 = mock_urlopen.call_count
+
+        # Update mock response
+        mock_response.read.return_value = b"192.168.0.0/16\n"
+
+        # Check within interval - should not call fetch again
+        self.assertTrue(ip_list.contains("10.0.0.1"))
+        self.assertEqual(mock_urlopen.call_count, call_count_1)
+
+        # Wait for interval
+        time.sleep(1.1)
+
+        # Next check should trigger fetch
+        self.assertTrue(ip_list.contains("192.168.1.1"))
+        self.assertGreater(mock_urlopen.call_count, call_count_1)
+
+    @patch("urllib.request.urlopen")
+    def test_url_backed_iplist_thread_safe(self, mock_urlopen):
+        """Test that URLBackedIPList is thread-safe."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"10.0.0.0/8\n"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+        mock_urlopen.return_value = mock_response
+
+        ip_list = URLBackedIPList("https://example.com/ips.txt")
+        results = []
+
+        def check_ip():
+            for _ in range(100):
+                results.append(ip_list.contains("10.0.0.1"))
+
+        threads = [threading.Thread(target=check_ip) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # All checks should have succeeded
+        self.assertEqual(len(results), 500)
+        self.assertTrue(all(results))
+
+
+class ParseIPListTests(SimpleTestCase):
+    """Test cases for parse_ip_list helper function."""
+
+    def test_parse_iplist_none_returns_none(self):
+        """Test parse_ip_list(None) returns None."""
+        result = parse_ip_list(None)
+        self.assertIsNone(result)
+
+    def test_parse_iplist_iplist_instance_returns_as_is(self):
+        """Test parse_ip_list with IPList returns same instance."""
+        ip_list = IPList(["10.0.0.0/8"])
+        result = parse_ip_list(ip_list)
+        self.assertIs(result, ip_list)
+
+    def test_parse_iplist_list_returns_iplist(self):
+        """Test parse_ip_list with list returns IPList."""
+        cidrs = ["10.0.0.0/8", "192.168.0.0/16"]
+        result = parse_ip_list(cidrs)
+        self.assertIsInstance(result, IPList)
+        self.assertTrue(result.contains("10.0.0.1"))
+
+    def test_parse_iplist_file_url_returns_filebacked(self):
+        """Test parse_ip_list with file:// URL returns FileBackedIPList."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as f:
+            f.write("10.0.0.0/8\n")
+            f.flush()
+            path = f.name
+
+        try:
+            result = parse_ip_list(f"file://{path}")
+            self.assertIsInstance(result, FileBackedIPList)
+            self.assertTrue(result.contains("10.0.0.1"))
+        finally:
+            Path(path).unlink()
+
+    def test_parse_iplist_file_path_returns_filebacked(self):
+        """Test parse_ip_list with file path returns FileBackedIPList."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as f:
+            f.write("10.0.0.0/8\n")
+            f.flush()
+            path = f.name
+
+        try:
+            result = parse_ip_list(path)
+            self.assertIsInstance(result, FileBackedIPList)
+            self.assertTrue(result.contains("10.0.0.1"))
+        finally:
+            Path(path).unlink()
+
+    @patch("urllib.request.urlopen")
+    def test_parse_iplist_http_url_returns_urlbacked(self, mock_urlopen):
+        """Test parse_ip_list with http URL returns URLBackedIPList."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"10.0.0.0/8\n"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+        mock_urlopen.return_value = mock_response
+
+        result = parse_ip_list("https://example.com/ips.txt")
+        self.assertIsInstance(result, URLBackedIPList)
+
+    @patch("urllib.request.urlopen")
+    def test_parse_iplist_http_url_returns_urlbacked_http(self, mock_urlopen):
+        """Test parse_ip_list with http URL returns URLBackedIPList."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"10.0.0.0/8\n"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+        mock_urlopen.return_value = mock_response
+
+        result = parse_ip_list("http://example.com/ips.txt")
+        self.assertIsInstance(result, URLBackedIPList)
+
+    def test_parse_iplist_single_cidr_returns_iplist(self):
+        """Test parse_ip_list with single CIDR returns IPList."""
+        result = parse_ip_list("10.0.0.0/8")
+        self.assertIsInstance(result, IPList)
+        self.assertTrue(result.contains("10.0.0.1"))
+
+    def test_parse_iplist_single_ip_returns_iplist(self):
+        """Test parse_ip_list with single IP returns IPList."""
+        result = parse_ip_list("203.0.113.42")
+        self.assertIsInstance(result, IPList)
+        self.assertTrue(result.contains("203.0.113.42"))
+
+
+class ExtractClientIPTests(SimpleTestCase):
+    """Test cases for extract_client_ip function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.factory = RequestFactory()
+
+    def test_extract_client_ip_remote_addr(self):
+        """Test extract_client_ip with REMOTE_ADDR."""
+        request = self.factory.get("/")
+        request.META["REMOTE_ADDR"] = "192.168.1.100"
+        ip = extract_client_ip(request)
+        self.assertEqual(ip, "192.168.1.100")
+
+    def test_extract_client_ip_x_forwarded_for(self):
+        """Test extract_client_ip respects X-Forwarded-For."""
+        request = self.factory.get("/")
+        request.META["HTTP_X_FORWARDED_FOR"] = "203.0.113.42"
+        ip = extract_client_ip(request)
+        self.assertEqual(ip, "203.0.113.42")
+
+    def test_extract_client_ip_x_forwarded_for_comma_separated(self):
+        """Test extract_client_ip handles comma-separated X-Forwarded-For."""
+        request = self.factory.get("/")
+        request.META["HTTP_X_FORWARDED_FOR"] = "203.0.113.42, 10.0.0.1, 192.168.1.1"
+        ip = extract_client_ip(request)
+        # Should use first IP
+        self.assertEqual(ip, "203.0.113.42")
+
+    def test_extract_client_ip_x_real_ip(self):
+        """Test extract_client_ip respects X-Real-IP."""
+        request = self.factory.get("/")
+        request.META["HTTP_X_REAL_IP"] = "203.0.113.42"
+        ip = extract_client_ip(request)
+        self.assertEqual(ip, "203.0.113.42")
+
+    def test_extract_client_ip_cloudflare(self):
+        """Test extract_client_ip respects Cloudflare IP header."""
+        request = self.factory.get("/")
+        request.META["HTTP_CF_CONNECTING_IP"] = "203.0.113.42"
+        ip = extract_client_ip(request)
+        self.assertEqual(ip, "203.0.113.42")
+
+    def test_extract_client_ip_cloudflare_takes_precedence(self):
+        """Test extract_client_ip prefers Cloudflare over other headers."""
+        request = self.factory.get("/")
+        request.META["HTTP_CF_CONNECTING_IP"] = "203.0.113.42"
+        request.META["HTTP_X_FORWARDED_FOR"] = "203.0.113.43"
+        request.META["HTTP_X_REAL_IP"] = "203.0.113.44"
+        ip = extract_client_ip(request)
+        self.assertEqual(ip, "203.0.113.42")
+
+    def test_extract_client_ip_whitespace_stripped(self):
+        """Test extract_client_ip strips whitespace."""
+        request = self.factory.get("/")
+        request.META["HTTP_X_FORWARDED_FOR"] = "  203.0.113.42  "
+        ip = extract_client_ip(request)
+        self.assertEqual(ip, "203.0.113.42")
+
+    def test_extract_client_ip_unknown_default(self):
+        """Test extract_client_ip returns unknown when no IP found."""
+        request = self.factory.get("/")
+        request.META = {}
+        ip = extract_client_ip(request)
+        self.assertEqual(ip, "unknown")
+
+
+class CheckListsTests(SimpleTestCase):
+    """Test cases for check_lists function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.factory = RequestFactory()
+
+    def test_check_lists_no_lists_returns_false_empty_reason(self):
+        """Test check_lists with no lists returns (False, '')."""
+        request = self.factory.get("/")
+        request.META["REMOTE_ADDR"] = "192.168.1.100"
+        should_skip, reason = check_lists(request)
+        self.assertFalse(should_skip)
+        self.assertEqual(reason, "")
+
+    def test_check_lists_allow_list_skip(self):
+        """Test check_lists skips rate limiting for IPs in allow list."""
+        request = self.factory.get("/")
+        request.META["REMOTE_ADDR"] = "10.0.0.1"
+        allow_list = IPList(["10.0.0.0/8"])
+        should_skip, reason = check_lists(request, allow_list=allow_list)
+        self.assertTrue(should_skip)
+        self.assertEqual(reason, "allow_list")
+
+    def test_check_lists_deny_list_block(self):
+        """Test check_lists blocks for IPs in deny list."""
+        request = self.factory.get("/")
+        request.META["REMOTE_ADDR"] = "203.0.113.42"
+        deny_list = IPList(["203.0.113.0/24"])
+        should_skip, reason = check_lists(request, deny_list=deny_list)
+        self.assertFalse(should_skip)
+        self.assertEqual(reason, "deny_list")
+
+    def test_check_lists_deny_precedence_over_allow(self):
+        """Test check_lists deny list takes precedence over allow list."""
+        request = self.factory.get("/")
+        request.META["REMOTE_ADDR"] = "10.0.0.1"
+        allow_list = IPList(["10.0.0.0/8"])
+        deny_list = IPList(["10.0.0.0/16"])
+        should_skip, reason = check_lists(request, allow_list=allow_list, deny_list=deny_list)
+        self.assertFalse(should_skip)
+        self.assertEqual(reason, "deny_list")
+
+    def test_check_lists_neither_list_normal_limiting(self):
+        """Test check_lists returns (False, '') when IP not in either list."""
+        request = self.factory.get("/")
+        request.META["REMOTE_ADDR"] = "8.8.8.8"
+        allow_list = IPList(["10.0.0.0/8"])
+        deny_list = IPList(["203.0.113.0/24"])
+        should_skip, reason = check_lists(request, allow_list=allow_list, deny_list=deny_list)
+        self.assertFalse(should_skip)
+        self.assertEqual(reason, "")
+
+    def test_check_lists_only_allow_list(self):
+        """Test check_lists with only allow list."""
+        request = self.factory.get("/")
+        request.META["REMOTE_ADDR"] = "10.0.0.1"
+        allow_list = IPList(["10.0.0.0/8"])
+        should_skip, reason = check_lists(request, allow_list=allow_list)
+        self.assertTrue(should_skip)
+        self.assertEqual(reason, "allow_list")
+
+    def test_check_lists_only_deny_list(self):
+        """Test check_lists with only deny list."""
+        request = self.factory.get("/")
+        request.META["REMOTE_ADDR"] = "203.0.113.42"
+        deny_list = IPList(["203.0.113.0/24"])
+        should_skip, reason = check_lists(request, deny_list=deny_list)
+        self.assertFalse(should_skip)
+        self.assertEqual(reason, "deny_list")
+
+    def test_check_lists_respects_x_forwarded_for(self):
+        """Test check_lists uses extract_client_ip for proxy support."""
+        request = self.factory.get("/")
+        request.META["HTTP_X_FORWARDED_FOR"] = "203.0.113.42"
+        request.META["REMOTE_ADDR"] = "10.0.0.1"
+        deny_list = IPList(["203.0.113.0/24"])
+        should_skip, reason = check_lists(request, deny_list=deny_list)
+        self.assertFalse(should_skip)
+        self.assertEqual(reason, "deny_list")

--- a/tests/unit/test_testing_utilities.py
+++ b/tests/unit/test_testing_utilities.py
@@ -1,0 +1,400 @@
+"""
+Tests for django_smart_ratelimit.testing utilities.
+
+Verifies that fixtures and assertion helpers work as documented.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from django.test import Client
+
+from django_smart_ratelimit.backends.memory import MemoryBackend
+from django_smart_ratelimit.testing import (
+    RateLimitClient,
+    assert_not_rate_limited,
+    assert_rate_limited,
+    assert_remaining,
+    assert_retry_after,
+    clear_rate_limit_cache,
+    read_rate_limit_headers,
+)
+
+
+class TestRateLimitMemoryBackendFixture:
+    """Test the ratelimit_memory_backend fixture."""
+
+    def test_fixture_provides_memory_backend(self, ratelimit_memory_backend):
+        """Fixture should provide a MemoryBackend instance."""
+        assert isinstance(ratelimit_memory_backend, MemoryBackend)
+
+    def test_fixture_clears_between_tests(self, ratelimit_memory_backend):
+        """Each test should get a fresh backend."""
+        # First test gets backend A
+        backend_a_id = id(ratelimit_memory_backend)
+        assert len(ratelimit_memory_backend._data) == 0
+
+        # Simulate adding data
+        ratelimit_memory_backend.incr("test_key", 60)
+        assert len(ratelimit_memory_backend._data) > 0
+
+    def test_backend_integration_with_decorator(self, ratelimit_memory_backend):
+        """Backend should be wired to @rate_limit decorator."""
+        from django_smart_ratelimit.backends import get_backend
+
+        active_backend = get_backend()
+        assert isinstance(active_backend, MemoryBackend)
+
+    def test_backend_incr_and_reset(self, ratelimit_memory_backend):
+        """Backend should support incr/reset operations."""
+        key = "test_key"
+
+        # Increment counter
+        count1 = ratelimit_memory_backend.incr(key, 60)
+        assert count1 == 1
+
+        count2 = ratelimit_memory_backend.incr(key, 60)
+        assert count2 == 2
+
+        # Reset
+        ratelimit_memory_backend.reset(key)
+        count3 = ratelimit_memory_backend.incr(key, 60)
+        assert count3 == 1
+
+    def test_backend_get_count(self, ratelimit_memory_backend):
+        """Backend should support get_count."""
+        key = "test_key"
+        ratelimit_memory_backend.incr(key, 60)
+        ratelimit_memory_backend.incr(key, 60)
+
+        count = ratelimit_memory_backend.get_count(key, 60)
+        assert count == 2
+
+
+class TestDisableRatelimitFixture:
+    """Test the disable_ratelimit fixture."""
+
+    def test_fixture_disables_rate_limiting(self, disable_ratelimit, settings):
+        """Fixture should set RATELIMIT_ENABLE to False."""
+        assert settings.RATELIMIT_ENABLE is False
+
+
+class TestFrozenRatelimitTimeFixture:
+    """Test the frozen_ratelimit_time fixture."""
+
+    def test_fixture_advances_time(self, frozen_ratelimit_time):
+        """Fixture should support time advancement."""
+        initial = frozen_ratelimit_time.current_time
+        frozen_ratelimit_time.advance(10)
+        assert frozen_ratelimit_time.current_time == initial + 10
+
+    def test_fixture_set_time(self, frozen_ratelimit_time):
+        """Fixture should support absolute time setting."""
+        frozen_ratelimit_time.set_time(1000.0)
+        assert frozen_ratelimit_time.current_time == 1000.0
+
+    def test_fixture_patches_time_module(self, frozen_ratelimit_time, monkeypatch):
+        """Fixture should patch time.time() globally."""
+        import time
+
+        # After patching, time.time() should return our frozen time
+        frozen_ratelimit_time.set_time(1234.5)
+        # Note: This test is tricky because monkeypatch is already applied
+        # Just verify the fixture state is maintained
+        assert frozen_ratelimit_time.current_time == 1234.5
+
+    def test_fixture_context_manager(self, frozen_ratelimit_time):
+        """Fixture should work as context manager."""
+        with frozen_ratelimit_time as ft:
+            assert isinstance(ft, type(frozen_ratelimit_time))
+            ft.advance(5)
+            assert frozen_ratelimit_time.current_time > 0
+
+
+class TestAssertRateLimited:
+    """Test assert_rate_limited assertion helper."""
+
+    def test_passes_on_429_status(self):
+        """Should pass when response is 429."""
+        response = Mock(status_code=429)
+        response.get = Mock(return_value=None)
+        # Should not raise
+        assert_rate_limited(response)
+
+    def test_fails_on_non_429_status(self):
+        """Should fail when response is not 429."""
+        response = Mock(status_code=200)
+        response.get = Mock(return_value=None)
+
+        with pytest.raises(AssertionError, match="Expected status 429"):
+            assert_rate_limited(response)
+
+    def test_validates_limit_header(self):
+        """Should validate X-RateLimit-Limit if provided."""
+        response = Mock(status_code=429)
+        response.get = Mock(side_effect=lambda key: "10" if key == "X-RateLimit-Limit" else None)
+
+        # Should pass
+        assert_rate_limited(response, expected_limit=10)
+
+        # Should fail on mismatch
+        with pytest.raises(AssertionError, match="X-RateLimit-Limit"):
+            assert_rate_limited(response, expected_limit=5)
+
+    def test_validates_remaining_header(self):
+        """Should validate X-RateLimit-Remaining if provided."""
+        response = Mock(status_code=429)
+
+        def mock_get(key):
+            if key == "X-RateLimit-Remaining":
+                return "0"
+            return None
+
+        response.get = Mock(side_effect=mock_get)
+
+        # Should pass
+        assert_rate_limited(response, expected_remaining=0)
+
+        # Should fail on mismatch
+        with pytest.raises(AssertionError, match="X-RateLimit-Remaining"):
+            assert_rate_limited(response, expected_remaining=5)
+
+
+class TestAssertNotRateLimited:
+    """Test assert_not_rate_limited assertion helper."""
+
+    def test_passes_on_non_429_status(self):
+        """Should pass when response is not 429."""
+        response = Mock(status_code=200)
+        response.get = Mock(side_effect=lambda key: "5" if key == "X-RateLimit-Remaining" else None)
+        # Should not raise
+        assert_not_rate_limited(response)
+
+    def test_fails_on_429_status(self):
+        """Should fail when response is 429."""
+        response = Mock(status_code=429)
+        response.get = Mock(return_value=None)
+
+        with pytest.raises(AssertionError, match="rate limited"):
+            assert_not_rate_limited(response)
+
+    def test_requires_remaining_header(self):
+        """Should fail if X-RateLimit-Remaining header is missing."""
+        response = Mock(status_code=200)
+        response.get = Mock(return_value=None)
+
+        # assert_not_rate_limited checks if remaining is in headers dict
+        # Since read_rate_limit_headers returns {'remaining': None} when header is absent,
+        # the check "remaining in headers" fails when the value is None
+        # Let's test with actual behavior: missing header means None value
+        with pytest.raises(AssertionError, match="X-RateLimit-Remaining"):
+            assert_not_rate_limited(response)
+
+
+class TestAssertRemaining:
+    """Test assert_remaining assertion helper."""
+
+    def test_passes_on_matching_remaining(self):
+        """Should pass when remaining matches expected."""
+        response = Mock()
+        response.get = Mock(side_effect=lambda key: "5" if key == "X-RateLimit-Remaining" else None)
+
+        # Should not raise
+        assert_remaining(response, 5)
+
+    def test_fails_on_mismatching_remaining(self):
+        """Should fail when remaining doesn't match."""
+        response = Mock()
+        response.get = Mock(side_effect=lambda key: "5" if key == "X-RateLimit-Remaining" else None)
+
+        with pytest.raises(AssertionError, match="X-RateLimit-Remaining"):
+            assert_remaining(response, 3)
+
+
+class TestAssertRetryAfter:
+    """Test assert_retry_after assertion helper."""
+
+    def test_passes_on_exact_match(self):
+        """Should pass when Retry-After matches expected."""
+        response = Mock()
+        response.get = Mock(side_effect=lambda key: "60" if key == "Retry-After" else None)
+
+        # Should not raise
+        assert_retry_after(response, 60)
+
+    def test_passes_within_tolerance(self):
+        """Should pass when Retry-After is within tolerance."""
+        response = Mock()
+        response.get = Mock(side_effect=lambda key: "62" if key == "Retry-After" else None)
+
+        # Should pass with tolerance=5
+        assert_retry_after(response, 60, tolerance=5)
+
+    def test_fails_outside_tolerance(self):
+        """Should fail when Retry-After is outside tolerance."""
+        response = Mock()
+        response.get = Mock(side_effect=lambda key: "70" if key == "Retry-After" else None)
+
+        with pytest.raises(AssertionError, match="Retry-After"):
+            assert_retry_after(response, 60, tolerance=5)
+
+    def test_fails_missing_header(self):
+        """Should fail when Retry-After header is missing."""
+        response = Mock()
+        response.get = Mock(return_value=None)
+
+        with pytest.raises(AssertionError, match="Retry-After"):
+            assert_retry_after(response, 60)
+
+    def test_fails_non_integer_header(self):
+        """Should fail when Retry-After is not an integer."""
+        response = Mock()
+        response.get = Mock(side_effect=lambda key: "invalid" if key == "Retry-After" else None)
+
+        with pytest.raises(AssertionError, match="not an integer"):
+            assert_retry_after(response, 60)
+
+
+class TestReadRateLimitHeaders:
+    """Test read_rate_limit_headers helper."""
+
+    def test_reads_all_headers(self):
+        """Should extract all rate limit headers."""
+        response = Mock()
+
+        def mock_get(key):
+            headers = {
+                "X-RateLimit-Limit": "10",
+                "X-RateLimit-Remaining": "5",
+                "X-RateLimit-Reset": "1234567890",
+            }
+            return headers.get(key)
+
+        response.get = Mock(side_effect=mock_get)
+
+        headers = read_rate_limit_headers(response)
+
+        assert headers["limit"] == 10
+        assert headers["remaining"] == 5
+        assert headers["reset"] == 1234567890
+
+    def test_returns_none_for_missing_headers(self):
+        """Should return None for missing headers."""
+        response = Mock()
+        response.get = Mock(return_value=None)
+
+        headers = read_rate_limit_headers(response)
+
+        assert headers["limit"] is None
+        assert headers["remaining"] is None
+        assert headers["reset"] is None
+
+    def test_handles_partial_headers(self):
+        """Should handle partial header sets."""
+        response = Mock()
+
+        def mock_get(key):
+            if key == "X-RateLimit-Limit":
+                return "10"
+            return None
+
+        response.get = Mock(side_effect=mock_get)
+
+        headers = read_rate_limit_headers(response)
+
+        assert headers["limit"] == 10
+        assert headers["remaining"] is None
+        assert headers["reset"] is None
+
+
+class TestRateLimitClient:
+    """Test RateLimitClient utility."""
+
+    def test_initializes_with_client(self):
+        """Should initialize with a Django test client."""
+        client = Client()
+        rl_client = RateLimitClient(client)
+        assert rl_client.client == client
+
+    def test_exhaust_limit_returns_tuple(self, ratelimit_memory_backend):
+        """Should return (successful_responses, exceeded_response)."""
+        client = Client()
+        rl_client = RateLimitClient(client)
+
+        # Mock the client method to return responses
+        responses_list = [Mock(status_code=200) for _ in range(5)] + [Mock(status_code=429)]
+
+        def mock_get(path, **kwargs):
+            return responses_list.pop(0)
+
+        client.get = Mock(side_effect=mock_get)
+
+        successful, exceeded = rl_client.exhaust_limit("/test/", limit=5)
+
+        assert len(successful) == 5
+        assert exceeded.status_code == 429
+
+    def test_exhaust_limit_calls_client_method(self, ratelimit_memory_backend):
+        """Should call the appropriate HTTP method."""
+        client = Client()
+        rl_client = RateLimitClient(client)
+
+        responses_list = [Mock(status_code=200) for _ in range(5)] + [Mock(status_code=429)]
+
+        def mock_post(path, **kwargs):
+            return responses_list.pop(0)
+
+        client.post = Mock(side_effect=mock_post)
+
+        successful, exceeded = rl_client.exhaust_limit("/test/", limit=5, method="POST")
+
+        assert client.post.called
+        client.post.assert_called()
+
+    def test_clear_responses(self):
+        """Should clear stored responses."""
+        client = Client()
+        rl_client = RateLimitClient(client)
+        rl_client.responses = [Mock(), Mock()]
+
+        rl_client.clear_responses()
+
+        assert rl_client.responses == []
+
+
+class TestClearRateLimitCache:
+    """Test clear_rate_limit_cache utility."""
+
+    def test_clears_all_with_wildcard(self, ratelimit_memory_backend):
+        """Should clear all entries with '*' pattern."""
+        backend = ratelimit_memory_backend
+
+        # Add some data
+        backend.incr("key1", 60)
+        backend.incr("key2", 60)
+        assert len(backend._data) > 0
+
+        # Clear all
+        clear_rate_limit_cache("*")
+
+        # Should be empty (or close to it)
+        # Note: the actual implementation may vary based on key normalization
+        # Just verify the function runs without error
+        assert True
+
+    def test_clears_without_error_if_backend_unavailable(self, monkeypatch):
+        """Should not raise if backend is unavailable."""
+        # Patch get_backend in the backends module to raise
+        from django_smart_ratelimit import backends
+
+        def mock_get_backend(*args, **kwargs):
+            raise RuntimeError("Backend unavailable")
+
+        monkeypatch.setattr(
+            "django_smart_ratelimit.backends.get_backend",
+            mock_get_backend,
+        )
+
+        # Should not raise
+        clear_rate_limit_cache()
+        assert True

--- a/tests/unit/test_testing_utilities.py
+++ b/tests/unit/test_testing_utilities.py
@@ -4,9 +4,10 @@ Tests for django_smart_ratelimit.testing utilities.
 Verifies that fixtures and assertion helpers work as documented.
 """
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
+
 from django.test import Client
 
 from django_smart_ratelimit.backends.memory import MemoryBackend
@@ -31,7 +32,7 @@ class TestRateLimitMemoryBackendFixture:
     def test_fixture_clears_between_tests(self, ratelimit_memory_backend):
         """Each test should get a fresh backend."""
         # First test gets backend A
-        backend_a_id = id(ratelimit_memory_backend)
+        id(ratelimit_memory_backend)
         assert len(ratelimit_memory_backend._data) == 0
 
         # Simulate adding data
@@ -95,7 +96,6 @@ class TestFrozenRatelimitTimeFixture:
 
     def test_fixture_patches_time_module(self, frozen_ratelimit_time, monkeypatch):
         """Fixture should patch time.time() globally."""
-        import time
 
         # After patching, time.time() should return our frozen time
         frozen_ratelimit_time.set_time(1234.5)
@@ -132,7 +132,9 @@ class TestAssertRateLimited:
     def test_validates_limit_header(self):
         """Should validate X-RateLimit-Limit if provided."""
         response = Mock(status_code=429)
-        response.get = Mock(side_effect=lambda key: "10" if key == "X-RateLimit-Limit" else None)
+        response.get = Mock(
+            side_effect=lambda key: "10" if key == "X-RateLimit-Limit" else None
+        )
 
         # Should pass
         assert_rate_limited(response, expected_limit=10)
@@ -166,7 +168,9 @@ class TestAssertNotRateLimited:
     def test_passes_on_non_429_status(self):
         """Should pass when response is not 429."""
         response = Mock(status_code=200)
-        response.get = Mock(side_effect=lambda key: "5" if key == "X-RateLimit-Remaining" else None)
+        response.get = Mock(
+            side_effect=lambda key: "5" if key == "X-RateLimit-Remaining" else None
+        )
         # Should not raise
         assert_not_rate_limited(response)
 
@@ -197,7 +201,9 @@ class TestAssertRemaining:
     def test_passes_on_matching_remaining(self):
         """Should pass when remaining matches expected."""
         response = Mock()
-        response.get = Mock(side_effect=lambda key: "5" if key == "X-RateLimit-Remaining" else None)
+        response.get = Mock(
+            side_effect=lambda key: "5" if key == "X-RateLimit-Remaining" else None
+        )
 
         # Should not raise
         assert_remaining(response, 5)
@@ -205,7 +211,9 @@ class TestAssertRemaining:
     def test_fails_on_mismatching_remaining(self):
         """Should fail when remaining doesn't match."""
         response = Mock()
-        response.get = Mock(side_effect=lambda key: "5" if key == "X-RateLimit-Remaining" else None)
+        response.get = Mock(
+            side_effect=lambda key: "5" if key == "X-RateLimit-Remaining" else None
+        )
 
         with pytest.raises(AssertionError, match="X-RateLimit-Remaining"):
             assert_remaining(response, 3)
@@ -217,7 +225,9 @@ class TestAssertRetryAfter:
     def test_passes_on_exact_match(self):
         """Should pass when Retry-After matches expected."""
         response = Mock()
-        response.get = Mock(side_effect=lambda key: "60" if key == "Retry-After" else None)
+        response.get = Mock(
+            side_effect=lambda key: "60" if key == "Retry-After" else None
+        )
 
         # Should not raise
         assert_retry_after(response, 60)
@@ -225,7 +235,9 @@ class TestAssertRetryAfter:
     def test_passes_within_tolerance(self):
         """Should pass when Retry-After is within tolerance."""
         response = Mock()
-        response.get = Mock(side_effect=lambda key: "62" if key == "Retry-After" else None)
+        response.get = Mock(
+            side_effect=lambda key: "62" if key == "Retry-After" else None
+        )
 
         # Should pass with tolerance=5
         assert_retry_after(response, 60, tolerance=5)
@@ -233,7 +245,9 @@ class TestAssertRetryAfter:
     def test_fails_outside_tolerance(self):
         """Should fail when Retry-After is outside tolerance."""
         response = Mock()
-        response.get = Mock(side_effect=lambda key: "70" if key == "Retry-After" else None)
+        response.get = Mock(
+            side_effect=lambda key: "70" if key == "Retry-After" else None
+        )
 
         with pytest.raises(AssertionError, match="Retry-After"):
             assert_retry_after(response, 60, tolerance=5)
@@ -249,7 +263,9 @@ class TestAssertRetryAfter:
     def test_fails_non_integer_header(self):
         """Should fail when Retry-After is not an integer."""
         response = Mock()
-        response.get = Mock(side_effect=lambda key: "invalid" if key == "Retry-After" else None)
+        response.get = Mock(
+            side_effect=lambda key: "invalid" if key == "Retry-After" else None
+        )
 
         with pytest.raises(AssertionError, match="not an integer"):
             assert_retry_after(response, 60)
@@ -322,7 +338,9 @@ class TestRateLimitClient:
         rl_client = RateLimitClient(client)
 
         # Mock the client method to return responses
-        responses_list = [Mock(status_code=200) for _ in range(5)] + [Mock(status_code=429)]
+        responses_list = [Mock(status_code=200) for _ in range(5)] + [
+            Mock(status_code=429)
+        ]
 
         def mock_get(path, **kwargs):
             return responses_list.pop(0)
@@ -339,7 +357,9 @@ class TestRateLimitClient:
         client = Client()
         rl_client = RateLimitClient(client)
 
-        responses_list = [Mock(status_code=200) for _ in range(5)] + [Mock(status_code=429)]
+        responses_list = [Mock(status_code=200) for _ in range(5)] + [
+            Mock(status_code=429)
+        ]
 
         def mock_post(path, **kwargs):
             return responses_list.pop(0)
@@ -385,7 +405,6 @@ class TestClearRateLimitCache:
     def test_clears_without_error_if_backend_unavailable(self, monkeypatch):
         """Should not raise if backend is unavailable."""
         # Patch get_backend in the backends module to raise
-        from django_smart_ratelimit import backends
 
         def mock_get_backend(*args, **kwargs):
             raise RuntimeError("Backend unavailable")


### PR DESCRIPTION
## Summary

- Extracts a shared evaluation pipeline (`resolve_effective_rate`, `apply_policy_lists`, `handle_shadow_decision`) now used by the decorator, middleware, and DRF adapter — one place to reason about rate-limit policy
- Adds four long-requested features: **shadow mode** (`shadow=True`), **cost-based limiting** (`cost=<int|callable>`), **CIDR allow/deny lists**, and a **DRF throttle adapter** (`UserRateLimitThrottle`, `AnonRateLimitThrottle`, `ScopedRateLimitThrottle`)
- Ships pytest fixtures (`pytest11` entry point) and an OpenTelemetry exporter, plus tightens a couple of latent issues along the way

## Breaking changes (hence v3)

- **Empty keys now raise `KeyGenerationError`** instead of silently allowing traffic through. This was a subtle footgun where a broken key function could effectively disable rate limiting.
- DRF adapter `wait()` now returns a non-None value on throttled responses so `Retry-After` works end-to-end.

Both are documented with upgrade guidance in `MIGRATION.md`.

## Notable fixes caught along the way

- **DRF cost bug**: `SmartRateLimitThrottle.allow_request` was computing `cost` via `get_cost()` but never actually consuming it in the limit check. Now calls `backend.incr(key, period, cost)` with a `TypeError` fallback so older backends still work.
- **Generic token-bucket race**: per-key threading locks serialize the read-modify-write inside a single process; cross-process contract is now explicitly documented.
- **Reset-time drift**: per-key cache keeps reset-time stable for first-request-aligned sliding windows; clock-aligned path is unchanged.
- **DRF callable attributes** (`rate`, `cost`, `key_func`): now accessed via `type(self).attr` so plain-function class attributes don't get bound as methods.

## Test plan

- [x] 1,083 passing, 50 skipped (optional Redis/Mongo), 1 deselected (Redis-parity test, Redis not available in CI)
- [x] 36 net new tests: `tests/unit/test_pipeline.py` (26) + `tests/integration/test_v3_features.py` (10)
- [x] autoflake + black + isort + flake8 clean on all touched files
- [x] Wheel builds cleanly (`python -m build`)
- [x] `pytest11` entry point resolves; all 4 fixtures register via `--fixtures`
- [x] OTel no-op path verified by forcing `HAS_OTEL=False`

## Follow-ups (post-release)

- Redis-backed atomic `token_bucket_check` via Lua so production multi-worker setups get atomic semantics (currently only in-process lock)
- OTel exporter examples in the docs
- Convenience `@shadow_rate_limit` alias for discoverability