### PR TITLE
v3.1.0: configurable proxy trust + async token/leaky bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-05-30
+
+### Added
+
+- **Configurable proxy trust for client IP extraction.** New settings
+  `RATELIMIT_TRUSTED_PROXIES` (a list of IP/CIDR strings) and
+  `RATELIMIT_TRUST_FORWARDED_HEADERS` (bool). When `RATELIMIT_TRUSTED_PROXIES`
+  is set, the forwarded headers (`X-Forwarded-For`, `CF-Connecting-IP`,
+  `X-Real-IP`) are honored only for requests that arrive from a trusted proxy,
+  and the real client is taken as the right-most non-trusted entry of the
+  `X-Forwarded-For` chain. The default behavior is unchanged and backward
+  compatible (forwarded headers are trusted) until you opt in. A new public
+  helper, `django_smart_ratelimit.policy.get_client_ip`, centralizes the logic;
+  `get_ip_key` and the CIDR allow/deny lists now share it so the rate-limit key
+  and policy lists always agree on the client IP.
+- **Async support for the token-bucket and leaky-bucket algorithms.**
+  `@rate_limit(..., algorithm="token_bucket")` (and `leaky_bucket` on backends
+  with native support, e.g. the database backend) are now honored on async
+  views — the algorithm check runs off the event loop via `sync_to_async`.
+  Previously async views silently fell back to window counting. Async views on
+  a backend without native leaky-bucket support still warn and use window
+  limiting.
+
+### Security
+
+- IP-based limits and CIDR allow/deny lists can no longer be bypassed by a
+  spoofed `X-Forwarded-For` (or `CF-Connecting-IP` / `X-Real-IP`) header once
+  `RATELIMIT_TRUSTED_PROXIES` is configured. A direct (non-proxied) client's
+  forwarded headers are ignored, and a client cannot move the result by
+  prepending fake entries to the chain. See the deployment docs for setup.
+
 ## [3.0.0] - 2026-05-30
 
 This is a major release that consolidates and hardens the v2.x runtime. Existing

--- a/django_smart_ratelimit/__init__.py
+++ b/django_smart_ratelimit/__init__.py
@@ -5,7 +5,7 @@ with support for multiple backends, algorithms (including token bucket),
 and comprehensive rate limiting strategies.
 """
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 __author__ = "Yasser Shkeir"
 
 # Optional backend imports (may not be available)

--- a/django_smart_ratelimit/config.py
+++ b/django_smart_ratelimit/config.py
@@ -39,6 +39,16 @@ class RateLimitSettings:
     default_limit: str = "100/m"
     align_window_to_clock: bool = True  # Clock-aligned windows by default
 
+    # Client IP / proxy trust. When ``trusted_proxies`` is set (a list of
+    # IP/CIDR strings), forwarded headers (X-Forwarded-For, CF-Connecting-IP,
+    # X-Real-IP) are only honored for requests arriving from a trusted proxy,
+    # and the real client is taken as the right-most non-trusted entry of the
+    # X-Forwarded-For chain. When it is not set, ``trust_forwarded_headers``
+    # controls whether forwarded headers are trusted at all (default True keeps
+    # the historical behavior; set False to use REMOTE_ADDR only).
+    trusted_proxies: Optional[list] = None
+    trust_forwarded_headers: bool = True
+
     # Error Handling
     log_exceptions: bool = True
     exception_handler: Optional[str] = None
@@ -108,6 +118,10 @@ class RateLimitSettings:
             default_limit=getattr(django_settings, "RATELIMIT_DEFAULT_LIMIT", "100/m"),
             align_window_to_clock=getattr(
                 django_settings, "RATELIMIT_ALIGN_WINDOW_TO_CLOCK", True
+            ),
+            trusted_proxies=getattr(django_settings, "RATELIMIT_TRUSTED_PROXIES", None),
+            trust_forwarded_headers=getattr(
+                django_settings, "RATELIMIT_TRUST_FORWARDED_HEADERS", True
             ),
             log_exceptions=getattr(django_settings, "RATELIMIT_LOG_EXCEPTIONS", True),
             collect_metrics=getattr(

--- a/django_smart_ratelimit/decorator.py
+++ b/django_smart_ratelimit/decorator.py
@@ -9,7 +9,7 @@ import functools
 import importlib
 import logging
 import time
-from typing import Any, Callable, Dict, Optional, Union, cast
+from typing import Any, Callable, Dict, Optional, Tuple, Union, cast
 
 from asgiref.sync import iscoroutinefunction, sync_to_async
 
@@ -559,17 +559,6 @@ def rate_limit(
                 if algorithm and hasattr(backend_instance, "config"):
                     backend_instance.config["algorithm"] = algorithm
 
-                # The async path performs window counting only; the dedicated
-                # token/leaky bucket handlers are sync-only for now. Warn instead
-                # of silently applying the wrong algorithm semantics.
-                if algorithm in ("token_bucket", "leaky_bucket"):
-                    logger.warning(
-                        "algorithm=%r is not yet honored for async views; "
-                        "falling back to window counting. Use a sync view for "
-                        "token/leaky bucket burst semantics.",
-                        algorithm,
-                    )
-
                 # Resolve key + rate + cost + adaptive in one place (v3 pipeline)
                 try:
                     resolved = resolve_effective_rate(
@@ -590,36 +579,58 @@ def rate_limit(
                 period = resolved.period
                 request_cost = resolved.cost
 
-                # Check limit
+                # Decide the allow/deny. token_bucket (and leaky_bucket on
+                # backends with native support) run their sync algorithm check
+                # off the event loop via sync_to_async, so async views get true
+                # bucket semantics instead of window counting.
+                bucket_metadata: Optional[Dict[str, Any]] = None
+                use_bucket = algorithm == "token_bucket" or (
+                    algorithm == "leaky_bucket"
+                    and hasattr(backend_instance, "leaky_bucket_check")
+                )
+                if algorithm == "leaky_bucket" and not use_bucket:
+                    logger.warning(
+                        "algorithm='leaky_bucket' requires a backend with native "
+                        "leaky-bucket support (e.g. the database backend); %s does "
+                        "not, so standard window limiting is applied instead.",
+                        type(backend_instance).__name__,
+                    )
+
                 try:
-                    # Use async increment if available
-                    if hasattr(backend_instance, "aincr"):
-                        current_count = await backend_instance.aincr(  # type: ignore[call-arg]
-                            limit_key, period, request_cost
-                        )
-                    else:
-                        current_count = await sync_to_async(backend_instance.incr)(  # type: ignore[call-arg]
-                            limit_key, period, request_cost
-                        )
-                except TypeError:
-                    # Backend's incr doesn't accept cost yet (pre-v3 custom
-                    # backend). Fall back to single-token incr and repeat if
-                    # cost > 1 so weighted limiting still works.
-                    if hasattr(backend_instance, "aincr"):
-                        current_count = await backend_instance.aincr(limit_key, period)
-                    else:
-                        current_count = await sync_to_async(backend_instance.incr)(
-                            limit_key, period
-                        )
-                    for _ in range(request_cost - 1):
-                        if hasattr(backend_instance, "aincr"):
-                            current_count = await backend_instance.aincr(
-                                limit_key, period
+                    if use_bucket:
+                        try:
+                            (
+                                is_allowed,
+                                bucket_metadata,
+                                remaining,
+                            ) = await sync_to_async(_run_bucket_check)(
+                                cast(str, algorithm),
+                                backend_instance,
+                                limit_key,
+                                limit,
+                                period,
+                                request_cost,
+                                algorithm_config,
                             )
-                        else:
-                            current_count = await sync_to_async(backend_instance.incr)(
-                                limit_key, period
+                        except Exception as exc:  # pragma: no cover - defensive
+                            logger.error(
+                                "Async %s algorithm failed: %s; falling back to "
+                                "window limiting.",
+                                algorithm,
+                                exc,
                             )
+                            bucket_metadata = None
+                            current_count = await _aincr_with_cost(
+                                backend_instance, limit_key, period, request_cost
+                            )
+                            is_allowed = current_count <= limit
+                            remaining = max(0, limit - current_count)
+                    else:
+                        current_count = await _aincr_with_cost(
+                            backend_instance, limit_key, period, request_cost
+                        )
+                        is_allowed = current_count <= limit
+                        remaining = max(0, limit - current_count)
                 except BackendError as e:
                     # Handle backend errors
                     if not backend_instance.fail_open:
@@ -632,11 +643,10 @@ def rate_limit(
                                 request=_request,
                                 response_callback=response_callback,
                             )
-                    current_count = 0
+                    is_allowed = True
+                    remaining = limit
 
-                # Check if limited, apply shadow mode
-                is_allowed = current_count <= limit
-                remaining = max(0, limit - current_count)
+                # Apply shadow mode
                 decision = handle_shadow_decision(
                     allowed=is_allowed,
                     shadow=shadow,
@@ -655,8 +665,13 @@ def rate_limit(
                             request=_request,
                             response_callback=response_callback,
                         )
-                        reset_time = int(time.time() + period)
-                        add_rate_limit_headers(response, limit, 0, reset_time)
+                        if bucket_metadata is not None:
+                            add_token_bucket_headers(
+                                response, bucket_metadata, limit, period
+                            )
+                        else:
+                            reset_time = int(time.time() + period)
+                            add_rate_limit_headers(response, limit, 0, reset_time)
                         return response
                     # Non-blocking: mark the request so the view can detect the
                     # soft-limit breach, mirroring the sync paths.
@@ -669,13 +684,14 @@ def rate_limit(
                 response = await func(*args, **kwargs)
 
                 # Add headers
-                reset_time = int(time.time() + period)
-
-                if (
-                    hasattr(response, "headers")
-                    and "X-RateLimit-Limit" not in response.headers
-                ):
-                    add_rate_limit_headers(response, limit, remaining, reset_time)
+                if hasattr(response, "headers"):
+                    if bucket_metadata is not None:
+                        add_token_bucket_headers(
+                            response, bucket_metadata, limit, period
+                        )
+                    elif "X-RateLimit-Limit" not in response.headers:
+                        reset_time = int(time.time() + period)
+                        add_rate_limit_headers(response, limit, remaining, reset_time)
 
                 return response
 
@@ -937,6 +953,65 @@ def _handle_middleware_processed_request(
     reset_time = ctx.reset_time or _get_reset_time(backend_instance, limit_key, period)
     add_rate_limit_headers(response, limit, ctx.remaining, reset_time)
     return response
+
+
+def _run_bucket_check(
+    algorithm: str,
+    backend_instance: Any,
+    limit_key: str,
+    limit: int,
+    period: int,
+    cost: int,
+    algorithm_config: Optional[Dict[str, Any]],
+) -> Tuple[bool, Dict[str, Any], int]:
+    """Run a (synchronous) token/leaky bucket check.
+
+    Returns ``(is_allowed, metadata, remaining)``. Used by the async decorator
+    via ``sync_to_async`` so async views get true bucket semantics.
+    """
+    if algorithm == "leaky_bucket":
+        algorithm_instance: Any = LeakyBucketAlgorithm(algorithm_config)
+        is_allowed, metadata = algorithm_instance.is_allowed(
+            backend_instance, limit_key, limit, period, request_cost=cost
+        )
+        remaining = int(metadata.get("space_remaining", 0)) if metadata else 0
+    else:
+        algorithm_instance = TokenBucketAlgorithm(algorithm_config)
+        try:
+            is_allowed, metadata = algorithm_instance.is_allowed(
+                backend_instance, limit_key, limit, period, tokens_requested=cost
+            )
+        except TypeError:
+            is_allowed, metadata = algorithm_instance.is_allowed(
+                backend_instance, limit_key, limit, period
+            )
+        remaining = int(metadata.get("tokens_remaining", 0)) if metadata else 0
+    return is_allowed, metadata, remaining
+
+
+async def _aincr_with_cost(
+    backend_instance: Any, limit_key: str, period: int, request_cost: int
+) -> int:
+    """Async increment honoring cost, with a fallback for cost-unaware backends."""
+    try:
+        if hasattr(backend_instance, "aincr"):
+            return await backend_instance.aincr(limit_key, period, request_cost)
+        return await sync_to_async(backend_instance.incr)(
+            limit_key, period, request_cost
+        )
+    except TypeError:
+        # Backend's incr doesn't accept cost yet (pre-v3 custom backend).
+        # Fall back to single-token increments so weighted limiting still works.
+        if hasattr(backend_instance, "aincr"):
+            count = await backend_instance.aincr(limit_key, period)
+        else:
+            count = await sync_to_async(backend_instance.incr)(limit_key, period)
+        for _ in range(request_cost - 1):
+            if hasattr(backend_instance, "aincr"):
+                count = await backend_instance.aincr(limit_key, period)
+            else:
+                count = await sync_to_async(backend_instance.incr)(limit_key, period)
+        return count
 
 
 def _handle_token_bucket_algorithm(

--- a/django_smart_ratelimit/key_functions.py
+++ b/django_smart_ratelimit/key_functions.py
@@ -25,25 +25,18 @@ def get_ip_key(request: HttpRequest) -> str:
 
     Returns:
         IP address string formatted as 'ip:{address}'
+
+    Note:
+        Client IP extraction (and whether forwarded headers such as
+        X-Forwarded-For are trusted) is governed by ``RATELIMIT_TRUSTED_PROXIES``
+        / ``RATELIMIT_TRUST_FORWARDED_HEADERS``. See
+        :func:`django_smart_ratelimit.policy.get_client_ip`.
     """
-    # Try various headers to get real IP (considering proxies)
-    ip_headers = [
-        "HTTP_CF_CONNECTING_IP",  # Cloudflare
-        "HTTP_X_FORWARDED_FOR",  # Standard proxy header
-        "HTTP_X_REAL_IP",  # Nginx proxy
-        "REMOTE_ADDR",  # Direct connection
-    ]
+    # Delegate to the shared, proxy-trust-aware extractor so the rate-limit key
+    # and the CIDR allow/deny lists agree on the client IP.
+    from .policy import get_client_ip
 
-    for header in ip_headers:
-        ip = request.META.get(header)
-        if ip:
-            # Handle comma-separated IPs (X-Forwarded-For)
-            if "," in ip:
-                ip = ip.split(",")[0].strip()
-            if ip and ip != "unknown":
-                return f"ip:{ip}"
-
-    return "ip:unknown"
+    return f"ip:{get_client_ip(request)}"
 
 
 def get_user_key(request: HttpRequest) -> str:

--- a/django_smart_ratelimit/policy/__init__.py
+++ b/django_smart_ratelimit/policy/__init__.py
@@ -11,7 +11,8 @@ Key classes:
 
 Key functions:
     - parse_ip_list: Convert various input formats to IPList instances
-    - extract_client_ip: Extract client IP from request
+    - get_client_ip: Extract client IP from request (proxy-trust aware)
+    - extract_client_ip: Backwards-compatible alias for get_client_ip
     - check_lists: Check if IP is in allow/deny lists
 """
 
@@ -21,6 +22,7 @@ from .lists import (
     URLBackedIPList,
     check_lists,
     extract_client_ip,
+    get_client_ip,
     parse_ip_list,
 )
 
@@ -29,6 +31,7 @@ __all__ = [
     "FileBackedIPList",
     "URLBackedIPList",
     "parse_ip_list",
+    "get_client_ip",
     "extract_client_ip",
     "check_lists",
 ]

--- a/django_smart_ratelimit/policy/lists.py
+++ b/django_smart_ratelimit/policy/lists.py
@@ -481,19 +481,126 @@ def parse_ip_list(source: Union[str, List[str], IPList, None]) -> Optional[IPLis
     return None
 
 
+# Cache of parsed trusted-proxy IPLists, keyed by the raw setting value so a
+# changed RATELIMIT_TRUSTED_PROXIES (e.g. via override_settings) re-parses.
+_TRUSTED_PROXY_CACHE: dict = {}
+
+# Forwarded headers consulted in the legacy (trust-everything) path, in order.
+_FORWARDED_HEADERS = (
+    "HTTP_CF_CONNECTING_IP",  # Cloudflare
+    "HTTP_X_FORWARDED_FOR",  # Standard proxy header
+    "HTTP_X_REAL_IP",  # Nginx
+)
+
+
+def _get_trusted_proxies() -> Optional[IPList]:
+    """Return the configured trusted-proxy IPList, or None if not configured."""
+    from django.conf import settings
+
+    raw = getattr(settings, "RATELIMIT_TRUSTED_PROXIES", None)
+    if not raw:
+        return None
+    key = tuple(raw)
+    cached = _TRUSTED_PROXY_CACHE.get(key)
+    if cached is not None:
+        return cached
+    try:
+        ip_list = IPList(list(raw))
+    except ValueError as exc:
+        logger.warning(
+            "Invalid RATELIMIT_TRUSTED_PROXIES (%s); ignoring proxy trust config",
+            exc,
+        )
+        return None
+    _TRUSTED_PROXY_CACHE[key] = ip_list
+    return ip_list
+
+
+def _client_from_trusted_chain(request: HttpRequest, trusted: IPList) -> str:
+    """Pick the real client IP when the request came from a trusted proxy.
+
+    The X-Forwarded-For chain is ``client, proxy1, proxy2, ...`` (left to
+    right). Walking from the right and returning the first address that is not
+    a trusted proxy yields the real client even when several proxies are
+    chained, and prevents a client from spoofing the value by prepending fake
+    entries.
+    """
+    xff = (request.META.get("HTTP_X_FORWARDED_FOR") or "").strip()
+    if xff:
+        parts = [p.strip() for p in xff.split(",") if p.strip()]
+        for addr in reversed(parts):
+            if not trusted.contains(addr):
+                return addr
+        if parts:
+            # Every hop was a trusted proxy — the left-most entry is the client.
+            return parts[0]
+    for header in ("HTTP_CF_CONNECTING_IP", "HTTP_X_REAL_IP"):
+        value = (request.META.get(header) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def get_client_ip(request: HttpRequest) -> str:
+    """
+    Extract the client IP from a Django request, honoring proxy-trust config.
+
+    Behavior:
+
+    - If ``RATELIMIT_TRUSTED_PROXIES`` is set (a list of IP/CIDR strings),
+      forwarded headers are honored ONLY when ``REMOTE_ADDR`` is one of those
+      trusted proxies; the client IP is the right-most non-trusted entry of the
+      ``X-Forwarded-For`` chain. Requests that did not arrive via a trusted
+      proxy fall back to ``REMOTE_ADDR``. This is the secure configuration.
+    - Else if ``RATELIMIT_TRUST_FORWARDED_HEADERS`` is False, ``REMOTE_ADDR`` is
+      used directly (forwarded headers ignored).
+    - Otherwise (the default, backward-compatible behavior), the first present
+      forwarded header (CF-Connecting-IP, then the left-most X-Forwarded-For,
+      then X-Real-IP) is trusted, falling back to ``REMOTE_ADDR``.
+
+    SECURITY: forwarded headers are client-controlled and spoofable unless a
+    trusted proxy overwrites them. Configure ``RATELIMIT_TRUSTED_PROXIES`` (or
+    set ``RATELIMIT_TRUST_FORWARDED_HEADERS = False``) whenever IP-based limits
+    or CIDR allow/deny lists are security-relevant.
+
+    Args:
+        request: Django HTTP request object
+
+    Returns:
+        Client IP address string, or "unknown" if none could be determined.
+    """
+    from django.conf import settings
+
+    remote_addr = (request.META.get("REMOTE_ADDR") or "").strip()
+
+    trusted = _get_trusted_proxies()
+    if trusted is not None:
+        if remote_addr and trusted.contains(remote_addr):
+            client = _client_from_trusted_chain(request, trusted)
+            if client:
+                return client
+        return remote_addr or "unknown"
+
+    if not getattr(settings, "RATELIMIT_TRUST_FORWARDED_HEADERS", True):
+        return remote_addr or "unknown"
+
+    # Legacy/default behavior: trust the first present forwarded header.
+    for header in _FORWARDED_HEADERS + ("REMOTE_ADDR",):
+        value = (request.META.get(header) or "").strip()
+        if value and value != "unknown":
+            if "," in value:
+                value = value.split(",")[0].strip()
+            if value:
+                return value
+    return "unknown"
+
+
 def extract_client_ip(request: HttpRequest) -> str:
     """
     Extract client IP address from a Django request.
 
-    Respects proxy headers (X-Forwarded-For, X-Real-IP, CF-Connecting-IP) to
-    support requests through load balancers and CDNs.
-
-    SECURITY WARNING:
-    This function trusts X-Forwarded-For and other proxy headers. These headers
-    can be spoofed if the request doesn't come from a trusted proxy. Only rely
-    on this function if your application is deployed behind a trusted reverse
-    proxy that overwrites these headers and strips any client-supplied values.
-    The library does not currently validate proxy trust itself.
+    Thin wrapper around :func:`get_client_ip` kept for backwards compatibility.
+    Proxy-header trust is configurable — see :func:`get_client_ip`.
 
     Args:
         request: Django HTTP request object
@@ -507,22 +614,9 @@ def extract_client_ip(request: HttpRequest) -> str:
         ...     # Handle blocked IP
         ...     pass
     """
-    # Order of preference for IP headers
-    ip_headers = [
-        "HTTP_CF_CONNECTING_IP",  # Cloudflare
-        "HTTP_X_FORWARDED_FOR",  # Standard proxy header
-        "HTTP_X_REAL_IP",  # Nginx
-        "REMOTE_ADDR",  # Direct connection (always available)
-    ]
-
-    for header in ip_headers:
-        ip = request.META.get(header, "").strip()
-        if ip and ip != "unknown":
-            # Handle comma-separated IPs (X-Forwarded-For)
-            if "," in ip:
-                ip = ip.split(",")[0].strip()
-            if ip:
-                return ip
+    ip = get_client_ip(request)
+    if ip:
+        return ip
 
     return "unknown"
 

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -137,11 +137,11 @@ Overflow (bucket full) → request rejected
 
 ## Async Views and Algorithm Selection
 
-On asynchronous views (`aratelimit`, or an `async def` view) algorithm selection is
-**not yet honored** for `token_bucket` and `leaky_bucket`. The async path performs
-window counting only; passing either of those algorithms logs a warning and falls
-back to window counting. Use a synchronous view if you need token/leaky bucket burst
-semantics.
+As of v3.1.0, `@rate_limit` on an `async def` view honors `token_bucket` (and
+`leaky_bucket` on a backend with native support, such as the database backend) —
+the algorithm check runs off the event loop. On backends without native
+leaky-bucket support, `leaky_bucket` logs a warning and falls back to window
+counting. The standalone `@aratelimit` decorator performs window counting only.
 
 ## Window Alignment
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,6 +161,29 @@ With clock alignment disabled:
 - User A's first request at 12:00:30 → window is 12:00:30-12:01:30 (60s remaining)
 - User B's first request at 12:00:45 → window is 12:00:45-12:01:45 (60s remaining)
 
+## Client IP and Proxy Trust
+
+The `"ip"` / `"user_or_ip"` keys and the CIDR allow/deny lists derive the client
+IP from request headers. Forwarded headers (`X-Forwarded-For`, `CF-Connecting-IP`,
+`X-Real-IP`) are client-controlled and spoofable unless a trusted proxy overwrites
+them, so two settings (added in v3.1.0) control how much they are trusted:
+
+```python
+# A list of IP/CIDR strings identifying your reverse proxies / load balancers.
+# When set, forwarded headers are honored ONLY for requests arriving from one of
+# these proxies, and the real client is the right-most non-trusted entry of the
+# X-Forwarded-For chain. This is the secure, recommended configuration.
+RATELIMIT_TRUSTED_PROXIES = ['10.0.0.0/8']
+
+# Master switch (default True). Set False to ignore forwarded headers entirely
+# and always use REMOTE_ADDR (useful when the app is never behind a proxy).
+RATELIMIT_TRUST_FORWARDED_HEADERS = True
+```
+
+Defaults are backward compatible: when neither setting is configured, the first
+present forwarded header is trusted (the historical behavior). See the deployment
+guide for the security rationale.
+
 ## Circuit Breaker Configuration
 
 Protects your application when backends are unhealthy.

--- a/docs/decorator.md
+++ b/docs/decorator.md
@@ -87,10 +87,10 @@ When `algorithm` is left as `None`, standard window limiting is applied
 
 Limitations to be aware of:
 
-- `token_bucket` and `leaky_bucket` are honored only by the **sync** decorator.
-  On async views (an `async def` view, or `@aratelimit`) algorithm selection is
-  not yet honored: the decorator logs a warning and falls back to window
-  counting.
+- `token_bucket` and `leaky_bucket` are honored on **sync** views and on
+  **async** `async def` views decorated with `@rate_limit` (as of v3.1.0 the
+  async path runs the algorithm check off the event loop). The standalone
+  `@aratelimit` decorator still applies window counting only.
 - `leaky_bucket` via the decorator requires a backend with native leaky-bucket
   support. The **database** backend provides this. On other backends the
   decorator logs a warning and falls back to standard window limiting, so do not
@@ -154,9 +154,9 @@ async def my_async_view(request):
 ```
 
 `@rate_limit` also detects `async def` views automatically and applies its async
-path, so most async views can use `@rate_limit` directly. Note that on either
-async path, `token_bucket` / `leaky_bucket` selection is not honored and window
-counting is used instead.
+path, so most async views can use `@rate_limit` directly — including
+`token_bucket` / `leaky_bucket`, which are honored on the async path as of
+v3.1.0. The standalone `@aratelimit` decorator applies window counting only.
 
 ## @ratelimit_batch
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -59,23 +59,33 @@ preferring proxy headers in this order before falling back to the socket address
 This affects the `"ip"` and `"user_or_ip"` keys (`RateLimitKey.IP`, `RateLimitKey.USER_OR_IP`)
 and the `allow_list` / `deny_list` arguments of the `rate_limit` decorator.
 
-**These headers are trusted as-is.** The library does not currently validate proxy trust,
-and any client can set `X-Forwarded-For` or `CF-Connecting-IP` on a request. If your app is
-reachable directly (no header-sanitizing proxy in front), a client can spoof its IP to:
+**By default these headers are trusted as-is** (backward-compatible behavior). Any client can
+set `X-Forwarded-For` or `CF-Connecting-IP` on a request, so if your app is reachable directly
+(no header-sanitizing proxy in front), a client can spoof its IP to:
 
 - match an `allow_list` entry and bypass rate limiting, or
 - evade a `deny_list` entry, or
 - pollute the keyspace by forging a different IP on every request.
 
-Only deploy IP keys or CIDR allow/deny lists behind a reverse proxy you control. That proxy
-**must**:
+You have two ways to lock this down (added in v3.1.0):
 
-- **Overwrite** the forwarded header with the real peer address (do not append).
-- **Strip** any client-supplied `X-Forwarded-For`, `X-Real-IP`, and `CF-Connecting-IP`
-  values on inbound requests so they cannot reach Django.
+```python
+# Recommended: validate proxy trust. Forwarded headers are honored ONLY for
+# requests arriving from one of these proxies, and the client is taken as the
+# right-most entry of X-Forwarded-For that is not one of them.
+RATELIMIT_TRUSTED_PROXIES = ['10.0.0.0/8', '172.16.0.0/12']
 
-There is no Django `TRUSTED_PROXIES` setting in this library; proxy trust is enforced at the
-edge (your nginx / load balancer / CDN), not in application settings.
+# Or, if you never sit behind a proxy, ignore forwarded headers entirely:
+RATELIMIT_TRUST_FORWARDED_HEADERS = False
+```
+
+With `RATELIMIT_TRUSTED_PROXIES` set, a direct client's forwarded headers are ignored and a
+client cannot move the result by prepending fake chain entries.
+
+Whether or not you configure the above, your edge proxy (nginx / load balancer / CDN) should
+still **overwrite** the forwarded header with the real peer address and **strip** any
+client-supplied `X-Forwarded-For` / `X-Real-IP` / `CF-Connecting-IP` values on inbound
+requests as defense in depth.
 
 Example: nginx terminating TLS in front of the app. `proxy_set_header` replaces the value
 the upstream sees, so any client-supplied header is discarded:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-smart-ratelimit"
-version = "3.0.0"
+version = "3.1.0"
 dynamic = []
 description = "A flexible and efficient rate limiting library for Django applications"
 readme = "README.md"

--- a/tests/unit/core/test_decorator_async_algorithms.py
+++ b/tests/unit/core/test_decorator_async_algorithms.py
@@ -1,0 +1,121 @@
+"""Tests for async decorator algorithm dispatch (v3.1.0).
+
+token_bucket (and leaky_bucket on backends with native support) are now honored
+on async views, instead of silently degrading to window counting.
+"""
+
+import logging
+
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
+
+from django_smart_ratelimit import rate_limit
+from django_smart_ratelimit.backends import clear_backend_cache
+from django_smart_ratelimit.decorator import _run_bucket_check
+
+MEMORY = "django_smart_ratelimit.backends.memory.MemoryBackend"
+
+
+def _req(ip="9.9.9.9"):
+    req = RequestFactory().get("/")
+    req.META["REMOTE_ADDR"] = ip
+    return req
+
+
+@override_settings(RATELIMIT_BACKEND=MEMORY)
+async def test_async_token_bucket_uses_bucket_semantics():
+    # rate is 2/m but the bucket holds 5 with no refill. Window counting would
+    # block after 2; getting 5 through proves the token-bucket path was used.
+    clear_backend_cache()
+    try:
+
+        @rate_limit(
+            key="ip",
+            rate="2/m",
+            algorithm="token_bucket",
+            algorithm_config={"bucket_size": 5, "refill_rate": 0},
+            block=True,
+        )
+        async def view(request):
+            return HttpResponse("ok")
+
+        for i in range(5):
+            resp = await view(_req())
+            assert resp.status_code == 200, f"request {i + 1} should pass"
+        # Bucket now empty (no refill) -> blocked.
+        assert (await view(_req())).status_code == 429
+    finally:
+        clear_backend_cache()
+
+
+@override_settings(RATELIMIT_BACKEND=MEMORY)
+async def test_async_token_bucket_sets_headers():
+    clear_backend_cache()
+    try:
+
+        @rate_limit(
+            key="ip",
+            rate="10/m",
+            algorithm="token_bucket",
+            algorithm_config={"bucket_size": 10, "refill_rate": 1},
+            block=True,
+        )
+        async def view(request):
+            return HttpResponse("ok")
+
+        resp = await view(_req())
+        assert resp.status_code == 200
+        assert "X-RateLimit-Limit" in resp.headers
+        assert "X-RateLimit-Remaining" in resp.headers
+    finally:
+        clear_backend_cache()
+
+
+@override_settings(RATELIMIT_BACKEND=MEMORY)
+async def test_async_leaky_bucket_falls_back_to_window(caplog):
+    # Memory has no native leaky_bucket_check -> warn + standard window limiting.
+    clear_backend_cache()
+    try:
+
+        @rate_limit(key="ip", rate="2/m", algorithm="leaky_bucket", block=True)
+        async def view(request):
+            return HttpResponse("ok")
+
+        with caplog.at_level(logging.WARNING):
+            assert (await view(_req())).status_code == 200
+            assert (await view(_req())).status_code == 200
+            # Window limit of 2 reached -> blocked.
+            assert (await view(_req())).status_code == 429
+        assert any("leaky_bucket" in r.message for r in caplog.records)
+    finally:
+        clear_backend_cache()
+
+
+class _FakeBucketBackend:
+    """Minimal backend exposing native bucket checks for _run_bucket_check."""
+
+    def token_bucket_check(self, key, bucket_size, refill_rate, initial, requested):
+        return True, {"tokens_remaining": 4, "bucket_size": bucket_size}
+
+    def leaky_bucket_check(self, key, capacity, leak_rate, cost):
+        return True, {"space_remaining": 7, "bucket_capacity": capacity}
+
+
+def test_run_bucket_check_token():
+    backend = _FakeBucketBackend()
+    allowed, metadata, remaining = _run_bucket_check(
+        "token_bucket", backend, "k", 10, 60, 1, None
+    )
+    assert allowed is True
+    assert remaining == 4
+    assert metadata["tokens_remaining"] == 4
+
+
+def test_run_bucket_check_leaky():
+    backend = _FakeBucketBackend()
+    allowed, metadata, remaining = _run_bucket_check(
+        "leaky_bucket", backend, "k", 10, 60, 1, None
+    )
+    assert allowed is True
+    assert remaining == 7
+    assert metadata["space_remaining"] == 7

--- a/tests/unit/core/test_trusted_proxy.py
+++ b/tests/unit/core/test_trusted_proxy.py
@@ -1,0 +1,83 @@
+"""Tests for proxy-trust-aware client IP extraction (v3.1.0)."""
+
+from django.test import RequestFactory, TestCase, override_settings
+
+from django_smart_ratelimit.key_functions import get_ip_key
+from django_smart_ratelimit.policy import get_client_ip
+from django_smart_ratelimit.policy.lists import IPList, check_lists
+
+
+def _req(remote, xff=None, cf=None, real=None):
+    req = RequestFactory().get("/")
+    req.META["REMOTE_ADDR"] = remote
+    if xff is not None:
+        req.META["HTTP_X_FORWARDED_FOR"] = xff
+    if cf is not None:
+        req.META["HTTP_CF_CONNECTING_IP"] = cf
+    if real is not None:
+        req.META["HTTP_X_REAL_IP"] = real
+    return req
+
+
+class DefaultBehaviorTests(TestCase):
+    """No proxy config: forwarded headers are trusted (backward compatible)."""
+
+    def test_xff_leftmost_is_trusted(self):
+        assert get_client_ip(_req("10.0.0.1", xff="1.2.3.4, 10.0.0.1")) == "1.2.3.4"
+
+    def test_cf_header_takes_precedence(self):
+        assert get_client_ip(_req("10.0.0.1", xff="1.2.3.4", cf="9.9.9.9")) == "9.9.9.9"
+
+    def test_falls_back_to_remote_addr(self):
+        assert get_client_ip(_req("203.0.113.7")) == "203.0.113.7"
+
+    def test_get_ip_key_uses_extractor(self):
+        assert get_ip_key(_req("10.0.0.1", xff="1.2.3.4")) == "ip:1.2.3.4"
+
+
+@override_settings(RATELIMIT_TRUST_FORWARDED_HEADERS=False)
+class TrustDisabledTests(TestCase):
+    """Forwarded headers ignored entirely."""
+
+    def test_remote_addr_only(self):
+        assert get_client_ip(_req("203.0.113.7", xff="1.2.3.4")) == "203.0.113.7"
+
+    def test_get_ip_key_remote_addr_only(self):
+        assert get_ip_key(_req("203.0.113.7", xff="1.2.3.4")) == "ip:203.0.113.7"
+
+
+@override_settings(RATELIMIT_TRUSTED_PROXIES=["10.0.0.0/8"])
+class TrustedProxyTests(TestCase):
+    """Secure mode: forwarded headers honored only from trusted proxies."""
+
+    def test_real_client_from_chain(self):
+        # Request arrives from a trusted proxy (10.0.0.5); the real client is
+        # the right-most non-trusted entry of the chain.
+        assert get_client_ip(_req("10.0.0.5", xff="1.2.3.4, 10.0.0.9")) == "1.2.3.4"
+
+    def test_spoofed_prepended_entry_is_ignored(self):
+        # A client prepending a fake entry cannot move the result: the
+        # right-most non-trusted hop is still the real client.
+        assert (
+            get_client_ip(_req("10.0.0.5", xff="6.6.6.6, 1.2.3.4, 10.0.0.9"))
+            == "1.2.3.4"
+        )
+
+    def test_direct_client_cannot_spoof(self):
+        # Request did NOT come from a trusted proxy: forwarded headers are
+        # ignored and REMOTE_ADDR is authoritative.
+        assert get_client_ip(_req("203.0.113.7", xff="1.2.3.4")) == "203.0.113.7"
+
+    def test_all_hops_trusted_returns_leftmost(self):
+        assert get_client_ip(_req("10.0.0.5", xff="10.0.0.1, 10.0.0.9")) == "10.0.0.1"
+
+    def test_allow_list_bypass_is_prevented(self):
+        # The motivating security case: a deny-listed direct client tries to
+        # spoof an allow-listed IP via X-Forwarded-For. With trusted proxies
+        # configured, the spoof is ignored and the deny list still applies.
+        allow = IPList(["192.168.1.0/24"])
+        deny = IPList(["203.0.113.7"])
+        request = _req("203.0.113.7", xff="192.168.1.50")
+        should_skip, reason = check_lists(request, allow_list=allow, deny_list=deny)
+        assert reason == "deny_list"
+        assert should_skip is False


### PR DESCRIPTION
## v3.1.0 — follow-ups from the v3.0.0 review

Two follow-ups identified (and documented as known limitations) during the
v3.0.0 hardening pass, now implemented with tests. Full suite: **1198 passed**,
mypy and pre-commit clean.

### 1. Configurable proxy trust for client IP extraction (security)

IP-based keys and the CIDR allow/deny lists previously trusted forwarded headers
(`X-Forwarded-For`, `CF-Connecting-IP`, `X-Real-IP`) unconditionally, so a direct
client could spoof its IP to bypass an allow-list or evade a deny-list.

- New settings: `RATELIMIT_TRUSTED_PROXIES` (list of IP/CIDR strings) and
  `RATELIMIT_TRUST_FORWARDED_HEADERS` (bool).
- A single `django_smart_ratelimit.policy.get_client_ip(request)` helper now
  backs both `get_ip_key` and the CIDR allow/deny lists, so the rate-limit key
  and the policy lists always agree on the client IP.
- When `RATELIMIT_TRUSTED_PROXIES` is set, forwarded headers are honored only for
  requests arriving from a trusted proxy, and the client is the right-most
  non-trusted entry of the `X-Forwarded-For` chain — spoof-prepend resistant, and
  a direct (non-proxied) client's forwarded headers are ignored.
- **Default behavior is unchanged / backward compatible**: forwarded headers are
  trusted until you opt in.

### 2. Async support for token bucket and leaky bucket

`@rate_limit(..., algorithm="token_bucket")` on an `async def` view previously
fell back to window counting silently. Now the async path runs the algorithm
check off the event loop via `sync_to_async`, so async views get true bucket
semantics. `leaky_bucket` is honored on backends with native support (database
backend); on others it warns and falls back to window limiting. The standalone
`@aratelimit` decorator is unchanged (window only).

### Tests
- 11 trusted-proxy tests (all four trust modes + the allow/deny bypass case).
- 5 async-algorithm tests (bucket semantics, header emission, leaky fallback,
  and `_run_bucket_check`).

### Docs
- `configuration.md` (new Client IP / Proxy Trust section), `deployment.md`
  (updated trusted-proxy guidance), `decorator.md` / `algorithms.md` (async
  algorithm support), and the `CHANGELOG.md` `[3.1.0]` entry. Version bumped to
  3.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
