### PR TITLE
v4.0.1: fix Redis token bucket with refill_rate=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - 2026-05-30
+
+### Fixed
+
+- **Redis token bucket with `refill_rate=0`.** The native Redis Lua script
+  computed the key TTL as `bucket_size / refill_rate`, which is infinite when
+  `refill_rate=0` (a never-refilling bucket — a valid config the memory and
+  database backends already handle). Redis then raised "value is not an integer
+  or out of range" on `EXPIRE`, and the decorator silently fell back to window
+  counting. The script now uses a fixed TTL and avoids the divide-by-zero. Found
+  via a manual cross-backend sweep of the token-bucket feature.
+
 ## [4.0.0] - 2026-05-30
 
 A consolidation release that pays down accumulated debt surfaced by a full-repo

--- a/django_smart_ratelimit/__init__.py
+++ b/django_smart_ratelimit/__init__.py
@@ -5,7 +5,7 @@ with support for multiple backends, algorithms (including token bucket),
 and comprehensive rate limiting strategies.
 """
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 __author__ = "Yasser Shkeir"
 
 # Optional backend imports (may not be available)

--- a/django_smart_ratelimit/backends/redis_backend.py
+++ b/django_smart_ratelimit/backends/redis_backend.py
@@ -116,32 +116,44 @@ class RedisBackend(BaseBackend):
         local tokens_to_add = time_elapsed * refill_rate
         current_tokens = math.min(bucket_size, current_tokens + tokens_to_add)
 
+        -- Expiration: time for a full refill + buffer. A non-positive
+        -- refill_rate means the bucket never refills; use a fixed TTL and do
+        -- NOT divide by zero (which yields inf and a Redis "value is not an
+        -- integer or out of range" error on EXPIRE).
+        local expiration
+        if refill_rate > 0 then
+            expiration = math.ceil(bucket_size / refill_rate) + 60
+        else
+            expiration = 3600
+        end
+
         -- Check if request can be served
         if current_tokens >= tokens_requested then
             -- Consume tokens
             local remaining_tokens = current_tokens - tokens_requested
             redis.call('HMSET', key, 'tokens', remaining_tokens, 'last_refill',
                       current_time)
-
-            -- Set expiration (bucket expires after it could be completely
-            -- refilled + buffer)
-            local expiration = math.ceil(bucket_size / refill_rate) + 60
             redis.call('EXPIRE', key, expiration)
 
-            -- Return success with metadata
-            return {1, remaining_tokens, bucket_size, refill_rate,
-                   (bucket_size - remaining_tokens) / refill_rate}
+            -- Return success with metadata (time_to_refill is 0 when the
+            -- bucket does not refill).
+            local time_to_refill = 0
+            if refill_rate > 0 then
+                time_to_refill = (bucket_size - remaining_tokens) / refill_rate
+            end
+            return {1, remaining_tokens, bucket_size, refill_rate, time_to_refill}
         else
             -- Update last_refill time even if request is denied
             redis.call('HMSET', key, 'tokens', current_tokens, 'last_refill',
                       current_time)
-
-            local expiration = math.ceil(bucket_size / refill_rate) + 60
             redis.call('EXPIRE', key, expiration)
 
             -- Return failure with metadata
-            return {0, current_tokens, bucket_size, refill_rate,
-                   (tokens_requested - current_tokens) / refill_rate}
+            local time_to_refill = 0
+            if refill_rate > 0 then
+                time_to_refill = (tokens_requested - current_tokens) / refill_rate
+            end
+            return {0, current_tokens, bucket_size, refill_rate, time_to_refill}
         end
     """  # nosec B105
 
@@ -162,9 +174,13 @@ class RedisBackend(BaseBackend):
         local tokens_to_add = time_elapsed * refill_rate
         current_tokens = math.min(bucket_size, current_tokens + tokens_to_add)
 
-        -- Return current state
-        return {current_tokens, bucket_size, refill_rate,
-               math.max(0, (bucket_size - current_tokens) / refill_rate), last_refill}
+        -- Return current state (time_to_refill is 0 when the bucket does not
+        -- refill, avoiding a divide-by-zero / inf metadata value).
+        local time_to_refill = 0
+        if refill_rate > 0 then
+            time_to_refill = math.max(0, (bucket_size - current_tokens) / refill_rate)
+        end
+        return {current_tokens, bucket_size, refill_rate, time_to_refill, last_refill}
     """  # nosec B105
 
     def __init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-smart-ratelimit"
-version = "4.0.0"
+version = "4.0.1"
 dynamic = []
 description = "A flexible and efficient rate limiting library for Django applications"
 readme = "README.md"

--- a/tests/integration/test_redis_token_bucket_refill.py
+++ b/tests/integration/test_redis_token_bucket_refill.py
@@ -1,0 +1,72 @@
+"""Live-Redis regression: token bucket with refill_rate=0 (never refill).
+
+The native Redis Lua script used to compute the key expiration as
+``bucket_size / refill_rate``, which is ``inf`` when refill_rate=0 and made
+Redis raise "value is not an integer or out of range" on EXPIRE. The token
+bucket then silently fell back to window counting. These tests run against a
+real Redis (the mock-based unit tests cannot exercise the Lua script).
+"""
+
+import pytest
+
+from django.test import override_settings
+
+from django_smart_ratelimit.backends import clear_backend_cache, get_backend
+
+
+def _redis_available():
+    try:
+        import redis as _redis
+    except ImportError:
+        return False
+    try:
+        _redis.Redis(host="localhost", port=6379, db=0).ping()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _redis_available(), reason="live Redis not available"
+)
+
+
+@override_settings(
+    RATELIMIT_BACKEND="redis",
+    RATELIMIT_REDIS={"host": "localhost", "port": 6379, "db": 0},
+)
+def test_redis_token_bucket_refill_rate_zero_native():
+    clear_backend_cache()
+    backend = get_backend()
+    backend.redis.delete("ratelimit:rrtest:token_bucket")
+    # bucket_size=3, refill_rate=0 -> exactly 3 allowed, then denied, with no
+    # Lua error and no window fallback.
+    results = [
+        backend.token_bucket_check(
+            "rrtest",
+            bucket_size=3,
+            refill_rate=0.0,
+            initial_tokens=3,
+            tokens_requested=1,
+        )[0]
+        for _ in range(4)
+    ]
+    assert results == [True, True, True, False], results
+    clear_backend_cache()
+
+
+@override_settings(
+    RATELIMIT_BACKEND="redis",
+    RATELIMIT_REDIS={"host": "localhost", "port": 6379, "db": 0},
+)
+def test_redis_token_bucket_info_refill_rate_zero():
+    clear_backend_cache()
+    backend = get_backend()
+    backend.redis.delete("ratelimit:rrinfo:token_bucket")
+    backend.token_bucket_check(
+        "rrinfo", bucket_size=5, refill_rate=0.0, initial_tokens=5, tokens_requested=1
+    )
+    info = backend.token_bucket_info("rrinfo", bucket_size=5, refill_rate=0.0)
+    # No inf/error; time_to_refill is a finite number.
+    assert info["time_to_refill"] in (0, 0.0)
+    clear_backend_cache()


### PR DESCRIPTION
## v4.0.1 — patch

Found by the manual cross-backend feature sweep requested after v4.0.0 shipped.

**Bug:** the native Redis token-bucket Lua script computed the key TTL as
`bucket_size / refill_rate`, which is infinite when `refill_rate=0` (a valid
"never refill" config that the **memory** and **database** backends already
handle correctly). Redis raised `value is not an integer or out of range` on
`EXPIRE`, the throttle errored, and the decorator silently **fell back to window
counting** — so `@rate_limit(algorithm="token_bucket", algorithm_config={"refill_rate": 0})`
enforced the wrong limit on Redis only.

**Fix:** use a fixed TTL when `refill_rate <= 0` and guard the divide-by-zero in
both the consume and info Lua scripts. Adds a **live-Redis** regression test
(the existing token-bucket unit tests use a mock that can't execute Lua, which
is why this slipped through).

mongodb does not implement native token bucket at all (pre-existing, separate
limitation); database and memory were already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)