### PR TITLE
v4.0.2: real-backend e2e suite + MongoDB reset-time and Redis reset() fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.2] - 2026-05-31
+
+### Fixed
+
+- **MongoDB `get_reset_time()` returned a wrong epoch on non-UTC hosts.** PyMongo
+  reads stored datetimes back as naive (UTC) values; calling `.timestamp()` on a
+  naive datetime makes Python assume the host's *local* timezone, skewing the
+  result by the host's UTC offset. The `X-RateLimit-Reset` header and the DRF
+  throttle `Retry-After` were therefore off by hours whenever the server's clock
+  was not set to UTC. The value is now made UTC-aware before conversion. (The
+  existing window-expiry comparison already used the UTC-aware helper, so only
+  the returned timestamp was affected.)
+- **Redis `reset()` did not clear fixed-window or token-bucket keys.** Clock-
+  aligned fixed-window counters are stored at `<key>:<bucket>` and token buckets
+  at `<key>:token_bucket`, but `reset()` deleted only the bare key, so a reset
+  left those counters in place. It now also scans and deletes the suffixed key
+  family. (Sliding-window keys, stored under the bare key, were already cleared.)
+
+Both bugs were surfaced by the new real-backend end-to-end suite (`tests/e2e/`),
+which exercises every public-usage API against live Redis, MongoDB, and the test
+database — no backend mocking — across all four algorithms. Mock-based unit tests
+could not have caught either, since neither the timezone round-trip nor the real
+key layout is exercised against a mock.
+
 ## [4.0.1] - 2026-05-30
 
 ### Fixed

--- a/django_smart_ratelimit/__init__.py
+++ b/django_smart_ratelimit/__init__.py
@@ -5,7 +5,7 @@ with support for multiple backends, algorithms (including token bucket),
 and comprehensive rate limiting strategies.
 """
 
-__version__ = "4.0.1"
+__version__ = "4.0.2"
 __author__ = "Yasser Shkeir"
 
 # Optional backend imports (may not be available)

--- a/django_smart_ratelimit/backends/mongodb.py
+++ b/django_smart_ratelimit/backends/mongodb.py
@@ -423,7 +423,12 @@ class MongoDBBackend(BaseBackend):
                     and self._ensure_utc_aware(counter["window_end"])
                     > get_current_datetime()
                 ):
-                    return int(counter["window_end"].timestamp())
+                    # PyMongo returns naive (UTC) datetimes; make them UTC-aware
+                    # before .timestamp() so the epoch is correct on hosts whose
+                    # local timezone is not UTC.
+                    return int(
+                        self._ensure_utc_aware(counter["window_end"]).timestamp()
+                    )
                 return None
             else:
                 # For sliding window, find the earliest expiry time
@@ -436,7 +441,7 @@ class MongoDBBackend(BaseBackend):
                     and self._ensure_utc_aware(entry["expires_at"])
                     > get_current_datetime()
                 ):
-                    return int(entry["expires_at"].timestamp())
+                    return int(self._ensure_utc_aware(entry["expires_at"]).timestamp())
                 return None
         except Exception as e:
             logger.error(f"Error getting reset time for key {key}: {e}")

--- a/django_smart_ratelimit/backends/redis_backend.py
+++ b/django_smart_ratelimit/backends/redis_backend.py
@@ -502,7 +502,7 @@ class RedisBackend(BaseBackend):
             try:
                 keys_to_delete.extend(self.redis.scan_iter(match=f"{normalized_key}:*"))
             except Exception:  # pragma: no cover - scan unsupported (e.g. mocks)
-                pass
+                pass  # nosec B110 - best-effort; bare key still deleted below
             self.redis.delete(*keys_to_delete)
             log_backend_operation(
                 "redis_reset",

--- a/django_smart_ratelimit/backends/redis_backend.py
+++ b/django_smart_ratelimit/backends/redis_backend.py
@@ -494,7 +494,16 @@ class RedisBackend(BaseBackend):
 
         start_time = get_current_timestamp()
         try:
-            self.redis.delete(normalized_key)
+            # Delete the bare key (sliding-window ZSET) plus any suffixed keys:
+            # clock-aligned fixed-window counters live at "<key>:<bucket>" and
+            # token buckets at "<key>:token_bucket", so a bare delete would not
+            # actually clear them. Scan + delete the whole family.
+            keys_to_delete = [normalized_key]
+            try:
+                keys_to_delete.extend(self.redis.scan_iter(match=f"{normalized_key}:*"))
+            except Exception:  # pragma: no cover - scan unsupported (e.g. mocks)
+                pass
+            self.redis.delete(*keys_to_delete)
             log_backend_operation(
                 "redis_reset",
                 f"Reset key {key}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-smart-ratelimit"
-version = "4.0.1"
+version = "4.0.2"
 dynamic = []
 description = "A flexible and efficient rate limiting library for Django applications"
 readme = "README.md"
@@ -150,6 +150,7 @@ markers = [
     "integration: marks tests as integration tests",
     "unit: marks tests as unit tests",
     "asyncio: marks tests as async tests",
+    "e2e: real-backend end-to-end scenario tests (live Redis/Mongo/DB)",
 ]
 
 [tool.coverage.run]

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""Real-backend end-to-end tests (live Redis/Mongo/DB, no mocks)."""

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,236 @@
+"""Shared harness for real-backend end-to-end tests.
+
+These tests exercise the public API against REAL storage (a live Redis, a live
+MongoDB, and the real Django test database) — no backend mocking. Each backend
+is skipped gracefully when its service is unavailable, so the suite is runnable
+anywhere while running in full in CI (where Redis/Mongo service containers and
+the test DB are present).
+
+Helpers:
+    - ``real_backend`` fixture: parametrizes a test over every AVAILABLE
+      non-database backend (memory, redis, async_redis, mongodb), applying the
+      backend setting, clearing the cache, and flushing the real store before
+      and after each test. Yields the backend's short name.
+    - ``use_backend(name)``: a context manager for explicit/per-scenario backend
+      selection (use this for the database backend together with
+      ``@pytest.mark.django_db``).
+    - ``make_request(...)`` / ``AuthedUser`` / ``AnonUser``: build realistic
+      Django requests.
+    - ``exhaust(view, n, ...)``: drive a view/callable n times and collect codes.
+"""
+
+from contextlib import contextmanager
+
+import pytest
+
+from django.test import RequestFactory, override_settings
+
+from django_smart_ratelimit.backends import clear_backend_cache, get_backend
+
+MEMORY = "django_smart_ratelimit.backends.memory.MemoryBackend"
+REDIS = "django_smart_ratelimit.backends.redis_backend.RedisBackend"
+ASYNC_REDIS = "django_smart_ratelimit.backends.redis_backend.AsyncRedisBackend"
+MONGODB = "django_smart_ratelimit.backends.mongodb.MongoDBBackend"
+DATABASE = "django_smart_ratelimit.backends.database.DatabaseBackend"
+
+REDIS_HOST = "localhost"
+REDIS_PORT = 6379
+MONGO_HOST = "localhost"
+MONGO_PORT = 27017
+
+
+def redis_available():
+    try:
+        import redis as _redis
+
+        _redis.Redis(host=REDIS_HOST, port=REDIS_PORT, db=0).ping()
+        return True
+    except Exception:
+        return False
+
+
+def mongo_available():
+    try:
+        from pymongo import MongoClient
+
+        MongoClient(
+            host=MONGO_HOST, port=MONGO_PORT, serverSelectionTimeoutMS=800
+        ).admin.command("ping")
+        return True
+    except Exception:
+        return False
+
+
+REDIS_UP = redis_available()
+MONGO_UP = mongo_available()
+
+# Mark factories so tests/files can build their own parametrizations.
+skip_without_redis = pytest.mark.skipif(not REDIS_UP, reason="live Redis unavailable")
+skip_without_mongo = pytest.mark.skipif(not MONGO_UP, reason="live MongoDB unavailable")
+
+
+def flush_store(name):
+    """Wipe the real store for a backend so each test starts clean."""
+    try:
+        if name in ("redis", "async_redis"):
+            import redis as _redis
+
+            _redis.Redis(host=REDIS_HOST, port=REDIS_PORT, db=0).flushdb()
+        elif name == "mongodb":
+            from pymongo import MongoClient
+
+            MongoClient(host=MONGO_HOST, port=MONGO_PORT).drop_database("ratelimit")
+        elif name == "memory":
+            backend = get_backend()
+            if hasattr(backend, "clear_all"):
+                backend.clear_all()
+    except Exception:
+        pass
+
+
+# (short name, dotted path, settings overrides) wrapped as pytest params.
+_REDIS_CFG = {"RATELIMIT_REDIS": {"host": REDIS_HOST, "port": REDIS_PORT, "db": 0}}
+_MONGO_CFG = {
+    "RATELIMIT_MONGODB": {
+        "host": MONGO_HOST,
+        "port": MONGO_PORT,
+        "database": "ratelimit",
+    }
+}
+
+_P_MEMORY = pytest.param(("memory", MEMORY, {}), id="memory")
+_P_REDIS = pytest.param(
+    ("redis", REDIS, _REDIS_CFG), id="redis", marks=skip_without_redis
+)
+_P_ASYNC_REDIS = pytest.param(
+    ("async_redis", ASYNC_REDIS, _REDIS_CFG), id="async_redis", marks=skip_without_redis
+)
+_P_MONGO = pytest.param(
+    ("mongodb", MONGODB, _MONGO_CFG), id="mongodb", marks=skip_without_mongo
+)
+
+# Backends usable through the SYNCHRONOUS API. AsyncRedisBackend is async-only
+# (its sync incr/get_count raise NotImplementedError, directing callers to the
+# a* methods), so it is excluded here and covered by ``async_real_backend``.
+_SYNC_BACKENDS = [_P_MEMORY, _P_REDIS, _P_MONGO]
+# All backends including the async-only redis backend, for async-path tests.
+_ASYNC_BACKENDS = [_P_MEMORY, _P_REDIS, _P_ASYNC_REDIS, _P_MONGO]
+# Backends with a NATIVE token/leaky-bucket implementation. MongoDB has none
+# (it raises NotImplementedError and the decorator falls back to window
+# counting), so bucket-semantics assertions must not run against it.
+_NATIVE_BUCKET_BACKENDS = [_P_MEMORY, _P_REDIS]
+
+
+@contextmanager
+def use_backend(name):
+    """Select a backend by short name for the duration of the block.
+
+    Applies RATELIMIT_BACKEND (+ store config) via override_settings, clears the
+    backend cache, flushes the real store on entry and exit.
+    """
+    paths = {
+        "memory": (MEMORY, {}),
+        "redis": (
+            REDIS,
+            {"RATELIMIT_REDIS": {"host": REDIS_HOST, "port": REDIS_PORT, "db": 0}},
+        ),
+        "async_redis": (
+            ASYNC_REDIS,
+            {"RATELIMIT_REDIS": {"host": REDIS_HOST, "port": REDIS_PORT, "db": 0}},
+        ),
+        "mongodb": (
+            MONGODB,
+            {
+                "RATELIMIT_MONGODB": {
+                    "host": MONGO_HOST,
+                    "port": MONGO_PORT,
+                    "database": "ratelimit",
+                }
+            },
+        ),
+        "database": (DATABASE, {}),
+    }
+    path, extra = paths[name]
+    ov = override_settings(RATELIMIT_BACKEND=path, **extra)
+    ov.enable()
+    clear_backend_cache()
+    flush_store(name)
+    try:
+        yield name
+    finally:
+        clear_backend_cache()
+        flush_store(name)
+        ov.disable()
+
+
+@pytest.fixture(params=_SYNC_BACKENDS)
+def real_backend(request):
+    """Parametrize over every available sync-capable backend (memory/redis/mongodb)."""
+    name, path, extra = request.param
+    with use_backend(name):
+        yield name
+
+
+@pytest.fixture(params=_ASYNC_BACKENDS)
+def async_real_backend(request):
+    """Parametrize over backends for async-path tests (adds async_redis)."""
+    name, path, extra = request.param
+    with use_backend(name):
+        yield name
+
+
+@pytest.fixture(params=_NATIVE_BUCKET_BACKENDS)
+def native_bucket_backend(request):
+    """Parametrize over backends with native token/leaky-bucket support."""
+    name, path, extra = request.param
+    with use_backend(name):
+        yield name
+
+
+class AnonUser:
+    is_authenticated = False
+    is_staff = False
+    is_superuser = False
+    id = None
+
+
+class AuthedUser:
+    is_authenticated = True
+    is_staff = False
+    is_superuser = False
+
+    def __init__(self, uid=1):
+        self.id = uid
+        self.pk = uid
+
+
+def make_request(
+    ip="203.0.113.10", method="get", user=None, headers=None, params=None, path="/"
+):
+    """Build a realistic Django request with a client IP and (optional) user."""
+    rf = RequestFactory()
+    query = (
+        "?" + "&".join(f"{k}={v}" for k, v in (params or {}).items()) if params else ""
+    )
+    req = getattr(rf, method.lower())(path + query)
+    req.META["REMOTE_ADDR"] = ip
+    for hk, hv in (headers or {}).items():
+        req.META["HTTP_" + hk.upper().replace("-", "_")] = hv
+    req.user = user if user is not None else AnonUser()
+    return req
+
+
+def exhaust(callable_view, n, ip="203.0.113.10", **kwargs):
+    """Call a view n times (each a fresh request from the same IP); return codes."""
+    codes = []
+    for _ in range(n):
+        resp = callable_view(make_request(ip=ip, **kwargs))
+        codes.append(getattr(resp, "status_code", resp))
+    return codes
+
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-mark everything under tests/e2e/ with the ``e2e`` marker."""
+    for item in items:
+        if "/tests/e2e/" in str(item.fspath).replace("\\", "/"):
+            item.add_marker(pytest.mark.e2e)

--- a/tests/e2e/test_algorithms_e2e.py
+++ b/tests/e2e/test_algorithms_e2e.py
@@ -1,0 +1,484 @@
+"""Real-backend end-to-end scenarios for the four rate-limit algorithms.
+
+Each test drives the public ``@rate_limit`` decorator against a REAL store
+(live Redis, live MongoDB, the in-process memory backend, or the real Django
+test database) — never a mock. Scenarios are written from a real-life angle:
+a bursty client vs a steady client, an API key allowed to burst then throttled,
+a never-refill quota bucket, a smoothly-draining leaky bucket, etc.
+
+Coverage map (by algorithm / option):
+
+* sliding_window  — rolling window blocks-after-N; independent buckets per key;
+  the window slides (old hits age out) rather than resetting on a hard edge.
+* fixed_window    — clock-aligned counting; ``get_count``/``reset`` correctness
+  read back off the real store; rollover at the clock boundary.
+* token_bucket    — burst up to ``bucket_size`` then block; refill over time;
+  ``initial_tokens`` (cold start empty/partial); ``tokens_per_request`` weight;
+  ``refill_rate=0`` never-refill quota edge (asserted to truly never refill on
+  Redis, i.e. NOT a silent window fallback); per-key isolation; bucket headers.
+* leaky_bucket    — database backend via ``use_backend('database')``: smooth
+  drain at ``leak_rate``, ``bucket_capacity`` overflow, ``cost_per_request``
+  weighting, per-key isolation.
+
+The ``real_backend`` fixture flushes the store and sets fresh state before and
+after every test, and every test uses DISTINCT IPs/keys, so tests never depend
+on one another.
+"""
+
+import time
+
+import pytest
+
+from django.http import HttpResponse, JsonResponse
+from django.test import override_settings
+
+from django_smart_ratelimit import rate_limit
+from django_smart_ratelimit.backends import clear_backend_cache, get_backend
+from django_smart_ratelimit.enums import Algorithm
+
+from .conftest import (
+    exhaust,
+    make_request,
+    use_backend,
+)
+
+# ``real_backend`` / ``native_bucket_backend`` are pytest fixtures from
+# conftest.py; they are auto-discovered by name when used as test parameters,
+# so they need no explicit import here.
+
+# ---------------------------------------------------------------------------
+# Small view factories. Each returns a fresh decorated view so a test's bucket
+# state lives only on the real store, not in any decorator-level cache.
+# ---------------------------------------------------------------------------
+
+
+def _ok_view(**decorator_kwargs):
+    """Build a JSON view wrapped with @rate_limit(**decorator_kwargs)."""
+
+    @rate_limit(**decorator_kwargs)
+    def view(_request):
+        return JsonResponse({"ok": True})
+
+    return view
+
+
+def _hdr_view(**decorator_kwargs):
+    """Build a plain HttpResponse view (carries .headers for assertions)."""
+
+    @rate_limit(**decorator_kwargs)
+    def view(_request):
+        return HttpResponse("ok")
+
+    return view
+
+
+def _set_backend_algorithm(algorithm):
+    """Pin the backend's *counting* algorithm and rebuild the cached backend.
+
+    The standard sliding/fixed window path counts according to the backend's
+    own ``_algorithm`` attribute, which is read from ``RATELIMIT_ALGORITHM`` at
+    construction time (the decorator's ``algorithm=`` arg only routes the
+    bucket algorithms). Tests that assert ``get_count``/``reset`` semantics on
+    the real store must therefore set the setting and force a fresh backend.
+    """
+    ov = override_settings(RATELIMIT_ALGORITHM=str(algorithm))
+    ov.enable()
+    clear_backend_cache()
+    return ov
+
+
+# ===========================================================================
+# SLIDING WINDOW
+# ===========================================================================
+
+
+def test_sliding_window_blocks_after_n_and_isolates_keys(real_backend):
+    """Sliding window 3/min per IP.
+
+    A single client hammering one IP gets exactly 3 OKs then 429s, while a
+    second client on a different IP is completely unaffected (independent
+    buckets keyed by IP). Verified on every real backend.
+    """
+    view = _ok_view(key="ip", rate="3/m", algorithm=Algorithm.SLIDING_WINDOW)
+
+    attacker = exhaust(view, 5, ip="198.51.100.1")
+    assert attacker == [200, 200, 200, 429, 429]
+
+    # A different IP shares nothing with the throttled one.
+    legit = exhaust(view, 3, ip="198.51.100.2")
+    assert legit == [200, 200, 200]
+
+
+def test_sliding_window_rolls_off_old_hits(real_backend):
+    """Sliding window 2/2s: the window genuinely slides.
+
+    Fill the window, get blocked, then wait just past the window and confirm
+    the oldest hits have aged out so requests are allowed again — i.e. it is a
+    rolling window on the real store, not a hard fixed reset.
+    """
+    view = _ok_view(key="ip", rate="2/2s", algorithm=Algorithm.SLIDING_WINDOW)
+    ip = "198.51.100.3"
+
+    assert exhaust(view, 3, ip=ip) == [200, 200, 429]
+    time.sleep(2.2)
+    # Old entries have slid out of the 2s window; budget is available again.
+    assert exhaust(view, 2, ip=ip) == [200, 200]
+
+
+def test_sliding_window_per_user_bucket(real_backend):
+    """Sliding window 2/min keyed by user id.
+
+    Two authenticated users each get their own 2/min budget regardless of the
+    shared client IP — the key template ``user:{user.id}`` isolates them.
+    """
+    from .conftest import AuthedUser
+
+    view = _ok_view(
+        key="user:{user.id}", rate="2/m", algorithm=Algorithm.SLIDING_WINDOW
+    )
+
+    u1 = AuthedUser(uid=8001)
+    u2 = AuthedUser(uid=8002)
+    shared_ip = "198.51.100.4"
+
+    codes_u1 = [view(make_request(ip=shared_ip, user=u1)).status_code for _ in range(3)]
+    codes_u2 = [view(make_request(ip=shared_ip, user=u2)).status_code for _ in range(3)]
+    assert codes_u1 == [200, 200, 429]
+    assert codes_u2 == [200, 200, 429]
+
+
+# ===========================================================================
+# FIXED WINDOW
+# ===========================================================================
+
+
+def test_fixed_window_blocks_after_n_and_isolates_keys(real_backend):
+    """Fixed window 3/min per IP.
+
+    Backend pinned to fixed_window counting. One IP gets 3 OKs then 429s; a
+    different IP is unaffected. Exercised on every real backend.
+    """
+    ov = _set_backend_algorithm(Algorithm.FIXED_WINDOW)
+    try:
+        view = _ok_view(key="ip", rate="3/m", algorithm=Algorithm.FIXED_WINDOW)
+        assert exhaust(view, 5, ip="203.0.113.21") == [200, 200, 200, 429, 429]
+        assert exhaust(view, 3, ip="203.0.113.22") == [200, 200, 200]
+    finally:
+        ov.disable()
+        clear_backend_cache()
+
+
+def test_fixed_window_get_count_and_reset_on_real_store(real_backend):
+    """Fixed window get_count/reset round-trips against the real store.
+
+    Drive a fixed-window view a few times, then read the live counter back via
+    the backend's ``get_count`` (clock-aligned key) and assert it matches the
+    number of requests. Then ``reset`` the key on the real store and confirm
+    the count is wiped and the budget is fresh again.
+    """
+    ov = _set_backend_algorithm(Algorithm.FIXED_WINDOW)
+    try:
+        key = "ip:203.0.113.23"
+        view = _ok_view(key="ip", rate="5/m", algorithm=Algorithm.FIXED_WINDOW)
+
+        assert exhaust(view, 3, ip="203.0.113.23") == [200, 200, 200]
+
+        backend = get_backend()
+        # The live counter reflects exactly the requests we made.
+        assert backend.get_count(key, period=60) == 3
+
+        # Reset wipes the real counter; a subsequent read sees zero and the
+        # full budget is available again.
+        backend.reset(key)
+        assert backend.get_count(key, period=60) == 0
+        assert exhaust(view, 5, ip="203.0.113.23") == [200, 200, 200, 200, 200]
+    finally:
+        ov.disable()
+        clear_backend_cache()
+
+
+def test_fixed_window_short_window_rolls_over(real_backend):
+    """Fixed window 2/1s: a new clock window restores the budget.
+
+    Exhaust the 1-second window, observe the block, then sleep past the next
+    clock boundary and confirm the counter has rolled over so requests pass
+    again — the canonical fixed-window reset behavior on the real store.
+    """
+    ov = _set_backend_algorithm(Algorithm.FIXED_WINDOW)
+    try:
+        view = _ok_view(key="ip", rate="2/1s", algorithm=Algorithm.FIXED_WINDOW)
+        ip = "203.0.113.24"
+        assert exhaust(view, 3, ip=ip) == [200, 200, 429]
+        # Sleep well past a 1s clock-aligned bucket boundary.
+        time.sleep(1.2)
+        assert 200 in exhaust(view, 2, ip=ip)
+    finally:
+        ov.disable()
+        clear_backend_cache()
+
+
+# ===========================================================================
+# TOKEN BUCKET
+# ===========================================================================
+
+
+def test_token_bucket_burst_then_block(native_bucket_backend):
+    """Token bucket: an API client may burst up to bucket_size, then is blocked.
+
+    Rate 2/m with bucket_size=5 and refill_rate=0 (so no tokens trickle back
+    during the test): the very first burst of 5 requests succeeds, the 6th is
+    rejected with 429. Models "allow a short burst, then throttle".
+    """
+    view = _ok_view(
+        key="ip",
+        rate="2/m",
+        algorithm=Algorithm.TOKEN_BUCKET,
+        algorithm_config={"bucket_size": 5, "refill_rate": 0},
+    )
+    codes = exhaust(view, 7, ip="192.0.2.31")
+    assert codes[:5] == [200, 200, 200, 200, 200]
+    assert codes[5:] == [429, 429]
+
+
+def test_token_bucket_refills_over_time(native_bucket_backend):
+    """Token bucket refills at refill_rate and lets traffic through again.
+
+    bucket_size=2, refill_rate=5 tokens/sec. Drain the 2 tokens (2 OK, 1
+    block), wait ~0.6s (>= 2 tokens refilled), and confirm requests succeed
+    again. Demonstrates steady-state refill on the real store.
+    """
+    view = _ok_view(
+        key="ip",
+        rate="2/s",
+        algorithm=Algorithm.TOKEN_BUCKET,
+        algorithm_config={"bucket_size": 2, "refill_rate": 5},
+    )
+    ip = "192.0.2.32"
+    assert exhaust(view, 3, ip=ip) == [200, 200, 429]
+    time.sleep(0.6)  # ~3 tokens refilled at 5/s, capped at bucket_size
+    assert exhaust(view, 2, ip=ip) == [200, 200]
+
+
+def test_token_bucket_initial_tokens_cold_start_empty(native_bucket_backend):
+    """Token bucket with initial_tokens=0 starts EMPTY (cold start).
+
+    bucket_size=5 but initial_tokens=0 and refill_rate=0: the bucket begins
+    empty, so the first request is immediately blocked even though capacity
+    exists. Models a quota that must be granted (refilled) before any use.
+    """
+    view = _ok_view(
+        key="ip",
+        rate="5/m",
+        algorithm=Algorithm.TOKEN_BUCKET,
+        algorithm_config={
+            "bucket_size": 5,
+            "initial_tokens": 0,
+            "refill_rate": 0,
+        },
+    )
+    assert exhaust(view, 2, ip="192.0.2.33") == [429, 429]
+
+
+def test_token_bucket_initial_tokens_partial(native_bucket_backend):
+    """Token bucket with a partial initial fill.
+
+    bucket_size=10, initial_tokens=2, refill_rate=0: exactly 2 requests are
+    served from the partial starting balance, then the bucket is empty.
+    """
+    view = _ok_view(
+        key="ip",
+        rate="10/m",
+        algorithm=Algorithm.TOKEN_BUCKET,
+        algorithm_config={
+            "bucket_size": 10,
+            "initial_tokens": 2,
+            "refill_rate": 0,
+        },
+    )
+    assert exhaust(view, 4, ip="192.0.2.34") == [200, 200, 429, 429]
+
+
+def test_token_bucket_weighted_cost_per_request(native_bucket_backend):
+    """Token bucket where each request costs more than one token (cost=2).
+
+    bucket_size=6, refill_rate=0, and the decorator ``cost=2`` makes every
+    request consume two tokens, so 3 requests drain the bucket and the 4th is
+    blocked. Models weighted/expensive operations consuming extra budget — this
+    is the public ``cost=`` weighting path the token bucket honors natively.
+    """
+    view = _ok_view(
+        key="ip",
+        rate="6/m",
+        algorithm=Algorithm.TOKEN_BUCKET,
+        algorithm_config={"bucket_size": 6, "refill_rate": 0},
+        cost=2,
+    )
+    assert exhaust(view, 4, ip="192.0.2.35") == [200, 200, 200, 429]
+
+
+def test_token_bucket_never_refill_quota_redis_only():
+    """refill_rate=0 is a true never-refill quota on REAL Redis.
+
+    This is the important edge: with refill_rate=0 the bucket must NEVER refill
+    and must NOT silently fall back to window counting. We assert on real Redis
+    specifically (native Lua token_bucket_check): a bucket of 3 grants exactly
+    3 lifetime requests, and after a wait that WOULD have refilled any
+    window/positive-rate bucket, the client is still blocked.
+    """
+    from .conftest import REDIS_UP
+
+    if not REDIS_UP:
+        pytest.skip("live Redis unavailable")
+
+    with use_backend("redis"):
+        # Confirm we are exercising the native atomic token-bucket path, not a
+        # generic fallback — that is the whole point of this assertion.
+        backend = get_backend()
+        assert hasattr(backend, "token_bucket_check")
+
+        view = _ok_view(
+            key="ip",
+            rate="100/s",  # period is large; refill_rate=0 overrides any drip
+            algorithm=Algorithm.TOKEN_BUCKET,
+            algorithm_config={"bucket_size": 3, "refill_rate": 0},
+        )
+        ip = "192.0.2.36"
+        assert exhaust(view, 4, ip=ip) == [200, 200, 200, 429]
+
+        # Wait long enough that a refilling bucket (or a 1s window) would have
+        # recovered. A never-refill bucket stays empty.
+        time.sleep(1.2)
+        assert exhaust(view, 2, ip=ip) == [429, 429]
+
+
+def test_token_bucket_isolated_per_api_key(native_bucket_backend):
+    """Token bucket keyed per API key: one tenant's burst doesn't starve another.
+
+    bucket_size=2, refill_rate=0, key on the X-Api-Key header. Tenant A drains
+    its bucket and gets blocked; tenant B still has its full burst available.
+    """
+    view = _ok_view(
+        key="header:X-Api-Key",
+        rate="2/m",
+        algorithm=Algorithm.TOKEN_BUCKET,
+        algorithm_config={"bucket_size": 2, "refill_rate": 0},
+    )
+
+    def hit(api_key):
+        req = make_request(ip="192.0.2.37", headers={"X-Api-Key": api_key})
+        return view(req).status_code
+
+    a = [hit("tenant-A") for _ in range(3)]
+    b = [hit("tenant-B") for _ in range(3)]
+    assert a == [200, 200, 429]
+    assert b == [200, 200, 429]
+
+
+def test_token_bucket_headers_on_allowed_response(native_bucket_backend):
+    """Allowed token-bucket responses carry bucket headers reflecting drain.
+
+    Each served request decrements X-RateLimit-Bucket-Remaining and the
+    response advertises X-RateLimit-Bucket-Size. (Blocked 429s use the generic
+    error response, so we assert the informative headers on the 2xx path.)
+    """
+    view = _hdr_view(
+        key="ip",
+        rate="4/m",
+        algorithm=Algorithm.TOKEN_BUCKET,
+        algorithm_config={"bucket_size": 4, "refill_rate": 0},
+    )
+    ip = "192.0.2.38"
+
+    r1 = view(make_request(ip=ip))
+    assert r1.status_code == 200
+    assert r1.headers["X-RateLimit-Bucket-Size"] == "4"
+    rem1 = int(r1.headers["X-RateLimit-Bucket-Remaining"])
+
+    r2 = view(make_request(ip=ip))
+    rem2 = int(r2.headers["X-RateLimit-Bucket-Remaining"])
+    # Consuming a token strictly reduces the advertised remaining tokens.
+    assert rem2 < rem1
+
+
+# ===========================================================================
+# LEAKY BUCKET  (database backend — native leaky_bucket_check)
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_leaky_bucket_capacity_then_overflow_database():
+    """Leaky bucket on the database backend: fill to capacity, then overflow.
+
+    bucket_capacity=3, leak_rate=0 (no drain during the test): the bucket
+    accepts exactly 3 requests then rejects the rest. The database backend
+    provides the native, atomic ``leaky_bucket_check`` this algorithm needs.
+    """
+    with use_backend("database"):
+        backend = get_backend()
+        assert hasattr(backend, "leaky_bucket_check")
+
+        view = _ok_view(
+            key="ip",
+            rate="3/m",
+            algorithm=Algorithm.LEAKY_BUCKET,
+            algorithm_config={"bucket_capacity": 3, "leak_rate": 0},
+        )
+        assert exhaust(view, 5, ip="192.0.2.41") == [200, 200, 200, 429, 429]
+
+
+@pytest.mark.django_db
+def test_leaky_bucket_smooth_drain_database():
+    """Leaky bucket drains smoothly at leak_rate, admitting new traffic.
+
+    bucket_capacity=2, leak_rate=5/s. Fill the bucket (2 OK, 1 reject), wait
+    ~0.6s so several units leak out, then confirm new requests are admitted —
+    the smooth, burst-free drain that distinguishes leaky from token bucket.
+    """
+    with use_backend("database"):
+        view = _ok_view(
+            key="ip",
+            rate="2/s",
+            algorithm=Algorithm.LEAKY_BUCKET,
+            algorithm_config={"bucket_capacity": 2, "leak_rate": 5},
+        )
+        ip = "192.0.2.42"
+        assert exhaust(view, 3, ip=ip) == [200, 200, 429]
+        time.sleep(0.6)  # ~3 units drained at 5/s
+        assert exhaust(view, 2, ip=ip) == [200, 200]
+
+
+@pytest.mark.django_db
+def test_leaky_bucket_weighted_cost_per_request_database():
+    """Leaky bucket honoring a per-request weight (cost=2) on the DB backend.
+
+    bucket_capacity=4, leak_rate=0, and the decorator ``cost=2`` makes each
+    request add 2 to the level, so 2 requests fill the bucket and the 3rd
+    overflows. This is the public ``cost=`` weighting path for leaky bucket.
+    """
+    with use_backend("database"):
+        view = _ok_view(
+            key="ip",
+            rate="4/m",
+            algorithm=Algorithm.LEAKY_BUCKET,
+            algorithm_config={"bucket_capacity": 4, "leak_rate": 0},
+            cost=2,
+        )
+        assert exhaust(view, 3, ip="192.0.2.43") == [200, 200, 429]
+
+
+@pytest.mark.django_db
+def test_leaky_bucket_isolated_per_key_database():
+    """Leaky buckets are independent per key on the database backend.
+
+    Two distinct IPs each get their own capacity-2 bucket; exhausting one
+    leaves the other untouched.
+    """
+    with use_backend("database"):
+        view = _ok_view(
+            key="ip",
+            rate="2/m",
+            algorithm=Algorithm.LEAKY_BUCKET,
+            algorithm_config={"bucket_capacity": 2, "leak_rate": 0},
+        )
+        assert exhaust(view, 3, ip="192.0.2.44") == [200, 200, 429]
+        assert exhaust(view, 2, ip="192.0.2.45") == [200, 200]

--- a/tests/e2e/test_async_decorator_e2e.py
+++ b/tests/e2e/test_async_decorator_e2e.py
@@ -1,0 +1,497 @@
+"""Real-backend end-to-end scenarios for ASYNC rate limiting.
+
+These exercise the two async public entry points against REAL storage (live
+Redis / live MongoDB / in-process memory) -- never a mocked backend:
+
+    * ``@rate_limit`` applied to an ``async def`` view. The decorator
+      auto-detects the coroutine and runs an async wrapper that awaits the
+      view, increments the real store via ``aincr`` / ``sync_to_async(incr)``,
+      and honors ``block=``, ``cost=`` and ``algorithm="token_bucket"`` with
+      true bucket semantics (run off the event loop) on backends with native
+      ``token_bucket_check`` support.
+    * the standalone ``@aratelimit`` decorator. NOTE: ``@aratelimit`` is
+      WINDOW-ONLY -- it always calls ``acheck_rate_limit`` (a counting
+      increment) and has no ``algorithm`` / ``cost`` knobs, so its bucket of
+      ``N`` is a plain per-window counter.
+
+Real-life framing: an async API endpoint (ASGI) is hammered by a client
+burst; we assert exactly when the 4xx kicks in, that distinct callers get
+independent buckets, and that the advertised ``X-RateLimit-*`` headers match.
+
+asyncio_mode=auto is configured for the suite, so ``async def`` tests run under
+pytest-asyncio; tests are additionally marked ``asyncio`` to match project
+style.
+"""
+
+import pytest
+
+from django.http import HttpResponse, JsonResponse
+
+from django_smart_ratelimit import aratelimit, rate_limit
+
+from .conftest import (
+    MEMORY,
+    REDIS,
+    REDIS_UP,
+    AuthedUser,
+    make_request,
+    skip_without_redis,
+    use_backend,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def aexhaust(view, n, ip="198.51.100.7", **kwargs):
+    """Await an async view ``n`` times from one IP; return the status codes.
+
+    The sync ``exhaust`` helper in conftest cannot drive a coroutine view, so
+    this is the async sibling: each call is a fresh realistic request from the
+    same client IP, hitting the real backend store every time.
+    """
+    codes = []
+    for _ in range(n):
+        resp = await view(make_request(ip=ip, **kwargs))
+        codes.append(getattr(resp, "status_code", resp))
+    return codes
+
+
+# Token-bucket scenarios need a backend that implements an atomic, native
+# ``token_bucket_check`` (memory + redis do). The async ``@rate_limit`` path
+# runs that sync check off the event loop via ``sync_to_async`` so async views
+# get real bucket semantics rather than window counting. async_redis / mongodb
+# have no native bucket support, so they are intentionally excluded here.
+_NATIVE_BUCKET_BACKENDS = [
+    pytest.param("memory", MEMORY, {}, id="memory"),
+    pytest.param(
+        "redis",
+        REDIS,
+        {"RATELIMIT_REDIS": {"host": "localhost", "port": 6379, "db": 0}},
+        id="redis",
+        marks=skip_without_redis,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# @rate_limit on an async def view (coroutine auto-detected)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncRateLimitDecorator:
+    """``@rate_limit`` auto-detecting an ``async def`` view, on every backend."""
+
+    async def test_async_endpoint_burst_blocked_after_n(self, async_real_backend):
+        """Async profile API: 5/min per IP.
+
+        A client bursting the async endpoint gets the first 5 requests served
+        (200) and is throttled (429) from the 6th onward -- verified against
+        the real store on every available backend.
+        """
+
+        @rate_limit(key="ip", rate="5/m", backend=async_real_backend)
+        async def profile(_request):
+            return JsonResponse({"ok": True})
+
+        codes = await aexhaust(profile, 7, ip="198.51.100.10")
+
+        assert codes[:5] == [200] * 5
+        assert codes[5:] == [429, 429]
+
+    async def test_independent_buckets_per_ip(self, async_real_backend):
+        """Two async clients from distinct IPs do not share a bucket.
+
+        An attacker hammering from one IP is blocked while a legitimate user on
+        another IP keeps getting 200s -- each IP keys its own real-store bucket.
+        """
+
+        @rate_limit(key="ip", rate="3/m", backend=async_real_backend)
+        async def search(_request):
+            return JsonResponse({"results": []})
+
+        attacker = await aexhaust(search, 5, ip="198.51.100.21")
+        victim = await aexhaust(search, 3, ip="198.51.100.22")
+
+        assert attacker == [200, 200, 200, 429, 429]
+        assert victim == [200, 200, 200]
+
+    async def test_per_user_key_template_isolates_accounts(self, async_real_backend):
+        """Async endpoint keyed by ``user:{user.id}``: budgets are per account.
+
+        User 1001 exhausting their quota does not consume user 2002's budget,
+        even when both arrive over the same connection/IP.
+        """
+
+        @rate_limit(key="user:{user.id}", rate="2/m", backend=async_real_backend)
+        async def dashboard(_request):
+            return HttpResponse("dash")
+
+        u1 = AuthedUser(uid=1001)
+        u2 = AuthedUser(uid=2002)
+
+        first = [
+            (await dashboard(make_request(ip="198.51.100.30", user=u1))).status_code
+            for _ in range(3)
+        ]
+        second = [
+            (await dashboard(make_request(ip="198.51.100.30", user=u2))).status_code
+            for _ in range(2)
+        ]
+
+        assert first == [200, 200, 429]
+        assert second == [200, 200]
+
+    async def test_rate_limit_headers_present_on_async_response(
+        self, async_real_backend
+    ):
+        """Async responses advertise X-RateLimit-* so clients can self-throttle.
+
+        The very first request reports the full limit and a decremented
+        remaining count; these come from the real backend's count.
+        """
+
+        @rate_limit(key="ip", rate="10/m", backend=async_real_backend)
+        async def feed(_request):
+            return JsonResponse({"items": []})
+
+        resp = await feed(make_request(ip="198.51.100.40"))
+
+        assert resp.status_code == 200
+        assert resp.headers["X-RateLimit-Limit"] == "10"
+        # First hit consumes one unit -> 9 remain.
+        assert resp.headers["X-RateLimit-Remaining"] == "9"
+        assert "X-RateLimit-Reset" in resp.headers
+
+    async def test_block_false_shadows_allows_but_marks_request(
+        self, async_real_backend
+    ):
+        """``block=False`` async endpoint: never returns 429, flags the breach.
+
+        With non-blocking mode the over-limit request is still served (200) but
+        the wrapper sets ``request.rate_limit_exceeded`` so the view (or
+        downstream middleware) can react -- e.g. log, degrade, or add a banner.
+        Real counts in the store drive when the flag flips on.
+        """
+        seen_flags = []
+
+        @rate_limit(key="ip", rate="2/m", block=False, backend=async_real_backend)
+        async def soft_limited(request):
+            seen_flags.append(getattr(request, "rate_limit_exceeded", False))
+            return HttpResponse("served")
+
+        codes = await aexhaust(soft_limited, 4, ip="198.51.100.50")
+
+        # Never blocked under block=False.
+        assert codes == [200, 200, 200, 200]
+        # First two requests are within budget; the 3rd and 4th breach it and
+        # are flagged even though they were still served.
+        assert seen_flags == [False, False, True, True]
+
+    async def test_cost_consumes_multiple_units_per_request(self, async_real_backend):
+        """Weighted async endpoint: each call costs 2 units of a 6/min budget.
+
+        ``cost=2`` means three calls (2+2+2 = 6) exactly drain the window and
+        the fourth is throttled -- exercising cost accounting through the real
+        backend increment path on every backend.
+        """
+
+        @rate_limit(key="ip", rate="6/m", cost=2, backend=async_real_backend)
+        async def expensive(_request):
+            return JsonResponse({"ok": True})
+
+        codes = await aexhaust(expensive, 4, ip="198.51.100.60")
+
+        assert codes == [200, 200, 200, 429]
+
+    async def test_cost_callable_charges_by_request(self, async_real_backend):
+        """Async endpoint with a per-request cost callable on a 10/min budget.
+
+        ``/export`` requests cost 5 units each; cheap reads cost 1. Two exports
+        (10) exhaust the budget so a following export is blocked, while the
+        callable is evaluated against the real request object.
+        """
+
+        def price(request):
+            return 5 if request.path.startswith("/export") else 1
+
+        @rate_limit(key="ip", rate="10/m", cost=price, backend=async_real_backend)
+        async def api(_request):
+            return JsonResponse({"ok": True})
+
+        ip = "198.51.100.70"
+        first = (await api(make_request(ip=ip, path="/export/big"))).status_code
+        second = (await api(make_request(ip=ip, path="/export/big"))).status_code
+        third = (await api(make_request(ip=ip, path="/export/big"))).status_code
+
+        assert first == 200  # 5/10 used
+        assert second == 200  # 10/10 used
+        assert third == 429  # would be 15/10 -> blocked
+
+    async def test_skip_if_async_predicate_bypasses_limit(self, async_real_backend):
+        """Async endpoint skipping internal traffic via an async ``skip_if``.
+
+        Requests carrying the internal marker bypass the limiter entirely (the
+        backend is never touched), so the internal caller is never throttled
+        even far beyond the public 1/min limit.
+        """
+
+        async def is_internal(request):
+            return request.META.get("HTTP_X_INTERNAL") == "yes"
+
+        @rate_limit(
+            key="ip", rate="1/m", skip_if=is_internal, backend=async_real_backend
+        )
+        async def metrics(_request):
+            return HttpResponse("metrics")
+
+        internal_codes = [
+            (
+                await metrics(
+                    make_request(ip="198.51.100.80", headers={"X-Internal": "yes"})
+                )
+            ).status_code
+            for _ in range(5)
+        ]
+        # A public caller on a different IP still hits the 1/min wall.
+        public_codes = await aexhaust(metrics, 2, ip="198.51.100.81")
+
+        assert internal_codes == [200] * 5
+        assert public_codes == [200, 429]
+
+
+# ---------------------------------------------------------------------------
+# @rate_limit token_bucket on an async view (native-support backends)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncTokenBucketDecorator:
+    """Async ``@rate_limit(algorithm='token_bucket')`` with real bucket math.
+
+    The async wrapper runs the synchronous bucket check off the event loop via
+    ``sync_to_async`` on backends that expose a native ``token_bucket_check``
+    (memory + redis), so an async view gets genuine burst-then-refill behavior
+    rather than plain window counting.
+    """
+
+    @pytest.mark.parametrize("name,path,extra", _NATIVE_BUCKET_BACKENDS)
+    async def test_bucket_size_allows_burst_beyond_window_rate(self, name, path, extra):
+        """Token bucket: bucket_size=10 absorbs a burst the 2/min window can't.
+
+        rate='2/m' sets the steady refill (2 tokens/min) but bucket_size=10
+        lets a fresh client spend up to 10 tokens immediately. So a 10-request
+        burst all succeeds (window counting would have blocked after 2), and
+        the 11th -- with the bucket drained and effectively no refill within
+        the burst -- is throttled. This is the whole point of token_bucket on
+        an async endpoint, and it is honored only because the backend has
+        native bucket support.
+        """
+        with use_backend(name):
+
+            @rate_limit(
+                key="ip",
+                rate="2/m",
+                algorithm="token_bucket",
+                algorithm_config={"bucket_size": 10},
+                backend=name,
+            )
+            async def burst_api(_request):
+                return JsonResponse({"ok": True})
+
+            codes = await aexhaust(burst_api, 11, ip="198.51.100.90")
+
+        assert codes[:10] == [200] * 10  # full bucket burst allowed
+        assert codes[10] == 429  # bucket drained -> blocked
+
+    @pytest.mark.parametrize("name,path,extra", _NATIVE_BUCKET_BACKENDS)
+    async def test_bucket_emits_token_bucket_headers(self, name, path, extra):
+        """Token-bucket async responses carry bucket-specific headers.
+
+        On a native-support backend the wrapper attaches
+        ``X-RateLimit-Bucket-Size`` / ``X-RateLimit-Bucket-Remaining`` (plus
+        the standard limit/remaining/reset) so clients see the real bucket
+        state, not just a window counter.
+        """
+        with use_backend(name):
+
+            @rate_limit(
+                key="ip",
+                rate="3/m",
+                algorithm="token_bucket",
+                algorithm_config={"bucket_size": 5},
+                backend=name,
+            )
+            async def metered(_request):
+                return JsonResponse({"ok": True})
+
+            resp = await metered(make_request(ip="198.51.100.95"))
+
+        assert resp.status_code == 200
+        assert resp.headers["X-RateLimit-Bucket-Size"] == "5"
+        # One token spent out of five -> four remain in the bucket.
+        assert resp.headers["X-RateLimit-Bucket-Remaining"] == "4"
+        assert "X-RateLimit-Remaining" in resp.headers
+
+    @pytest.mark.parametrize("name,path,extra", _NATIVE_BUCKET_BACKENDS)
+    async def test_bucket_cost_drains_multiple_tokens(self, name, path, extra):
+        """Token bucket honors ``cost`` natively as tokens-per-request.
+
+        bucket_size=6 with cost=3 means two requests (3+3) drain the bucket and
+        the third is throttled -- cost flows straight into the bucket's
+        ``tokens_requested`` on a native-support backend.
+        """
+        with use_backend(name):
+
+            @rate_limit(
+                key="ip",
+                rate="2/m",
+                algorithm="token_bucket",
+                algorithm_config={"bucket_size": 6},
+                cost=3,
+                backend=name,
+            )
+            async def heavy(_request):
+                return JsonResponse({"ok": True})
+
+            codes = await aexhaust(heavy, 3, ip="198.51.100.99")
+
+        assert codes == [200, 200, 429]
+
+
+# ---------------------------------------------------------------------------
+# Standalone @aratelimit decorator (WINDOW-ONLY)
+# ---------------------------------------------------------------------------
+
+
+class TestAratelimitDecorator:
+    """The standalone ``@aratelimit`` decorator against real async backends.
+
+    ``@aratelimit`` is WINDOW-ONLY: it always runs ``acheck_rate_limit`` (a
+    counting increment) and exposes no algorithm/cost options, so its limit of
+    ``N`` is a plain per-window counter. It resolves its backend via
+    ``get_async_backend`` (which promotes ``redis`` to the true AsyncRedis
+    backend).
+    """
+
+    async def test_window_limit_blocks_after_n(self, async_real_backend):
+        """@aratelimit login endpoint: 5/min per IP, window counting.
+
+        An attacker hammering the async login from one IP is blocked after 5
+        attempts; the count lives in the real store.
+        """
+
+        @aratelimit(key="ip", rate="5/m", backend=async_real_backend)
+        async def login(_request):
+            return JsonResponse({"token": "abc"})
+
+        codes = await aexhaust(login, 7, ip="198.51.100.110")
+
+        assert codes[:5] == [200] * 5
+        assert codes[5:] == [429, 429]
+
+    async def test_distinct_ips_have_independent_windows(self, async_real_backend):
+        """@aratelimit keeps a separate window per IP key.
+
+        One IP exhausting its 2/min window leaves a second IP's window
+        untouched.
+        """
+
+        @aratelimit(key="ip", rate="2/m", backend=async_real_backend)
+        async def signup(_request):
+            return JsonResponse({"ok": True})
+
+        a = await aexhaust(signup, 3, ip="198.51.100.120")
+        b = await aexhaust(signup, 2, ip="198.51.100.121")
+
+        assert a == [200, 200, 429]
+        assert b == [200, 200]
+
+    async def test_block_false_allows_but_flags_request(self, async_real_backend):
+        """@aratelimit ``block=False``: serve over-limit but flag the request.
+
+        Non-blocking mode never returns 429; instead the over-limit request is
+        served and ``request.rate_limit_exceeded`` is set true so the view can
+        observe the soft breach. Counts come from the real backend.
+        """
+        flags = []
+
+        @aratelimit(key="ip", rate="2/m", block=False, backend=async_real_backend)
+        async def soft(request):
+            flags.append(getattr(request, "rate_limit_exceeded", False))
+            return HttpResponse("ok")
+
+        codes = await aexhaust(soft, 4, ip="198.51.100.130")
+
+        assert codes == [200, 200, 200, 200]
+        # The 3rd and 4th calls exceed the 2/min window and are flagged.
+        assert flags[2] is True and flags[3] is True
+
+    async def test_method_scoping_only_limits_targeted_verb(self, async_real_backend):
+        """@aratelimit ``method='POST'`` limits writes but never reads.
+
+        A write-heavy async endpoint throttles POSTs after the window fills,
+        while GETs to the same key bypass the limit entirely (method filter
+        short-circuits before any backend work).
+        """
+
+        @aratelimit(key="ip", rate="2/m", method="POST", backend=async_real_backend)
+        async def resource(_request):
+            return JsonResponse({"ok": True})
+
+        ip = "198.51.100.140"
+        posts = [
+            (await resource(make_request(ip=ip, method="post"))).status_code
+            for _ in range(3)
+        ]
+        gets = [
+            (await resource(make_request(ip=ip, method="get"))).status_code
+            for _ in range(5)
+        ]
+
+        assert posts == [200, 200, 429]
+        assert gets == [200] * 5
+
+    async def test_headers_advertise_window_state(self, async_real_backend):
+        """@aratelimit attaches X-RateLimit-* describing the window.
+
+        The response advertises the configured limit so async clients can pace
+        themselves; remaining/reset are derived from the real backend metadata.
+        """
+
+        @aratelimit(key="ip", rate="8/m", backend=async_real_backend)
+        async def feed(_request):
+            return JsonResponse({"items": []})
+
+        resp = await feed(make_request(ip="198.51.100.150"))
+
+        assert resp.status_code == 200
+        assert resp.headers["X-RateLimit-Limit"] == "8"
+        assert "X-RateLimit-Remaining" in resp.headers
+        assert "X-RateLimit-Reset" in resp.headers
+
+
+@pytest.mark.skipif(not REDIS_UP, reason="live Redis unavailable")
+class TestAratelimitAsyncRedisBackend:
+    """@aratelimit explicitly resolving the native AsyncRedis backend.
+
+    ``get_async_backend`` promotes the ``redis`` name to the true async Redis
+    client (non-blocking ``aincr`` Lua eval), so this verifies the standalone
+    async decorator end-to-end against the dedicated async backend rather than
+    a sync-wrapped one.
+    """
+
+    async def test_async_redis_window_counts_real_store(self):
+        """@aratelimit(backend='redis') hits the real async Redis store.
+
+        Window of 4/min: the burst is allowed for 4 calls then blocked, with
+        the counter persisted in the live Redis via the async Lua increment.
+        """
+        with use_backend("async_redis"):
+
+            @aratelimit(key="ip", rate="4/m", backend="redis")
+            async def ping(_request):
+                return JsonResponse({"pong": True})
+
+            codes = await aexhaust(ping, 6, ip="198.51.100.160")
+
+        assert codes[:4] == [200] * 4
+        assert codes[4:] == [429, 429]

--- a/tests/e2e/test_backends_failover_e2e.py
+++ b/tests/e2e/test_backends_failover_e2e.py
@@ -1,0 +1,452 @@
+"""Real-backend end-to-end tests for backend storage behavior and failover.
+
+These scenarios exercise the public backend API against REAL storage (a live
+Redis, a live MongoDB, the in-memory store, and the real Django test database) --
+no mocking of the rate-limit store. Each scenario uses DISTINCT keys/IPs and the
+``real_backend`` fixture flushes the store before and after, so tests are fully
+self-contained.
+
+Coverage:
+    - Per-backend storage round-trip: ``incr`` / ``get_count`` /
+      ``get_reset_time`` / ``reset`` behave correctly against the real store,
+      independent buckets per distinct key, a limit is enforced and then resets.
+    - MultiBackend failover: a primary + fallback configured via
+      ``RATELIMIT_BACKENDS`` / ``RATELIMIT_MULTI_BACKENDS`` (e.g. redis primary +
+      memory fallback) keeps serving and limiting while the primary is healthy,
+      and transparently falls over to the secondary when the primary is dead.
+    - Real outage scenario: a Redis backend pointed at a DEAD port fails open
+      (``fail_open=True`` allows) or closed (``fail_open=False`` denies / refuses
+      to construct), observable at both the backend layer and the HTTP layer.
+    - Database backend (``@pytest.mark.django_db``) round-trip and enforcement.
+"""
+
+import time
+
+import pytest
+
+from django.test import override_settings
+
+from django_smart_ratelimit.backends import clear_backend_cache, get_backend
+from django_smart_ratelimit.backends.multi import MultiBackend
+from django_smart_ratelimit.decorator import rate_limit
+
+from .conftest import (  # noqa: F401  (real_backend is a pytest fixture)
+    MEMORY,
+    REDIS,
+    exhaust,
+    real_backend,
+    skip_without_redis,
+    use_backend,
+)
+
+# A port nothing listens on -- a "dead" Redis so we can exercise outage paths.
+DEAD_REDIS_PORT = 6390
+
+
+def _ok_view(_request):
+    """Return a trivial 200 response; wrapped by the rate_limit decorator."""
+    from django.http import HttpResponse
+
+    return HttpResponse("ok")
+
+
+# ---------------------------------------------------------------------------
+# Per-backend storage round-trip on the REAL store (every available backend).
+# ---------------------------------------------------------------------------
+
+
+def test_incr_get_count_round_trip_on_real_store(real_backend):  # noqa: F811
+    """Storage round-trip: each incr is durably recorded on the real store.
+
+    A counter that is incremented N times reports a count of N via get_count on
+    the very same real backend (memory dict / live Redis / live MongoDB) -- the
+    write is observable by an independent read.
+    """
+    backend = get_backend()
+    key = f"e2e:roundtrip:{real_backend}"
+
+    assert backend.get_count(key, 60) == 0
+    for expected in range(1, 6):
+        assert backend.incr(key, 60) == expected
+    assert backend.get_count(key, 60) == 5
+
+
+def test_distinct_keys_are_independent_buckets(real_backend):  # noqa: F811
+    """Two distinct keys never share a counter on the real store.
+
+    Hammering bucket A leaves bucket B untouched -- the backend keys requests
+    independently, which is what makes per-IP / per-user limiting work.
+    """
+    backend = get_backend()
+    key_a = f"e2e:independent:A:{real_backend}"
+    key_b = f"e2e:independent:B:{real_backend}"
+
+    for _ in range(7):
+        backend.incr(key_a, 60)
+
+    assert backend.get_count(key_a, 60) == 7
+    assert backend.get_count(key_b, 60) == 0
+    assert backend.incr(key_b, 60) == 1
+    # A is still untouched by B's activity.
+    assert backend.get_count(key_a, 60) == 7
+
+
+def test_get_reset_time_is_in_the_future(real_backend):  # noqa: F811
+    """get_reset_time returns a future expiry once a key exists, None otherwise.
+
+    Before any request the key has no reset time; after the first incr the real
+    store reports a reset timestamp roughly one window into the future (used to
+    populate the X-RateLimit-Reset header).
+    """
+    backend = get_backend()
+    key = f"e2e:resettime:{real_backend}"
+
+    assert backend.get_reset_time(key) is None
+
+    before = int(time.time())
+    backend.incr(key, 60)
+    reset = backend.get_reset_time(key)
+
+    assert reset is not None
+    # Reset is in the future and within (roughly) one window of "now".
+    assert reset >= before
+    assert reset <= before + 60 + 5
+
+
+def test_reset_clears_the_counter_on_real_store(real_backend):  # noqa: F811
+    """reset() wipes the counter so a fresh budget starts on the real store.
+
+    After exhausting some budget, reset() drops the count back to 0 and the next
+    incr starts the window over from 1 -- the manual "unblock this key" path.
+    """
+    backend = get_backend()
+    key = f"e2e:reset:{real_backend}"
+
+    for _ in range(4):
+        backend.incr(key, 60)
+    assert backend.get_count(key, 60) == 4
+
+    backend.reset(key)
+
+    assert backend.get_count(key, 60) == 0
+    assert backend.incr(key, 60) == 1
+
+
+def test_limit_enforced_then_resets_on_real_store(real_backend):  # noqa: F811
+    """A 3/window limit blocks the 4th request, then reset re-opens the budget.
+
+    check_rate_limit (the primitive every algorithm builds on) returns allowed
+    for the first 3 requests and denied for the 4th against the real store; after
+    reset(), the key is allowed again.
+    """
+    backend = get_backend()
+    key = f"e2e:enforced:{real_backend}"
+    limit, period = 3, 60
+
+    decisions = [backend.check_rate_limit(key, limit, period)[0] for _ in range(4)]
+    assert decisions == [True, True, True, False]
+
+    backend.reset(key)
+
+    allowed, meta = backend.check_rate_limit(key, limit, period)
+    assert allowed is True
+    assert meta["count"] == 1
+
+
+def test_increment_reports_remaining_budget(real_backend):  # noqa: F811
+    """increment() returns (count, remaining) so callers can emit headers.
+
+    Against the real store, the remaining budget counts down as requests arrive
+    and never goes negative once the limit is blown.
+    """
+    backend = get_backend()
+    key = f"e2e:remaining:{real_backend}"
+    limit, period = 5, 60
+
+    seen = [backend.increment(key, period, limit) for _ in range(7)]
+    counts = [c for c, _ in seen]
+    remaining = [r for _, r in seen]
+
+    assert counts == [1, 2, 3, 4, 5, 6, 7]
+    assert remaining == [4, 3, 2, 1, 0, 0, 0]
+
+
+def test_short_window_expires_and_budget_refreshes(real_backend):  # noqa: F811
+    """A 1-second window expires on the real store and the budget refreshes.
+
+    After filling a 2/1s bucket and waiting out the window, the real backend's
+    TTL/eviction has dropped the old entries and a fresh request is allowed --
+    proving expiry is enforced by the live store, not just in memory bookkeeping.
+    """
+    backend = get_backend()
+    key = f"e2e:expiry:{real_backend}"
+    limit, period = 2, 1
+
+    first = [backend.check_rate_limit(key, limit, period)[0] for _ in range(3)]
+    assert first == [True, True, False]
+
+    # Wait out the window (plus margin) so the live store expires the entries.
+    time.sleep(1.6)
+
+    allowed, _ = backend.check_rate_limit(key, limit, period)
+    assert allowed is True
+
+
+# ---------------------------------------------------------------------------
+# Multi-backend failover against the REAL store.
+# ---------------------------------------------------------------------------
+
+
+@skip_without_redis
+def test_multi_backend_serves_through_healthy_primary():
+    """RATELIMIT_BACKENDS with redis primary + memory fallback limits normally.
+
+    With a healthy redis primary the MultiBackend routes everything to redis and
+    enforces a 3/window limit just like a single backend -- the fallback is dormant
+    but configured. Verified end-to-end through the real redis store.
+    """
+    backends = [
+        {
+            "name": "primary-redis",
+            "backend": REDIS,
+            "config": {"host": "localhost", "port": 6379, "db": 0},
+        },
+        {"name": "fallback-memory", "backend": MEMORY, "config": {}},
+    ]
+    with override_settings(
+        RATELIMIT_BACKEND="multi",
+        RATELIMIT_BACKENDS=backends,
+        RATELIMIT_MULTI_BACKEND_STRATEGY="first_healthy",
+        RATELIMIT_HEALTH_CHECK_INTERVAL=0,
+        RATELIMIT_REDIS={"host": "localhost", "port": 6379, "db": 0},
+    ):
+        clear_backend_cache()
+        try:
+            import redis as _redis
+
+            _redis.Redis(host="localhost", port=6379, db=0).flushdb()
+
+            backend = get_backend()
+            assert isinstance(backend, MultiBackend)
+
+            key = "e2e:multi:healthy:primary"
+            decisions = [backend.check_rate_limit(key, 3, 60)[0] for _ in range(4)]
+            assert decisions == [True, True, True, False]
+
+            # The write landed on the real redis primary, not the memory fallback.
+            _, redis_backend = backend.backends[0]
+            assert redis_backend.get_count(key, 60) == 4
+        finally:
+            clear_backend_cache()
+            _redis.Redis(host="localhost", port=6379, db=0).flushdb()
+
+
+@skip_without_redis
+def test_multi_backend_fails_over_to_memory_when_primary_is_dead():
+    """Dead redis primary -> MultiBackend transparently uses the memory fallback.
+
+    The primary points at a dead port. A fail-closed redis backend cannot connect
+    at startup, so the MultiBackend drops it during initialization and is left with
+    only the live memory fallback, which then serves every request and still
+    enforces the 2/window limit. This is the resilience promise: a redis outage
+    degrades to local limiting instead of taking the limiter down.
+    """
+    backends = [
+        {
+            "name": "primary-dead-redis",
+            "backend": REDIS,
+            "config": {"host": "localhost", "port": DEAD_REDIS_PORT},
+        },
+        {"name": "fallback-memory", "backend": MEMORY, "config": {}},
+    ]
+    with override_settings(
+        RATELIMIT_BACKEND="multi",
+        RATELIMIT_MULTI_BACKENDS=backends,
+        RATELIMIT_MULTI_BACKEND_STRATEGY="first_healthy",
+        RATELIMIT_HEALTH_CHECK_INTERVAL=0,
+        RATELIMIT_REDIS={"host": "localhost", "port": DEAD_REDIS_PORT},
+    ):
+        clear_backend_cache()
+        try:
+            backend = get_backend()
+            assert isinstance(backend, MultiBackend)
+
+            # The unreachable primary was dropped; only the memory fallback remains.
+            surviving = [name for name, _ in backend.backends]
+            assert surviving == ["fallback-memory"]
+
+            key = "e2e:multi:failover:dead-primary"
+            decisions = [backend.check_rate_limit(key, 2, 60)[0] for _ in range(3)]
+            assert decisions == [True, True, False]
+
+            # State materialized on the surviving memory fallback.
+            _, mem_backend = backend.backends[-1]
+            assert mem_backend.get_count(key, 60) == 3
+        finally:
+            clear_backend_cache()
+
+
+def test_multi_backend_memory_pair_round_trip():
+    """Two memory backends behind MultiBackend: primary serves, state round-trips.
+
+    A backend-agnostic failover topology (memory primary + memory fallback) that
+    runs without any external service: requests are counted on the primary and a
+    3/window limit is enforced through the multi layer.
+    """
+    backends = [
+        {"name": "primary-mem", "backend": MEMORY, "config": {}},
+        {"name": "fallback-mem", "backend": MEMORY, "config": {}},
+    ]
+    with override_settings(
+        RATELIMIT_BACKEND="multi",
+        RATELIMIT_MULTI_BACKENDS=backends,
+        RATELIMIT_MULTI_BACKEND_STRATEGY="first_healthy",
+        RATELIMIT_HEALTH_CHECK_INTERVAL=0,
+    ):
+        clear_backend_cache()
+        try:
+            backend = get_backend()
+            assert isinstance(backend, MultiBackend)
+
+            key = "e2e:multi:memory-pair"
+            decisions = [backend.check_rate_limit(key, 3, 60)[0] for _ in range(4)]
+            assert decisions == [True, True, True, False]
+
+            _, primary = backend.backends[0]
+            assert primary.get_count(key, 60) == 4
+        finally:
+            clear_backend_cache()
+
+
+# ---------------------------------------------------------------------------
+# Real outage scenario: redis on a DEAD port + fail_open semantics.
+# ---------------------------------------------------------------------------
+
+
+@skip_without_redis
+def test_dead_redis_fail_open_true_allows_requests():
+    """Redis pointed at a dead port with fail_open=True keeps allowing traffic.
+
+    A misconfigured/unreachable Redis must not take the site down: with
+    fail_open=True the backend constructs (redis handle is None) and incr returns
+    a safe "allowed" value, so the HTTP endpoint keeps returning 200 during the
+    outage instead of 5xx-ing every visitor.
+    """
+    with override_settings(
+        RATELIMIT_BACKEND=REDIS,
+        RATELIMIT_REDIS={"host": "localhost", "port": DEAD_REDIS_PORT},
+        RATELIMIT_FAIL_OPEN=True,
+    ):
+        clear_backend_cache()
+        try:
+            backend = get_backend()
+            assert backend.fail_open is True
+            # Backend came up despite the dead port and fails open on incr.
+            assert backend.incr("e2e:dead:fail-open", 60) == 0
+
+            view = rate_limit(key="ip", rate="2/m")(_ok_view)
+            codes = exhaust(view, 5, ip="198.51.100.7")
+            # Never blocked: the outage degrades to "allow everything".
+            assert codes == [200, 200, 200, 200, 200]
+        finally:
+            clear_backend_cache()
+
+
+@skip_without_redis
+def test_dead_redis_fail_open_false_denies():
+    """Redis on a dead port with fail_open=False refuses rather than silently allow.
+
+    Fail-closed deployments treat a backend outage as a hard error: constructing
+    the Redis backend against a dead port raises ImproperlyConfigured (the limiter
+    will not silently let everyone through). This is the security-first posture.
+    """
+    from django.core.exceptions import ImproperlyConfigured
+
+    with override_settings(
+        RATELIMIT_BACKEND=REDIS,
+        RATELIMIT_REDIS={"host": "localhost", "port": DEAD_REDIS_PORT},
+        RATELIMIT_FAIL_OPEN=False,
+    ):
+        clear_backend_cache()
+        try:
+            with pytest.raises(ImproperlyConfigured):
+                get_backend()
+        finally:
+            clear_backend_cache()
+
+
+# ---------------------------------------------------------------------------
+# Database backend against the REAL test DB.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_database_backend_round_trip_and_enforcement():
+    """Database backend: incr/get_count/reset round-trip on the real test DB.
+
+    The SQL-backed limiter durably records each increment as rows, reports the
+    count back via an independent read, enforces a 3/window limit, and reset()
+    deletes the rows so the budget re-opens -- all against the real Django DB.
+    """
+    with use_backend("database"):
+        backend = get_backend()
+        key = "e2e:db:round-trip"
+
+        assert backend.get_count(key, 60) == 0
+        for expected in range(1, 4):
+            assert backend.incr(key, 60) == expected
+        assert backend.get_count(key, 60) == 3
+
+        # 4th request over a 3/window limit is denied.
+        decisions = [backend.check_rate_limit(key, 3, 60)[0] for _ in range(2)]
+        # Two more increments land us at counts 4 and 5 -> both over the limit.
+        assert decisions == [False, False]
+
+        backend.reset(key)
+        assert backend.get_count(key, 60) == 0
+
+
+@pytest.mark.django_db
+def test_database_backend_distinct_keys_independent():
+    """Database backend keys distinct buckets independently on the real DB.
+
+    Two keys (e.g. two different client IPs) accumulate counts without bleeding
+    into each other -- the per-key WHERE clause isolates their rows.
+    """
+    with use_backend("database"):
+        backend = get_backend()
+        key_a = "e2e:db:independent:A"
+        key_b = "e2e:db:independent:B"
+
+        for _ in range(5):
+            backend.incr(key_a, 60)
+        backend.incr(key_b, 60)
+
+        assert backend.get_count(key_a, 60) == 5
+        assert backend.get_count(key_b, 60) == 1
+
+        backend.reset(key_a)
+        assert backend.get_count(key_a, 60) == 0
+        # Resetting A leaves B intact.
+        assert backend.get_count(key_b, 60) == 1
+
+
+@pytest.mark.django_db
+def test_database_backend_get_reset_time_in_future():
+    """Database backend reports a future reset time once a key has activity.
+
+    get_reset_time is None for an untouched key and a future timestamp after the
+    first incr, sourced from the window_end / expires_at columns on the real DB.
+    """
+    with use_backend("database"):
+        backend = get_backend()
+        key = "e2e:db:reset-time"
+
+        assert backend.get_reset_time(key) is None
+
+        before = int(time.time())
+        backend.incr(key, 60)
+        reset = backend.get_reset_time(key)
+
+        assert reset is not None
+        assert reset >= before

--- a/tests/e2e/test_decorator_e2e.py
+++ b/tests/e2e/test_decorator_e2e.py
@@ -1,0 +1,603 @@
+"""Real-backend end-to-end scenarios for the SYNC ``rate_limit`` decorator.
+
+Every scenario drives the decorator (and its ``ratelimit`` alias) against REAL
+storage — a live Redis, a live MongoDB, the real Django test DB, or the
+in-process memory backend — via the shared harness in ``conftest.py``. Nothing
+about the rate-limit store is mocked: the limiter actually increments real
+counters and the assertions check observable behavior (HTTP 200 vs 429,
+``X-RateLimit-*`` headers, per-key bucket isolation, soft-limit flags, shadow
+logging, CIDR allow/deny policy, custom 429 bodies).
+
+The ``real_backend`` fixture re-runs each backend-agnostic scenario on every
+available non-DB backend; database-backend scenarios use
+``use_backend("database")`` together with ``@pytest.mark.django_db``. Each test
+uses distinct IPs / keys so the tests stay independent even though they share
+one live store.
+"""
+
+import logging
+
+import pytest
+
+from django.http import HttpResponse, JsonResponse
+
+from django_smart_ratelimit import rate_limit, ratelimit
+from django_smart_ratelimit.enums import RateLimitKey
+
+from .conftest import (
+    AnonUser,
+    AuthedUser,
+    exhaust,
+    make_request,
+    use_backend,
+)
+
+# Logger that emits the SHADOW_RATE_LIMIT_BLOCK line (see pipeline.py).
+SHADOW_LOGGER = "django_smart_ratelimit.pipeline"
+
+
+# ---------------------------------------------------------------------------
+# Rate parsing: "N/s", "N/m", "N/h" all enforced against the real store.
+# ---------------------------------------------------------------------------
+
+
+class TestRateParsing:
+    """The ``rate`` string maps to a real limit/period enforced by the store."""
+
+    def test_per_minute_blocks_after_n(self, real_backend):
+        """5/m: the first 5 requests from one IP pass, the 6th is blocked (429)."""
+
+        @rate_limit(key="ip", rate="5/m")
+        def view(_request):
+            return HttpResponse("ok")
+
+        codes = exhaust(view, 6, ip="198.51.100.1")
+        assert codes[:5] == [200, 200, 200, 200, 200]
+        assert codes[5] == 429
+
+    def test_per_hour_limit(self, real_backend):
+        """100/h: request 100 passes, request 101 is blocked."""
+
+        @rate_limit(key="ip", rate="100/h")
+        def view(_request):
+            return HttpResponse("ok")
+
+        codes = exhaust(view, 101, ip="198.51.100.2")
+        assert codes.count(200) == 100
+        assert codes[-1] == 429
+
+    def test_per_second_limit(self, real_backend):
+        """10/s: ten quick requests pass, the eleventh in the same second blocks."""
+
+        @rate_limit(key="ip", rate="10/s")
+        def view(_request):
+            return HttpResponse("ok")
+
+        codes = exhaust(view, 11, ip="198.51.100.3")
+        assert codes[:10] == [200] * 10
+        assert codes[10] == 429
+
+
+# ---------------------------------------------------------------------------
+# Key types: ip / user / user_or_ip / header / param / custom callable.
+# Each must produce INDEPENDENT buckets per distinct key value.
+# ---------------------------------------------------------------------------
+
+
+class TestKeyTypes:
+    """Every supported key type buckets distinct principals independently."""
+
+    def test_key_ip_independent_buckets(self, real_backend):
+        """Login throttle: an attacker hammering one IP is blocked.
+
+        A legitimate user on another IP is completely unaffected.
+        """
+
+        @rate_limit(key="ip", rate="5/m")
+        def login(_request):
+            return HttpResponse("ok")
+
+        attacker = exhaust(login, 7, ip="203.0.113.50")
+        assert attacker[:5] == [200] * 5
+        assert attacker[5] == 429 and attacker[6] == 429
+
+        # A different IP has its own fresh bucket.
+        victim = exhaust(login, 5, ip="203.0.113.51")
+        assert victim == [200] * 5
+
+    def test_key_user_buckets_by_user_id(self, real_backend):
+        """Key='user' gives two authenticated users separate buckets.
+
+        The same user is throttled across requests regardless of source IP.
+        """
+
+        @rate_limit(key="user", rate="3/m")
+        def view(_request):
+            return HttpResponse("ok")
+
+        u1 = AuthedUser(uid=9001)
+        codes_u1 = [
+            view(make_request(ip="203.0.113.60", user=u1)).status_code for _ in range(4)
+        ]
+        assert codes_u1 == [200, 200, 200, 429]
+
+        # Same user from a *different* IP shares the (already-exhausted) bucket.
+        assert view(make_request(ip="203.0.113.61", user=u1)).status_code == 429
+
+        # A different user is unaffected.
+        u2 = AuthedUser(uid=9002)
+        assert view(make_request(ip="203.0.113.60", user=u2)).status_code == 200
+
+    def test_key_user_or_ip_falls_back_to_ip_when_anonymous(self, real_backend):
+        """Key='user_or_ip' keys anonymous traffic on IP, auth traffic on user.
+
+        So an anonymous flood does not consume an authenticated user's quota.
+        """
+
+        @rate_limit(key="user_or_ip", rate="3/m")
+        def view(_request):
+            return HttpResponse("ok")
+
+        # Anonymous: buckets by IP.
+        anon = [
+            view(make_request(ip="203.0.113.70", user=AnonUser())).status_code
+            for _ in range(4)
+        ]
+        assert anon == [200, 200, 200, 429]
+
+        # Authenticated user from the SAME IP has an independent (user) bucket.
+        authed = AuthedUser(uid=7777)
+        assert view(make_request(ip="203.0.113.70", user=authed)).status_code == 200
+
+    def test_key_header_api_key(self, real_backend):
+        """Keying on the X-Api-Key header gives each API key its own quota.
+
+        One noisy key cannot exhaust another tenant's budget.
+        """
+
+        @rate_limit(key=f"{RateLimitKey.HEADER}:X-Api-Key", rate="4/m")
+        def api(_request):
+            return JsonResponse({"ok": True})
+
+        def call(api_key):
+            return api(
+                make_request(ip="203.0.113.80", headers={"X-Api-Key": api_key})
+            ).status_code
+
+        first_key = [call("key-aaa") for _ in range(5)]
+        assert first_key == [200, 200, 200, 200, 429]
+
+        # A different API key from the same IP is on its own bucket.
+        assert call("key-bbb") == 200
+
+    def test_key_param_tenant(self, real_backend):
+        """Keying on the ?tenant= query param defines the bucket per tenant.
+
+        Per-tenant quotas hold even when requests share one source IP.
+        """
+
+        @rate_limit(key=f"{RateLimitKey.PARAM}:tenant", rate="3/m")
+        def view(_request):
+            return HttpResponse("ok")
+
+        def call(tenant):
+            return view(
+                make_request(ip="203.0.113.90", params={"tenant": tenant})
+            ).status_code
+
+        acme = [call("acme") for _ in range(4)]
+        assert acme == [200, 200, 200, 429]
+
+        # Distinct tenant value -> distinct bucket.
+        assert call("globex") == 200
+
+    def test_custom_callable_key(self, real_backend):
+        """A custom callable key (per-account bucket) is honored end to end.
+
+        Buckets are isolated exactly as the callable's return value dictates.
+        """
+
+        def account_key(request, *args, **kwargs):
+            return f"account:{request.META.get('HTTP_X_ACCOUNT', 'anon')}"
+
+        @rate_limit(key=account_key, rate="2/m")
+        def view(_request):
+            return HttpResponse("ok")
+
+        def call(account):
+            return view(
+                make_request(ip="203.0.113.100", headers={"X-Account": account})
+            ).status_code
+
+        acc1 = [call("alpha") for _ in range(3)]
+        assert acc1 == [200, 200, 429]
+        # Different account => fresh bucket.
+        assert call("beta") == 200
+
+
+# ---------------------------------------------------------------------------
+# block=True / block=False behavior.
+# ---------------------------------------------------------------------------
+
+
+class TestBlockMode:
+    """block=True returns 429; block=False sets a flag but still serves 200."""
+
+    def test_block_true_returns_429(self, real_backend):
+        """block=True (the default): over-limit requests get a hard 429."""
+
+        @rate_limit(key="ip", rate="2/m", block=True)
+        def view(_request):
+            return HttpResponse("ok")
+
+        codes = exhaust(view, 3, ip="203.0.113.110")
+        assert codes == [200, 200, 429]
+
+    def test_block_false_sets_flag_but_serves_200(self, real_backend):
+        """Soft limit: block=False never returns 429.
+
+        It marks request.rate_limit_exceeded so the view can degrade gracefully.
+        """
+
+        seen_flags = []
+
+        @rate_limit(key="ip", rate="2/m", block=False)
+        def view(request):
+            seen_flags.append(getattr(request, "rate_limit_exceeded", False))
+            return HttpResponse("ok")
+
+        codes = exhaust(view, 4, ip="203.0.113.111")
+        # Every request is served.
+        assert codes == [200, 200, 200, 200]
+        # The first two are within limit; the over-limit ones are flagged.
+        assert seen_flags[0] is False and seen_flags[1] is False
+        assert seen_flags[2] is True and seen_flags[3] is True
+
+
+# ---------------------------------------------------------------------------
+# skip_if: conditionally bypass rate limiting entirely.
+# ---------------------------------------------------------------------------
+
+
+class TestSkipIf:
+    """skip_if short-circuits rate limiting when it returns True."""
+
+    def test_skip_if_bypasses_limit_for_staff(self, real_backend):
+        """Skip_if lets staff users bypass the limit entirely.
+
+        Regular users are still throttled on the same endpoint.
+        """
+
+        @rate_limit(
+            key="ip",
+            rate="2/m",
+            skip_if=lambda request: getattr(request.user, "is_staff", False),
+        )
+        def view(_request):
+            return HttpResponse("ok")
+
+        # Staff user — never counted, never blocked even past the limit.
+        staff = AuthedUser(uid=1)
+        staff.is_staff = True
+        staff_codes = [
+            view(make_request(ip="203.0.113.120", user=staff)).status_code
+            for _ in range(5)
+        ]
+        assert staff_codes == [200] * 5
+
+        # A non-staff caller on a different IP is throttled normally.
+        regular = exhaust(view, 3, ip="203.0.113.121")
+        assert regular == [200, 200, 429]
+
+
+# ---------------------------------------------------------------------------
+# cost: weighted requests, as an int and as a callable.
+# ---------------------------------------------------------------------------
+
+
+class TestCost:
+    """cost lets expensive operations consume more of the budget."""
+
+    def test_integer_cost_consumes_budget(self, real_backend):
+        """cost=2 against a 6/m budget: 3 calls fit (2+2+2=6), the 4th blocks."""
+
+        @rate_limit(key="ip", rate="6/m", cost=2)
+        def view(_request):
+            return HttpResponse("ok")
+
+        codes = exhaust(view, 4, ip="203.0.113.130")
+        assert codes == [200, 200, 200, 429]
+
+    def test_callable_cost_weights_expensive_endpoint(self, real_backend):
+        """Weighted endpoint: a callable cost charges POSTs (exports) 3x.
+
+        Cheap GETs cost 1; all draw from the same 5/m budget.
+        """
+
+        def cost_fn(request):
+            return 3 if request.method == "POST" else 1
+
+        @rate_limit(key="ip", rate="5/m", cost=cost_fn)
+        def view(_request):
+            return HttpResponse("ok")
+
+        ip = "203.0.113.131"
+        # GET(1) + POST(3) + GET(1) = 5  -> all allowed.
+        assert view(make_request(ip=ip, method="get")).status_code == 200
+        assert view(make_request(ip=ip, method="post")).status_code == 200
+        assert view(make_request(ip=ip, method="get")).status_code == 200
+        # Budget exhausted: the next request is blocked.
+        assert view(make_request(ip=ip, method="get")).status_code == 429
+
+
+# ---------------------------------------------------------------------------
+# shadow=True: allows past the limit but logs SHADOW_RATE_LIMIT_BLOCK.
+# ---------------------------------------------------------------------------
+
+
+class TestShadowMode:
+    """shadow mode observes what *would* be blocked without enforcing it."""
+
+    def test_shadow_allows_but_logs(self, real_backend, caplog):
+        """Soft-rollout monitoring: shadow=True serves every request 200.
+
+        It still emits a SHADOW_RATE_LIMIT_BLOCK log line once the limit spills.
+        """
+
+        @rate_limit(key="ip", rate="2/m", shadow=True)
+        def view(_request):
+            return HttpResponse("ok")
+
+        with caplog.at_level(logging.INFO, logger=SHADOW_LOGGER):
+            codes = exhaust(view, 6, ip="203.0.113.140")
+
+        # Nothing is ever blocked in shadow mode.
+        assert codes == [200] * 6
+        # But the over-limit calls were logged for the operator to review.
+        assert any(
+            "SHADOW_RATE_LIMIT_BLOCK" in rec.getMessage() for rec in caplog.records
+        )
+
+    def test_shadow_false_enforces(self, real_backend):
+        """Control: with shadow=False the same config enforces a hard 429."""
+
+        @rate_limit(key="ip", rate="2/m", shadow=False)
+        def view(_request):
+            return HttpResponse("ok")
+
+        codes = exhaust(view, 3, ip="203.0.113.141")
+        assert codes == [200, 200, 429]
+
+
+# ---------------------------------------------------------------------------
+# allow_list (CIDR bypass) and deny_list (CIDR block); deny wins.
+# ---------------------------------------------------------------------------
+
+
+class TestAllowDenyLists:
+    """CIDR allow/deny policy is evaluated before the backend; deny precedes."""
+
+    def test_allow_list_internal_cidr_bypasses_limit(self, real_backend):
+        """Internal-CIDR allowlist: hosts in 10.0.0.0/8 skip rate limiting.
+
+        External IPs remain throttled.
+        """
+
+        @rate_limit(key="ip", rate="2/m", allow_list=["10.0.0.0/8"])
+        def view(_request):
+            return HttpResponse("ok")
+
+        # Internal IP: bypasses the limit no matter how many calls.
+        internal = exhaust(view, 6, ip="10.1.2.3")
+        assert internal == [200] * 6
+
+        # External IP: throttled normally.
+        external = exhaust(view, 3, ip="203.0.113.150")
+        assert external == [200, 200, 429]
+
+    def test_deny_list_abusive_cidr_blocked(self, real_backend):
+        """Abusive-IP denylist: a known-bad /24 is blocked with 429.
+
+        The block happens from the very first request, before any quota is used.
+        """
+
+        @rate_limit(key="ip", rate="1000/m", deny_list=["192.0.2.0/24"])
+        def view(_request):
+            return HttpResponse("ok")
+
+        # Deny-listed source is blocked immediately despite a huge limit.
+        denied = exhaust(view, 3, ip="192.0.2.55")
+        assert denied == [429, 429, 429]
+
+        # A non-listed IP is served.
+        assert view(make_request(ip="203.0.113.151")).status_code == 200
+
+    def test_deny_wins_over_allow(self, real_backend):
+        """When an IP matches both lists, deny takes precedence (fail-closed)."""
+
+        @rate_limit(
+            key="ip",
+            rate="1000/m",
+            allow_list=["10.0.0.0/8"],
+            deny_list=["10.0.0.99"],
+        )
+        def view(_request):
+            return HttpResponse("ok")
+
+        # In allow CIDR but also explicitly denied -> blocked.
+        assert view(make_request(ip="10.0.0.99")).status_code == 429
+        # In allow CIDR and NOT denied -> bypasses the limit.
+        assert view(make_request(ip="10.0.0.100")).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# response_callback: custom 429 body / status.
+# ---------------------------------------------------------------------------
+
+
+class TestResponseCallback:
+    """response_callback fully controls the over-limit response."""
+
+    def test_custom_429_body_and_status(self, real_backend):
+        """A custom response_callback returns a branded JSON 429 body.
+
+        Allowed requests still flow through the real view.
+        """
+
+        def custom_response(_request):
+            return JsonResponse(
+                {"error": "slow down", "support": "help@example.com"},
+                status=429,
+            )
+
+        @rate_limit(key="ip", rate="1/m", response_callback=custom_response)
+        def view(_request):
+            return HttpResponse("ok")
+
+        ip = "203.0.113.160"
+        first = view(make_request(ip=ip))
+        assert first.status_code == 200
+
+        blocked = view(make_request(ip=ip))
+        assert blocked.status_code == 429
+        assert b"slow down" in blocked.content
+        assert b"help@example.com" in blocked.content
+
+
+# ---------------------------------------------------------------------------
+# X-RateLimit-* headers on allowed responses (and on the 429).
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitHeaders:
+    """Allowed responses advertise the standard X-RateLimit-* headers."""
+
+    def test_headers_present_and_decrementing(self, real_backend):
+        """Each allowed response carries X-RateLimit-Limit and Remaining.
+
+        Remaining decreases as the bucket fills; the 429 reports zero remaining.
+        """
+
+        @rate_limit(key="ip", rate="3/m")
+        def view(_request):
+            return HttpResponse("ok")
+
+        ip = "203.0.113.170"
+        r1 = view(make_request(ip=ip))
+        r2 = view(make_request(ip=ip))
+        r3 = view(make_request(ip=ip))
+        r4 = view(make_request(ip=ip))
+
+        # Limit header is advertised on every allowed response.
+        assert r1.headers["X-RateLimit-Limit"] == "3"
+        assert "X-RateLimit-Reset" in r1.headers
+
+        # Remaining counts down monotonically.
+        remaining = [int(r.headers["X-RateLimit-Remaining"]) for r in (r1, r2, r3)]
+        assert remaining == sorted(remaining, reverse=True)
+        assert remaining[0] >= remaining[-1]
+
+        # The blocked response reports the limit with zero remaining.
+        assert r4.status_code == 429
+        assert r4.headers["X-RateLimit-Limit"] == "3"
+        assert r4.headers["X-RateLimit-Remaining"] == "0"
+
+
+# ---------------------------------------------------------------------------
+# The ``ratelimit`` alias behaves identically to ``rate_limit``.
+# ---------------------------------------------------------------------------
+
+
+class TestRatelimitAlias:
+    """The django-ratelimit-compatible ``ratelimit`` alias is a true alias."""
+
+    def test_alias_enforces_limit(self, real_backend):
+        """@ratelimit(...) enforces exactly like @rate_limit(...)."""
+
+        @ratelimit(key="ip", rate="2/m")
+        def view(_request):
+            return HttpResponse("ok")
+
+        codes = exhaust(view, 3, ip="203.0.113.180")
+        assert codes == [200, 200, 429]
+
+    def test_alias_passes_all_options(self, real_backend, caplog):
+        """The alias forwards block/shadow/cost/lists faithfully.
+
+        shadow+cost here serves 200 throughout and logs a shadow block once the
+        weighted budget spills.
+        """
+
+        @ratelimit(key="ip", rate="4/m", cost=2, shadow=True)
+        def view(_request):
+            return HttpResponse("ok")
+
+        with caplog.at_level(logging.INFO, logger=SHADOW_LOGGER):
+            codes = exhaust(view, 4, ip="203.0.113.181")
+
+        # cost=2, budget 4 -> 2 calls fit; shadow keeps the rest at 200.
+        assert codes == [200] * 4
+        assert any(
+            "SHADOW_RATE_LIMIT_BLOCK" in rec.getMessage() for rec in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# DATABASE backend scenarios (real Django test DB).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestDatabaseBackend:
+    """The same decorator semantics hold against the real Django test DB."""
+
+    def test_login_throttle_on_database(self):
+        """Login endpoint on the DB backend: 3/m per IP blocks the 4th attempt.
+
+        A second IP keeps its own independent bucket.
+        """
+
+        with use_backend("database"):
+
+            @rate_limit(key="ip", rate="3/m")
+            def login(_request):
+                return HttpResponse("ok")
+
+            attacker = exhaust(login, 4, ip="203.0.113.190")
+            assert attacker == [200, 200, 200, 429]
+
+            # Independent bucket for a different IP.
+            other = exhaust(login, 3, ip="203.0.113.191")
+            assert other == [200, 200, 200]
+
+    def test_soft_limit_flag_on_database(self):
+        """Block=False on the DB backend: requests are served 200.
+
+        The request is flagged once the limit is exceeded.
+        """
+
+        with use_backend("database"):
+            seen = []
+
+            @rate_limit(key="ip", rate="2/m", block=False)
+            def view(request):
+                seen.append(getattr(request, "rate_limit_exceeded", False))
+                return HttpResponse("ok")
+
+            codes = exhaust(view, 4, ip="203.0.113.192")
+            assert codes == [200, 200, 200, 200]
+            assert seen[2] is True and seen[3] is True
+
+    def test_headers_on_database_backend(self):
+        """Allowed responses on the DB backend advertise X-RateLimit-* headers."""
+
+        with use_backend("database"):
+
+            @rate_limit(key="ip", rate="5/m")
+            def view(_request):
+                return HttpResponse("ok")
+
+            resp = view(make_request(ip="203.0.113.193"))
+            assert resp.status_code == 200
+            assert resp.headers["X-RateLimit-Limit"] == "5"
+            assert "X-RateLimit-Remaining" in resp.headers

--- a/tests/e2e/test_drf_e2e.py
+++ b/tests/e2e/test_drf_e2e.py
@@ -1,0 +1,527 @@
+"""Real-backend end-to-end tests for the DRF throttle adapter.
+
+These tests stand up REAL Django REST Framework views (an ``APIView`` and a
+``ViewSet``), wire them into a URLconf, and drive them with DRF's
+``APIClient`` against REAL storage (live Redis / async Redis / live MongoDB /
+in-memory). The rate-limit backend is NEVER mocked — every counter increment
+hits the actual store via ``django_smart_ratelimit``'s DRF throttle classes.
+
+Scope under test (``django_smart_ratelimit.integrations.drf``):
+
+    - ``UserRateLimitThrottle``  -- per-user bucket, IP fallback for anon.
+    - ``AnonRateLimitThrottle``  -- per-IP bucket.
+    - ``ScopedRateLimitThrottle`` -- rate resolved from ``view.throttle_scope``.
+    - ``SmartRateLimitThrottle`` subclasses with:
+        * a ``rate`` attribute, a callable ``rate``, a callable ``cost`` /
+          ``get_cost`` override (weighted throttling),
+        * the v4 decorator-parity attributes ``allow_list`` / ``deny_list`` /
+          ``shadow``.
+
+Observable behavior asserted: HTTP 200 vs 429, the ``Retry-After`` header /
+``throttle.wait()`` value on a 429, independent buckets per distinct key
+(per-IP, per-user, per-scope), authed-vs-anon tiers, deny-list blocking,
+allow-list bypass, and shadow-mode allow-but-log.
+
+The module is skipped entirely when DRF is not installed.
+"""
+
+import logging
+
+import pytest
+
+from django.test import override_settings
+from django.urls import path
+
+# ``real_backend`` is a fixture auto-discovered from tests/e2e/conftest.py; only
+# the request-building helpers need importing here.
+from .conftest import AuthedUser
+
+try:
+    from rest_framework import status, viewsets
+    from rest_framework.response import Response
+    from rest_framework.test import APIClient
+    from rest_framework.views import APIView
+
+    DRF_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only when DRF is absent
+    DRF_AVAILABLE = False
+
+    APIClient = APIView = Response = viewsets = status = None  # type: ignore
+
+from django_smart_ratelimit.integrations.drf import (  # noqa: E402
+    AnonRateLimitThrottle,
+    ScopedRateLimitThrottle,
+    SmartRateLimitThrottle,
+    UserRateLimitThrottle,
+)
+
+pytestmark = pytest.mark.skipif(
+    not DRF_AVAILABLE, reason="Django REST Framework not installed"
+)
+
+
+# ---------------------------------------------------------------------------
+# Real throttle subclasses exercised through real views.
+# ---------------------------------------------------------------------------
+if DRF_AVAILABLE:
+
+    class LoginAnonThrottle(AnonRateLimitThrottle):
+        """A tight per-IP login limit: 5 requests/minute."""
+
+        rate = "5/m"
+
+    class TieredUserThrottle(UserRateLimitThrottle):
+        """Authed-user tier: 10/minute, keyed by user id (IP for anon)."""
+
+        rate = "10/m"
+
+    def _tiered_rate(throttle, request):
+        """Callable rate: staff users get a far higher tier than mortals."""
+        user = getattr(request, "user", None)
+        if user is not None and getattr(user, "is_staff", False):
+            return "100/m"
+        return "3/m"
+
+    class CallableRateThrottle(SmartRateLimitThrottle):
+        """Dynamic rate resolved per-request from the user's privilege."""
+
+        scope = "callable_tier"
+        rate = _tiered_rate
+
+    class SearchCostThrottle(SmartRateLimitThrottle):
+        """Weighted throttle: a 'deep' search costs more tokens than a cheap one.
+
+        Budget is 10 tokens/minute. A request carrying ``?deep=1`` spends 5
+        tokens; a normal request spends 1. ``get_cost`` reads the request, so
+        two deep searches (10 tokens) exhaust the budget and the third deep
+        search is blocked, while many cheap searches are still permitted.
+        """
+
+        scope = "search_cost"
+        rate = "10/m"
+
+        def get_cost(self, request, view):
+            return 5 if request.query_params.get("deep") == "1" else 1
+
+    class DenyListThrottle(AnonRateLimitThrottle):
+        """Per-IP 100/m, but a known-bad CIDR is hard-blocked regardless."""
+
+        rate = "100/m"
+        deny_list = ["198.51.100.0/24"]
+
+    class AllowListThrottle(AnonRateLimitThrottle):
+        """Per-IP 2/m, but an internal CIDR bypasses throttling entirely."""
+
+        rate = "2/m"
+        allow_list = ["10.0.0.0/8"]
+
+    class ShadowDenyThrottle(AnonRateLimitThrottle):
+        """Deny-list in SHADOW mode: would-be blocks are allowed but logged."""
+
+        rate = "100/m"
+        deny_list = ["198.51.100.0/24"]
+        shadow = True
+
+    class ShadowRateThrottle(AnonRateLimitThrottle):
+        """A new 2/m limit run in shadow: never blocks, only logs over-limit."""
+
+        rate = "2/m"
+        shadow = True
+
+    # --- Views -------------------------------------------------------------
+
+    class LoginView(APIView):
+        """Public login endpoint protected per-IP (anon throttle)."""
+
+        permission_classes = []
+        throttle_classes = [LoginAnonThrottle]
+
+        def post(self, request):
+            return Response({"detail": "ok"})
+
+    class ProfileView(APIView):
+        """Authed endpoint: each user gets their own 10/m bucket."""
+
+        permission_classes = []
+        throttle_classes = [TieredUserThrottle]
+
+        def get(self, request):
+            return Response({"detail": "profile"})
+
+    class CallableRateView(APIView):
+        """Tier resolved at request time via a callable rate."""
+
+        permission_classes = []
+        throttle_classes = [CallableRateThrottle]
+
+        def get(self, request):
+            return Response({"detail": "ok"})
+
+    class SearchView(APIView):
+        """Weighted search endpoint (deep searches cost more)."""
+
+        permission_classes = []
+        throttle_classes = [SearchCostThrottle]
+
+        def get(self, request):
+            return Response({"detail": "results"})
+
+    class ReportsView(APIView):
+        """Scoped endpoint: rate comes from ``view.throttle_scope``."""
+
+        permission_classes = []
+        throttle_classes = [ScopedRateLimitThrottle]
+        throttle_scope = "reports"
+
+        def get(self, request):
+            return Response({"detail": "report"})
+
+    class ExportsView(APIView):
+        """A second scoped endpoint with its own scope/bucket."""
+
+        permission_classes = []
+        throttle_classes = [ScopedRateLimitThrottle]
+        throttle_scope = "exports"
+
+        def get(self, request):
+            return Response({"detail": "export"})
+
+    class DenyListView(APIView):
+        permission_classes = []
+        throttle_classes = [DenyListThrottle]
+
+        def get(self, request):
+            return Response({"detail": "ok"})
+
+    class AllowListView(APIView):
+        permission_classes = []
+        throttle_classes = [AllowListThrottle]
+
+        def get(self, request):
+            return Response({"detail": "ok"})
+
+    class ShadowDenyView(APIView):
+        permission_classes = []
+        throttle_classes = [ShadowDenyThrottle]
+
+        def get(self, request):
+            return Response({"detail": "ok"})
+
+    class ShadowRateView(APIView):
+        permission_classes = []
+        throttle_classes = [ShadowRateThrottle]
+
+        def get(self, request):
+            return Response({"detail": "ok"})
+
+    class ItemViewSet(viewsets.ViewSet):
+        """A real ViewSet whose actions are throttled per-IP at 5/m."""
+
+        permission_classes = []
+        throttle_classes = [LoginAnonThrottle]
+
+        def list(self, request):
+            return Response([{"id": 1}])
+
+        def create(self, request):
+            return Response({"id": 2}, status=status.HTTP_201_CREATED)
+
+    # --- URLconf (this module IS the ROOT_URLCONF for these tests) ---------
+
+    urlpatterns = [
+        path("login/", LoginView.as_view()),
+        path("profile/", ProfileView.as_view()),
+        path("tier/", CallableRateView.as_view()),
+        path("search/", SearchView.as_view()),
+        path("reports/", ReportsView.as_view()),
+        path("exports/", ExportsView.as_view()),
+        path("deny/", DenyListView.as_view()),
+        path("allow/", AllowListView.as_view()),
+        path("shadow-deny/", ShadowDenyView.as_view()),
+        path("shadow-rate/", ShadowRateView.as_view()),
+        path(
+            "items/",
+            ItemViewSet.as_view({"get": "list", "post": "create"}),
+        ),
+    ]
+
+
+# Route every request in this module through the views defined above.
+pytestmark = [
+    pytestmark,
+    pytest.mark.urls(__name__),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _codes(client, path_, n, ip="203.0.113.10", **kw):
+    """Hit ``path_`` n times from one IP; return the list of status codes."""
+    out = []
+    for _ in range(n):
+        resp = client.get(path_, REMOTE_ADDR=ip, **kw)
+        out.append(resp.status_code)
+    return out
+
+
+# ===========================================================================
+# AnonRateLimitThrottle: per-IP login limiter
+# ===========================================================================
+def test_login_anon_per_ip_blocks_attacker_not_legit_user(real_backend):
+    """Login endpoint (5/min per IP): an attacker hammering from one IP gets
+    blocked after 5 attempts while a legitimate user on another IP is
+    unaffected, on every real backend.
+    """
+    client = APIClient()
+    attacker = "198.51.100.5"
+    victim = "203.0.113.77"
+
+    # 5 allowed, then 429 for the attacker.
+    codes = [client.post("/login/", REMOTE_ADDR=attacker).status_code for _ in range(6)]
+    assert codes == [200, 200, 200, 200, 200, 429], codes
+
+    # A legitimate user on a different IP has a completely independent bucket.
+    assert client.post("/login/", REMOTE_ADDR=victim).status_code == 200
+
+
+def test_login_429_sets_retry_after(real_backend):
+    """When the per-IP login limit is exceeded the 429 carries a positive
+    integer ``Retry-After`` header derived from the throttle's wait().
+    """
+    client = APIClient()
+    ip = "198.51.100.40"
+    for _ in range(5):
+        assert client.post("/login/", REMOTE_ADDR=ip).status_code == 200
+
+    blocked = client.post("/login/", REMOTE_ADDR=ip)
+    assert blocked.status_code == 429
+    retry_after = blocked.headers.get("Retry-After")
+    assert retry_after is not None, blocked.headers
+    # 5/m window -> wait should be > 0 and at most the 60s period.
+    assert 0 < int(retry_after) <= 60
+
+
+# ===========================================================================
+# UserRateLimitThrottle: per-user buckets, authed vs anon tiers
+# ===========================================================================
+def test_user_throttle_independent_buckets_per_user(real_backend):
+    """Two authenticated users each get their own 10/min bucket: exhausting
+    user A's budget never affects user B.
+    """
+    client = APIClient()
+    user_a = AuthedUser(uid=4001)
+    user_b = AuthedUser(uid=4002)
+
+    client.force_authenticate(user=user_a)
+    codes_a = [client.get("/profile/").status_code for _ in range(11)]
+    assert codes_a == [200] * 10 + [429], codes_a
+
+    # User B, sharing the same client IP, is untouched -> keyed by user id.
+    client.force_authenticate(user=user_b)
+    assert client.get("/profile/").status_code == 200
+
+
+def test_user_throttle_authed_tier_higher_than_anon(real_backend):
+    """A public API where authed users get a higher tier than anon: the anon
+    LoginView caps at 5/min per IP, while an authed user on ProfileView gets
+    10/min — demonstrating the higher authed tier on a real backend.
+    """
+    client = APIClient()
+    ip = "203.0.113.120"
+
+    # Anonymous tier on the login endpoint: 5 then blocked.
+    anon_codes = [client.post("/login/", REMOTE_ADDR=ip).status_code for _ in range(6)]
+    assert anon_codes == [200] * 5 + [429], anon_codes
+
+    # Authed tier on the profile endpoint: 10 allowed (independent bucket).
+    client.force_authenticate(user=AuthedUser(uid=4100))
+    authed_codes = [
+        client.get("/profile/", REMOTE_ADDR=ip).status_code for _ in range(10)
+    ]
+    assert authed_codes == [200] * 10, authed_codes
+    assert client.get("/profile/", REMOTE_ADDR=ip).status_code == 429
+
+
+# ===========================================================================
+# SmartRateLimitThrottle: callable rate
+# ===========================================================================
+def test_callable_rate_staff_get_higher_tier(real_backend):
+    """A callable ``rate`` resolves the tier from the request: a staff user
+    sails past the 3/min mortal limit because staff resolve to 100/min.
+    """
+    client = APIClient()
+
+    # Non-staff authed user -> 3/m.
+    mortal = AuthedUser(uid=5001)
+    client.force_authenticate(user=mortal)
+    mortal_codes = [client.get("/tier/").status_code for _ in range(4)]
+    assert mortal_codes == [200, 200, 200, 429], mortal_codes
+
+    # Staff user (distinct id => distinct bucket) -> 100/m, never blocked here.
+    staff = AuthedUser(uid=5002)
+    staff.is_staff = True
+    client.force_authenticate(user=staff)
+    staff_codes = [client.get("/tier/").status_code for _ in range(20)]
+    assert staff_codes == [200] * 20, staff_codes
+
+
+# ===========================================================================
+# SmartRateLimitThrottle: get_cost (weighted throttling)
+# ===========================================================================
+def test_get_cost_weighted_throttling(real_backend):
+    """Weighted throttling via ``get_cost``: with a 10-token/min budget, a
+    'deep' search spends 5 tokens. Two deep searches drain the budget and the
+    third is blocked — proving cost is honored against the real store.
+    """
+    client = APIClient()
+    ip = "203.0.113.200"
+
+    # Two deep searches (cost 5 each) = 10 tokens -> both allowed.
+    assert client.get("/search/", {"deep": "1"}, REMOTE_ADDR=ip).status_code == 200
+    assert client.get("/search/", {"deep": "1"}, REMOTE_ADDR=ip).status_code == 200
+    # Third deep search would push to 15 tokens -> blocked.
+    assert client.get("/search/", {"deep": "1"}, REMOTE_ADDR=ip).status_code == 429
+
+
+def test_get_cost_cheap_requests_within_budget(real_backend):
+    """The same 10-token budget allows up to 10 cheap (cost-1) requests; the
+    11th is blocked.
+    """
+    client = APIClient()
+    ip = "203.0.113.201"
+    codes = _codes(client, "/search/", 11, ip=ip)
+    assert codes == [200] * 10 + [429], codes
+
+
+# ===========================================================================
+# ScopedRateLimitThrottle: rate from view.throttle_scope
+# ===========================================================================
+@override_settings(
+    REST_FRAMEWORK={"DEFAULT_THROTTLE_RATES": {"reports": "4/m", "exports": "2/m"}}
+)
+def test_scoped_throttle_uses_view_scope(real_backend):
+    """Each scoped view resolves its own rate from DEFAULT_THROTTLE_RATES via
+    ``view.throttle_scope``: /reports/ enforces 4/min and /exports/ enforces
+    2/min. The scope selects the *rate*; the cache key is the client IP, so
+    distinct IPs are used to keep the two scopes from sharing a per-IP bucket.
+    """
+    client = APIClient()
+    reports_ip = "203.0.113.210"
+    exports_ip = "203.0.113.211"
+
+    reports = _codes(client, "/reports/", 5, ip=reports_ip)
+    assert reports == [200, 200, 200, 200, 429], reports
+
+    # The 'exports' scope resolves a smaller (2/m) limit.
+    exports = _codes(client, "/exports/", 3, ip=exports_ip)
+    assert exports == [200, 200, 429], exports
+
+
+@override_settings(
+    REST_FRAMEWORK={"DEFAULT_THROTTLE_RATES": {"reports": "4/m", "exports": "2/m"}}
+)
+def test_scoped_throttle_buckets_independent_per_ip(real_backend):
+    """Distinct IPs hitting the same scoped endpoint keep independent buckets."""
+    client = APIClient()
+    a, b = "203.0.113.220", "203.0.113.221"
+
+    assert _codes(client, "/exports/", 3, ip=a) == [200, 200, 429]
+    # Second IP is unaffected by the first IP exhausting its bucket.
+    assert _codes(client, "/exports/", 2, ip=b) == [200, 200]
+
+
+# ===========================================================================
+# v4 parity: deny_list / allow_list / shadow as throttle attributes
+# ===========================================================================
+def test_deny_list_blocks_client(real_backend):
+    """A deny-listed client (CIDR 198.51.100.0/24) is blocked on the very first
+    request — before any counting — while an off-list client is served.
+    """
+    client = APIClient()
+
+    # Deny-listed IP: blocked immediately (429), even though the rate is 100/m.
+    assert client.get("/deny/", REMOTE_ADDR="198.51.100.9").status_code == 429
+    # An IP outside the deny CIDR is allowed.
+    assert client.get("/deny/", REMOTE_ADDR="203.0.113.9").status_code == 200
+
+
+def test_allow_list_bypasses_throttle(real_backend):
+    """An allow-listed internal client (10.0.0.0/8) bypasses throttling
+    entirely: it stays 200 well past the 2/min limit that blocks others.
+    """
+    client = APIClient()
+
+    internal = "10.1.2.3"
+    external = "203.0.113.30"
+
+    # Allow-listed: 200 for many requests despite the 2/m cap.
+    assert _codes(client, "/allow/", 8, ip=internal) == [200] * 8
+
+    # A normal external client is still throttled at 2/m on the same view.
+    assert _codes(client, "/allow/", 3, ip=external) == [200, 200, 429]
+
+
+def test_shadow_deny_allows_but_logs(real_backend, caplog):
+    """A deny-list run in SHADOW mode logs the would-be block but still serves
+    the request (200) — the rollout-validation path.
+    """
+    client = APIClient()
+    with caplog.at_level(logging.INFO, logger="django_smart_ratelimit.pipeline"):
+        resp = client.get("/shadow-deny/", REMOTE_ADDR="198.51.100.50")
+
+    assert resp.status_code == 200
+    assert any("SHADOW" in r.getMessage() for r in caplog.records), [
+        r.getMessage() for r in caplog.records
+    ]
+
+
+def test_shadow_rate_allows_over_limit_but_logs(real_backend, caplog):
+    """A new 2/min limit deployed in SHADOW mode never returns 429: requests
+    past the limit are served (200) but each over-limit hit emits a SHADOW log
+    line so operators can size the limit before enforcing it.
+    """
+    client = APIClient()
+    ip = "203.0.113.40"
+    with caplog.at_level(logging.INFO, logger="django_smart_ratelimit.pipeline"):
+        codes = _codes(client, "/shadow-rate/", 5, ip=ip)
+
+    # Shadow never blocks.
+    assert codes == [200] * 5, codes
+    # At least one over-limit request (#3..#5) produced a SHADOW log line.
+    assert any("SHADOW" in r.getMessage() for r in caplog.records), [
+        r.getMessage() for r in caplog.records
+    ]
+
+
+# ===========================================================================
+# Real ViewSet routed through APIClient
+# ===========================================================================
+def test_viewset_actions_share_per_ip_bucket(real_backend):
+    """A real ViewSet throttled per-IP at 5/min: list() and create() actions
+    draw from the same per-IP bucket, so mixing them still blocks after 5.
+    """
+    client = APIClient()
+    ip = "203.0.113.50"
+
+    # 3 lists + 2 creates = 5 allowed, then the 6th (a list) is blocked.
+    assert client.get("/items/", REMOTE_ADDR=ip).status_code == 200
+    assert client.get("/items/", REMOTE_ADDR=ip).status_code == 200
+    assert client.post("/items/", REMOTE_ADDR=ip).status_code == 201
+    assert client.post("/items/", REMOTE_ADDR=ip).status_code == 201
+    assert client.get("/items/", REMOTE_ADDR=ip).status_code == 200
+    # Budget (5) now spent.
+    assert client.get("/items/", REMOTE_ADDR=ip).status_code == 429
+
+
+def test_viewset_independent_bucket_per_ip(real_backend):
+    """Distinct IPs against the ViewSet keep independent per-IP buckets."""
+    client = APIClient()
+    a, b = "203.0.113.60", "203.0.113.61"
+
+    for _ in range(5):
+        assert client.get("/items/", REMOTE_ADDR=a).status_code == 200
+    assert client.get("/items/", REMOTE_ADDR=a).status_code == 429
+
+    # Second IP unaffected.
+    assert client.get("/items/", REMOTE_ADDR=b).status_code == 200

--- a/tests/e2e/test_keys_e2e.py
+++ b/tests/e2e/test_keys_e2e.py
@@ -1,0 +1,732 @@
+"""Real-backend end-to-end scenarios for rate-limit KEY functions.
+
+Every public key function (used either as the decorator ``key=`` or called
+directly) is exercised against a REAL store via the shared harness. The
+controlling assertion throughout is the bucketing contract:
+
+    * DISTINCT key values get INDEPENDENT buckets (one identity being blocked
+      never bleeds into another), and
+    * the SAME key value SHARES one bucket (so a single identity is actually
+      limited).
+
+Each scenario uses its own DISTINCT IPs / users / headers so tests never depend
+on one another, and the ``real_backend`` fixture flushes the real store before
+and after each test. The proxy-trust and path/bypass helpers are validated as
+real request scenarios via :func:`get_client_ip` and the public utility
+functions.
+"""
+
+import pytest
+
+from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpResponse
+from django.test import override_settings
+
+from django_smart_ratelimit import (
+    api_key_aware_key,
+    composite_key,
+    device_fingerprint_key,
+    geographic_key,
+    get_ip_key,
+    get_rate_for_path,
+    get_user_key,
+    is_exempt_request,
+    is_internal_request,
+    rate_limit,
+    should_skip_path,
+    tenant_aware_key,
+    time_aware_key,
+    user_or_ip_key,
+    user_role_key,
+)
+from django_smart_ratelimit.enums import RateLimitKey
+from django_smart_ratelimit.policy import get_client_ip
+
+from .conftest import AnonUser, AuthedUser, make_request
+
+OK = 200
+TOO_MANY = 429
+
+
+def _ok_view(_request):
+    """A trivial 200 view body to wrap with the rate-limit decorator."""
+    return HttpResponse("ok")
+
+
+def _codes(view, requests):
+    """Drive a view across a sequence of pre-built requests; return codes."""
+    return [view(req).status_code for req in requests]
+
+
+def _key(fn, **opts):
+    """Adapt a single-argument key function for use as a decorator ``key=``.
+
+    The decorator calls a callable key as ``key(request, *view_args,
+    **view_kwargs)``, so a bare ``fn(request)`` helper must be wrapped to
+    ignore the forwarded view positional/keyword args. This is the realistic
+    public pattern for using the library's key helpers (and lets us pass
+    per-call options such as ``header_name`` / ``time_window``).
+    """
+
+    def _adapter(request, *args, **kwargs):
+        return fn(request, **opts)
+
+    return _adapter
+
+
+# ---------------------------------------------------------------------------
+# Built-in string / enum keys via the decorator
+# ---------------------------------------------------------------------------
+
+
+def test_ip_key_blocks_attacker_not_legit_user(real_backend):
+    """Public login endpoint keyed by "ip" at 3/min.
+
+    An attacker hammering from one IP is blocked after 3 requests while a
+    legitimate user on a different IP is completely unaffected — proving each
+    distinct IP gets an independent bucket on the real backend.
+    """
+
+    @rate_limit(key="ip", rate="3/m")
+    def login(_request):
+        return _ok_view(_request)
+
+    attacker = [make_request(ip="198.51.100.7") for _ in range(5)]
+    assert _codes(login, attacker) == [OK, OK, OK, TOO_MANY, TOO_MANY]
+
+    # A legitimate user from a totally different IP is untouched.
+    legit = [make_request(ip="198.51.100.200") for _ in range(3)]
+    assert _codes(login, legit) == [OK, OK, OK]
+
+
+def test_ip_enum_key_matches_string(real_backend):
+    """``RateLimitKey.IP`` enum behaves identically to the literal "ip"."""
+
+    @rate_limit(key=RateLimitKey.IP, rate="2/m")
+    def view(_request):
+        return _ok_view(_request)
+
+    codes = _codes(view, [make_request(ip="198.51.100.21") for _ in range(4)])
+    assert codes == [OK, OK, TOO_MANY, TOO_MANY]
+
+
+def test_user_key_independent_per_user(real_backend):
+    """API keyed by "user" at 2/min: two authenticated users have separate
+    quotas; exhausting user A's bucket never blocks user B.
+    """
+
+    @rate_limit(key="user", rate="2/m")
+    def view(_request):
+        return _ok_view(_request)
+
+    user_a = AuthedUser(uid=901)
+    user_b = AuthedUser(uid=902)
+
+    a = [make_request(ip="203.0.113.31", user=user_a) for _ in range(3)]
+    assert _codes(view, a) == [OK, OK, TOO_MANY]
+
+    b = [make_request(ip="203.0.113.31", user=user_b) for _ in range(2)]
+    assert _codes(view, b) == [OK, OK]
+
+
+def test_user_key_anonymous_falls_back_to_ip(real_backend):
+    """Anonymous traffic on a "user"-keyed view falls back to the client IP,
+    so two anonymous clients on different IPs are bucketed separately.
+    """
+
+    @rate_limit(key="user", rate="2/m")
+    def view(_request):
+        return _ok_view(_request)
+
+    anon_one = [make_request(ip="203.0.113.41", user=AnonUser()) for _ in range(3)]
+    assert _codes(view, anon_one) == [OK, OK, TOO_MANY]
+
+    anon_two = [make_request(ip="203.0.113.42", user=AnonUser()) for _ in range(2)]
+    assert _codes(view, anon_two) == [OK, OK]
+
+
+def test_user_or_ip_key_authenticated_shares_bucket_across_ips(real_backend):
+    """``RateLimitKey.USER_OR_IP``: an authenticated user roaming across two
+    IPs shares ONE bucket (keyed on the user id), while anonymous users are
+    keyed by IP. Regression guard for the v3 fix that stopped this collapsing
+    onto a single global bucket.
+    """
+
+    @rate_limit(key=RateLimitKey.USER_OR_IP, rate="3/m")
+    def view(_request):
+        return _ok_view(_request)
+
+    user = AuthedUser(uid=950)
+    # Same user, two different IPs -> still one shared bucket of 3.
+    roaming = [
+        make_request(ip="203.0.113.51", user=user),
+        make_request(ip="203.0.113.52", user=user),
+        make_request(ip="203.0.113.51", user=user),
+        make_request(ip="203.0.113.52", user=user),
+    ]
+    assert _codes(view, roaming) == [OK, OK, OK, TOO_MANY]
+
+    # An anonymous client (keyed by its own IP) is unaffected.
+    anon = [make_request(ip="203.0.113.60", user=AnonUser()) for _ in range(3)]
+    assert _codes(view, anon) == [OK, OK, OK]
+
+
+def test_user_or_ip_key_not_a_shared_global_bucket(real_backend):
+    """Two distinct anonymous IPs on a ``user_or_ip`` view must NOT share a
+    bucket (the literal must not fall through to a single global key).
+    """
+
+    @rate_limit(key="user_or_ip", rate="1/m")
+    def view(_request):
+        return _ok_view(_request)
+
+    assert make_request(ip="203.0.113.71").path  # sanity: request builds
+    first = [make_request(ip="203.0.113.71") for _ in range(2)]
+    assert _codes(view, first) == [OK, TOO_MANY]
+    # Different IP still gets its own first hit.
+    assert _codes(view, [make_request(ip="203.0.113.72")]) == [OK]
+
+
+# ---------------------------------------------------------------------------
+# Header- and param-prefixed keys
+# ---------------------------------------------------------------------------
+
+
+def test_header_key_per_api_key(real_backend):
+    """Partner API keyed by ``f"{RateLimitKey.HEADER}:X-Api-Key"`` at 2/min.
+
+    Each distinct X-Api-Key header value gets its own bucket; a missing header
+    collapses all header-less callers onto one (empty-value) bucket.
+    """
+    key = f"{RateLimitKey.HEADER}:X-Api-Key"
+
+    @rate_limit(key=key, rate="2/m")
+    def view(_request):
+        return _ok_view(_request)
+
+    # Same IP, two different API keys -> independent buckets.
+    a = [
+        make_request(ip="203.0.113.81", headers={"X-Api-Key": "alpha"})
+        for _ in range(3)
+    ]
+    assert _codes(view, a) == [OK, OK, TOO_MANY]
+
+    b = [
+        make_request(ip="203.0.113.81", headers={"X-Api-Key": "bravo"})
+        for _ in range(2)
+    ]
+    assert _codes(view, b) == [OK, OK]
+
+
+def test_get_param_key_independent_per_value(real_backend):
+    """A search endpoint keyed by ``get:tenant``: each ?tenant= value gets its
+    own bucket; the same value shares one.
+    """
+
+    @rate_limit(key="get:tenant", rate="2/m")
+    def view(_request):
+        return _ok_view(_request)
+
+    acme = [
+        make_request(ip="203.0.113.91", params={"tenant": "acme"}) for _ in range(3)
+    ]
+    assert _codes(view, acme) == [OK, OK, TOO_MANY]
+
+    globex = [
+        make_request(ip="203.0.113.91", params={"tenant": "globex"}) for _ in range(2)
+    ]
+    assert _codes(view, globex) == [OK, OK]
+
+
+def test_param_alias_key_matches_get(real_backend):
+    """``f"{RateLimitKey.PARAM}:page"`` is an alias of ``get:`` and buckets per
+    query-parameter value independently.
+    """
+    key = f"{RateLimitKey.PARAM}:page"
+
+    @rate_limit(key=key, rate="1/m")
+    def view(_request):
+        return _ok_view(_request)
+
+    p1 = [make_request(ip="203.0.113.101", params={"page": "1"}) for _ in range(2)]
+    assert _codes(view, p1) == [OK, TOO_MANY]
+
+    p2 = [make_request(ip="203.0.113.101", params={"page": "2"})]
+    assert _codes(view, p2) == [OK]
+
+
+# ---------------------------------------------------------------------------
+# Key functions passed directly as the decorator callable
+# ---------------------------------------------------------------------------
+
+
+def test_geographic_key_per_country(real_backend):
+    """``geographic_key`` (Cloudflare CF-IPCOUNTRY): same user from two
+    countries gets two buckets; same country shares one.
+    """
+
+    @rate_limit(key=_key(geographic_key), rate="2/m")
+    def view(_request):
+        return _ok_view(_request)
+
+    de = [
+        make_request(ip="203.0.113.111", headers={"CF-IPCOUNTRY": "DE"})
+        for _ in range(3)
+    ]
+    assert _codes(view, de) == [OK, OK, TOO_MANY]
+
+    fr = [
+        make_request(ip="203.0.113.111", headers={"CF-IPCOUNTRY": "FR"})
+        for _ in range(2)
+    ]
+    assert _codes(view, fr) == [OK, OK]
+
+
+def test_composite_key_prefers_user_over_ip(real_backend):
+    """``composite_key`` (default ["user", "ip"]): an authenticated user is
+    keyed by id regardless of IP, while anonymous callers fall back to IP.
+    """
+
+    @rate_limit(key=_key(composite_key), rate="2/m")
+    def view(_request):
+        return _ok_view(_request)
+
+    user = AuthedUser(uid=1201)
+    auth_reqs = [
+        make_request(ip="203.0.113.121", user=user),
+        make_request(ip="203.0.113.122", user=user),
+        make_request(ip="203.0.113.121", user=user),
+    ]
+    assert _codes(view, auth_reqs) == [OK, OK, TOO_MANY]
+
+    # Anonymous on a fresh IP gets its own bucket.
+    anon = [make_request(ip="203.0.113.130", user=AnonUser()) for _ in range(2)]
+    assert _codes(view, anon) == [OK, OK]
+
+
+def test_api_key_aware_key_uses_key_then_falls_back(real_backend):
+    """``api_key_aware_key``: keyed on X-API-Key when present, otherwise falls
+    back to user/IP. Two API keys are independent; the fallback path buckets
+    by IP.
+    """
+
+    @rate_limit(key=_key(api_key_aware_key), rate="2/m")
+    def view(_request):
+        return _ok_view(_request)
+
+    k1 = [
+        make_request(ip="203.0.113.141", headers={"X-API-Key": "key-1"})
+        for _ in range(3)
+    ]
+    assert _codes(view, k1) == [OK, OK, TOO_MANY]
+
+    k2 = [
+        make_request(ip="203.0.113.141", headers={"X-API-Key": "key-2"})
+        for _ in range(2)
+    ]
+    assert _codes(view, k2) == [OK, OK]
+
+    # No API key -> falls back to IP; distinct IP is its own bucket.
+    no_key = [make_request(ip="203.0.113.150") for _ in range(2)]
+    assert _codes(view, no_key) == [OK, OK]
+
+
+def test_time_aware_key_window_in_key(real_backend):
+    """``time_aware_key`` embeds the time window in the key. Within a single
+    window calls accumulate against the same bucket, so the limit is enforced
+    normally for one identity.
+    """
+
+    @rate_limit(key=_key(time_aware_key, time_window="hour"), rate="2/m")
+    def view(_request):
+        return _ok_view(_request)
+
+    same = [make_request(ip="203.0.113.161") for _ in range(3)]
+    assert _codes(view, same) == [OK, OK, TOO_MANY]
+
+    # A different IP within the same window is a separate bucket.
+    other = [make_request(ip="203.0.113.162") for _ in range(2)]
+    assert _codes(view, other) == [OK, OK]
+
+
+def test_tenant_aware_key_per_tenant(real_backend):
+    """``tenant_aware_key`` (get_tenant_key) buckets per tenant id read from a
+    ?tenant_id= param: each tenant gets an independent quota.
+    """
+
+    @rate_limit(key=_key(tenant_aware_key), rate="2/m")
+    def view(_request):
+        return _ok_view(_request)
+
+    t1 = [
+        make_request(ip="203.0.113.171", params={"tenant_id": "t1"}) for _ in range(3)
+    ]
+    assert _codes(view, t1) == [OK, OK, TOO_MANY]
+
+    t2 = [
+        make_request(ip="203.0.113.171", params={"tenant_id": "t2"}) for _ in range(2)
+    ]
+    assert _codes(view, t2) == [OK, OK]
+
+
+def test_device_fingerprint_key_per_device(real_backend):
+    """``device_fingerprint_key`` hashes UA + Accept-* + DNT headers: two
+    distinct browser fingerprints from the same IP get separate buckets, while
+    identical headers share one.
+    """
+
+    @rate_limit(key=_key(device_fingerprint_key), rate="2/m")
+    def view(_request):
+        return _ok_view(_request)
+
+    chrome_headers = {
+        "User-Agent": "Mozilla/5.0 (Chrome)",
+        "Accept-Language": "en-US",
+        "Accept-Encoding": "gzip",
+    }
+    firefox_headers = {
+        "User-Agent": "Mozilla/5.0 (Firefox)",
+        "Accept-Language": "en-US",
+        "Accept-Encoding": "gzip",
+    }
+
+    chrome = [
+        make_request(ip="203.0.113.181", headers=chrome_headers) for _ in range(3)
+    ]
+    assert _codes(view, chrome) == [OK, OK, TOO_MANY]
+
+    firefox = [
+        make_request(ip="203.0.113.181", headers=firefox_headers) for _ in range(2)
+    ]
+    assert _codes(view, firefox) == [OK, OK]
+
+
+def test_user_role_key_per_role(real_backend):
+    """``user_role_key`` includes the user's role in the key, so a staff user
+    and a regular user with the SAME id land in different buckets.
+    """
+
+    @rate_limit(key=_key(user_role_key), rate="2/m")
+    def view(_request):
+        return _ok_view(_request)
+
+    regular = AuthedUser(uid=1900)
+    staff = AuthedUser(uid=1900)
+    staff.is_staff = True
+
+    reg = [make_request(ip="203.0.113.191", user=regular) for _ in range(3)]
+    assert _codes(view, reg) == [OK, OK, TOO_MANY]
+
+    # Same id but staff role -> distinct bucket, unaffected by the above.
+    stf = [make_request(ip="203.0.113.191", user=staff) for _ in range(2)]
+    assert _codes(view, stf) == [OK, OK]
+
+
+# ---------------------------------------------------------------------------
+# Direct key-function output (the contract the buckets rely on)
+# ---------------------------------------------------------------------------
+
+
+def test_key_functions_produce_expected_strings():
+    """Sanity-check the raw key strings each function emits — the bucketing
+    behavior above depends on these being distinct/stable.
+    """
+    req = make_request(ip="192.0.2.5")
+    assert get_ip_key(req) == "ip:192.0.2.5"
+
+    anon = make_request(ip="192.0.2.6", user=AnonUser())
+    assert get_user_key(anon) == "ip:192.0.2.6"
+    assert user_or_ip_key(anon) == "ip:192.0.2.6"
+
+    authed = make_request(ip="192.0.2.7", user=AuthedUser(uid=42))
+    assert get_user_key(authed) == "user:42"
+    assert user_or_ip_key(authed) == "user:42"
+
+    geo = make_request(ip="192.0.2.8", headers={"CF-IPCOUNTRY": "JP"})
+    assert geographic_key(geo) == "geo:JP:ip:192.0.2.8"
+
+    api = make_request(ip="192.0.2.9", headers={"X-API-Key": "secret"})
+    assert api_key_aware_key(api) == "api_key:secret"
+
+    staff_user = AuthedUser(uid=7)
+    staff_user.is_staff = True
+    role_req = make_request(ip="192.0.2.10", user=staff_user)
+    assert user_role_key(role_req) == "7:staff"
+
+    composite_anon = make_request(ip="192.0.2.11", user=AnonUser())
+    assert composite_key(composite_anon) == "ip:192.0.2.11"
+
+    tenant_req = make_request(ip="192.0.2.12", params={"tenant_id": "acme"})
+    assert tenant_aware_key(tenant_req).startswith("tenant:acme:")
+
+    device = make_request(ip="192.0.2.13", headers={"User-Agent": "x"})
+    assert device_fingerprint_key(device).startswith("device:")
+
+    time_req = make_request(ip="192.0.2.14")
+    assert time_aware_key(time_req, "day").startswith("time:day:")
+
+
+# ---------------------------------------------------------------------------
+# Trusted-proxy scenarios via policy.get_client_ip
+# ---------------------------------------------------------------------------
+
+
+def test_trusted_proxy_returns_real_client_from_xff_chain():
+    """RATELIMIT_TRUSTED_PROXIES set: a request arriving from a trusted proxy
+    yields the REAL client (right-most non-trusted entry of the XFF chain),
+    not the proxy address.
+    """
+    with override_settings(RATELIMIT_TRUSTED_PROXIES=["10.0.0.0/8"]):
+        req = make_request(
+            ip="10.0.0.1",  # the trusted proxy (REMOTE_ADDR)
+            headers={"X-Forwarded-For": "203.0.113.5, 10.0.0.2"},
+        )
+        assert get_client_ip(req) == "203.0.113.5"
+
+
+def test_trusted_proxy_resists_spoof_prepend():
+    """A client cannot evade limits by PREPENDING a fake hop: walking the XFF
+    chain from the right past trusted proxies still returns the real edge
+    client, ignoring the spoofed left-most value.
+    """
+    with override_settings(RATELIMIT_TRUSTED_PROXIES=["10.0.0.0/8"]):
+        req = make_request(
+            ip="10.0.0.1",
+            headers={"X-Forwarded-For": "1.2.3.4, 203.0.113.9, 10.0.0.2"},
+        )
+        # 1.2.3.4 is the attacker-injected value; the genuine client added by
+        # the trusted edge is 203.0.113.9.
+        assert get_client_ip(req) == "203.0.113.9"
+
+
+def test_direct_client_cannot_spoof_when_not_trusted():
+    """A request that did NOT arrive via a trusted proxy cannot spoof its IP:
+    forwarded headers are ignored and REMOTE_ADDR is used.
+    """
+    with override_settings(RATELIMIT_TRUSTED_PROXIES=["10.0.0.0/8"]):
+        req = make_request(
+            ip="198.51.100.77",  # NOT a trusted proxy
+            headers={"X-Forwarded-For": "127.0.0.1"},  # spoof attempt
+        )
+        assert get_client_ip(req) == "198.51.100.77"
+
+
+def test_trust_forwarded_headers_disabled_uses_remote_addr():
+    """With RATELIMIT_TRUST_FORWARDED_HEADERS=False, forwarded headers are
+    ignored entirely and REMOTE_ADDR is authoritative.
+    """
+    with override_settings(RATELIMIT_TRUST_FORWARDED_HEADERS=False):
+        req = make_request(
+            ip="198.51.100.88",
+            headers={"X-Forwarded-For": "203.0.113.1", "X-Real-IP": "203.0.113.2"},
+        )
+        assert get_client_ip(req) == "198.51.100.88"
+
+
+def test_default_legacy_trusts_first_forwarded_header():
+    """Default (no trusted-proxy config, trust enabled): the left-most
+    X-Forwarded-For entry is honored — the documented backward-compatible
+    behavior.
+    """
+    with override_settings(
+        RATELIMIT_TRUSTED_PROXIES=None, RATELIMIT_TRUST_FORWARDED_HEADERS=True
+    ):
+        req = make_request(
+            ip="198.51.100.99",
+            headers={"X-Forwarded-For": "203.0.113.44, 10.0.0.2"},
+        )
+        assert get_client_ip(req) == "203.0.113.44"
+
+
+def test_invalid_trusted_proxy_config_fails_secure():
+    """An invalid RATELIMIT_TRUSTED_PROXIES value must FAIL SECURE: the request
+    stays in trusted-proxy mode and falls back to REMOTE_ADDR rather than
+    reverting to trusting spoofable client headers.
+    """
+    # Clear any cached parse of a prior (valid) config under the same value.
+    from django_smart_ratelimit.policy import lists as _lists
+
+    _lists._TRUSTED_PROXY_CACHE.clear()
+    with override_settings(RATELIMIT_TRUSTED_PROXIES=["not-a-cidr"]):
+        req = make_request(
+            ip="198.51.100.111",
+            headers={"X-Forwarded-For": "127.0.0.1"},  # would-be spoof
+        )
+        # Misconfig -> REMOTE_ADDR, NOT the spoofed forwarded header.
+        assert get_client_ip(req) == "198.51.100.111"
+
+
+def test_trusted_proxy_bucketing_keys_on_real_client(real_backend):
+    """End-to-end: with a trusted proxy, an "ip"-keyed view buckets on the REAL
+    client behind the proxy. Two real clients sharing the same proxy
+    REMOTE_ADDR get INDEPENDENT buckets; one real client spamming through the
+    proxy is blocked.
+    """
+    with override_settings(RATELIMIT_TRUSTED_PROXIES=["10.0.0.0/8"]):
+
+        @rate_limit(key="ip", rate="2/m")
+        def view(_request):
+            return _ok_view(_request)
+
+        client_a = [
+            make_request(
+                ip="10.0.0.5", headers={"X-Forwarded-For": "203.0.113.201, 10.0.0.5"}
+            )
+            for _ in range(3)
+        ]
+        assert _codes(view, client_a) == [OK, OK, TOO_MANY]
+
+        # Different real client, same proxy -> its own bucket.
+        client_b = [
+            make_request(
+                ip="10.0.0.5", headers={"X-Forwarded-For": "203.0.113.202, 10.0.0.5"}
+            )
+            for _ in range(2)
+        ]
+        assert _codes(view, client_b) == [OK, OK]
+
+
+# ---------------------------------------------------------------------------
+# Bypass / path helpers: is_internal_request, is_exempt_request,
+# should_skip_path, get_rate_for_path
+# ---------------------------------------------------------------------------
+
+
+def test_is_internal_request_defaults():
+    """``is_internal_request`` recognizes RFC-1918 / loopback by default and
+    rejects public addresses.
+    """
+    assert is_internal_request(make_request(ip="127.0.0.1")) is True
+    assert is_internal_request(make_request(ip="10.1.2.3")) is True
+    assert is_internal_request(make_request(ip="192.168.0.5")) is True
+    assert is_internal_request(make_request(ip="172.16.5.5")) is True
+    assert is_internal_request(make_request(ip="203.0.113.10")) is False
+
+
+def test_is_internal_request_custom_cidrs_and_proxy_trust():
+    """``is_internal_request`` honors a custom CIDR list and resolves the
+    client IP proxy-trust-aware, so an internal client behind a trusted proxy
+    is still recognized as internal.
+    """
+    assert (
+        is_internal_request(
+            make_request(ip="100.64.0.9"), internal_ips=["100.64.0.0/10"]
+        )
+        is True
+    )
+    assert (
+        is_internal_request(
+            make_request(ip="203.0.113.9"), internal_ips=["100.64.0.0/10"]
+        )
+        is False
+    )
+    with override_settings(RATELIMIT_TRUSTED_PROXIES=["10.0.0.0/8"]):
+        req = make_request(
+            ip="10.0.0.1", headers={"X-Forwarded-For": "192.168.1.50, 10.0.0.2"}
+        )
+        assert is_internal_request(req) is True
+
+
+def test_is_internal_request_skip_if_bypass(real_backend):
+    """Real scenario: ``skip_if=is_internal_request`` lets internal traffic
+    bypass the limiter entirely while external traffic is still capped.
+    """
+
+    @rate_limit(key="ip", rate="1/m", skip_if=is_internal_request)
+    def view(_request):
+        return _ok_view(_request)
+
+    # Internal IP: never blocked, even far beyond the limit.
+    internal = [make_request(ip="10.10.10.10") for _ in range(5)]
+    assert _codes(view, internal) == [OK, OK, OK, OK, OK]
+
+    # External IP: capped at 1/m.
+    external = [make_request(ip="203.0.113.210") for _ in range(2)]
+    assert _codes(view, external) == [OK, TOO_MANY]
+
+
+def test_is_exempt_request_paths_and_ips():
+    """``is_exempt_request`` exempts requests by path regex and by IP/CIDR."""
+    exempt_paths = [r"^/health", r"^/static/"]
+    assert is_exempt_request(make_request(path="/health"), exempt_paths) is True
+    assert is_exempt_request(make_request(path="/static/app.js"), exempt_paths) is True
+    assert is_exempt_request(make_request(path="/api/users"), exempt_paths) is False
+
+    assert (
+        is_exempt_request(make_request(ip="10.0.0.4"), exempt_ips=["10.0.0.0/8"])
+        is True
+    )
+    assert (
+        is_exempt_request(make_request(ip="203.0.113.4"), exempt_ips=["10.0.0.0/8"])
+        is False
+    )
+    # Exact-match IP (no CIDR).
+    assert (
+        is_exempt_request(make_request(ip="198.51.100.4"), exempt_ips=["198.51.100.4"])
+        is True
+    )
+
+
+def test_is_exempt_request_skip_if_bypass(real_backend):
+    """Real scenario: ``skip_if`` built on ``is_exempt_request`` lets a
+    health-check path bypass the limiter while ordinary paths are capped.
+    """
+
+    def skip(request):
+        return is_exempt_request(request, exempt_paths=[r"^/health"])
+
+    @rate_limit(key="ip", rate="1/m", skip_if=skip)
+    def view(_request):
+        return _ok_view(_request)
+
+    health = [make_request(ip="203.0.113.220", path="/health") for _ in range(4)]
+    assert _codes(view, health) == [OK, OK, OK, OK]
+
+    api = [make_request(ip="203.0.113.220", path="/api") for _ in range(2)]
+    assert _codes(view, api) == [OK, TOO_MANY]
+
+
+def test_should_skip_path():
+    """``should_skip_path`` matches by path prefix."""
+    patterns = ["/admin/", "/health/"]
+    assert should_skip_path("/admin/users", patterns) is True
+    assert should_skip_path("/health/live", patterns) is True
+    assert should_skip_path("/api/users", patterns) is False
+    assert should_skip_path("/", patterns) is False
+
+
+def test_get_rate_for_path():
+    """``get_rate_for_path`` picks the configured rate by path prefix, falling
+    back to the default when nothing matches.
+    """
+    rate_limits = {"/api/": "1000/h", "/auth/": "5/m"}
+    default = "100/m"
+    assert get_rate_for_path("/api/users", rate_limits, default) == "1000/h"
+    assert get_rate_for_path("/auth/login", rate_limits, default) == "5/m"
+    assert get_rate_for_path("/public/page", rate_limits, default) == default
+
+
+def test_get_rate_for_path_drives_real_limit(real_backend):
+    """Real scenario: a view whose rate is chosen via ``get_rate_for_path``
+    enforces the matched per-path rate against the live backend.
+    """
+    rate_limits = {"/auth/": "2/m"}
+
+    auth_rate = get_rate_for_path("/auth/login", rate_limits, "50/m")
+
+    @rate_limit(key="ip", rate=auth_rate)
+    def auth_view(_request):
+        return _ok_view(_request)
+
+    codes = _codes(auth_view, [make_request(ip="203.0.113.230") for _ in range(3)])
+    assert codes == [OK, OK, TOO_MANY]
+
+
+def test_invalid_identifier_type_raises():
+    """A bad client-identifier type is a configuration error, surfaced as
+    ImproperlyConfigured rather than silently mis-keying.
+    """
+    from django_smart_ratelimit.key_functions import get_client_identifier
+
+    with pytest.raises(ImproperlyConfigured):
+        get_client_identifier(make_request(), identifier_type="bogus")

--- a/tests/e2e/test_middleware_e2e.py
+++ b/tests/e2e/test_middleware_e2e.py
@@ -1,0 +1,579 @@
+"""Real-backend end-to-end scenarios for ``RateLimitMiddleware``.
+
+These tests drive the middleware exactly the way Django does in production: a
+configured ``RATELIMIT_MIDDLEWARE`` dict, a real (non-mocked) storage backend,
+and ``make_request()``-built requests fed through ``middleware(request)``. The
+limiter always talks to real Redis / real MongoDB / real memory storage — only
+the surrounding HTTP plumbing (RequestFactory + a fake ``get_response``) is
+synthetic.
+
+The headline scenario the suite encodes is a realistic site config:
+
+    * site-wide default of 100/m,
+    * a stricter ``/auth/`` bucket of 5/m to protect login,
+    * ``/health/`` skipped entirely (load balancers must never be throttled),
+    * an internal CIDR (``10.0.0.0/8``) allow-listed so office traffic bypasses,
+    * a known abuser CIDR deny-listed and force-blocked,
+    * and a shadow rollout where a brand-new limit only logs instead of blocking.
+
+Each test selects its backend via the shared ``real_backend`` fixture (so the
+behavior is verified on memory + redis + async_redis + mongodb) or, for the
+async ``__acall__`` path, pins memory explicitly. Distinct client IPs per test
+keep every scenario self-contained on the shared live stores.
+"""
+
+import time
+
+import pytest
+
+from django.http import HttpResponse, JsonResponse
+from django.test import override_settings
+
+from django_smart_ratelimit.middleware import RateLimitMiddleware
+
+from .conftest import AuthedUser, exhaust, make_request
+
+# ``real_backend`` is a pytest fixture from conftest.py; it is auto-discovered by
+# name when used as a test parameter, so it needs no explicit import here.
+
+# ---------------------------------------------------------------------------
+# Fake downstream apps. A real Django middleware wraps ``get_response``; we
+# stand in lightweight callables so the *only* thing under test is the limiter.
+# ---------------------------------------------------------------------------
+
+
+def ok_view(request):
+    """Sync downstream that always returns 200 OK (an unthrottled handler)."""
+    return HttpResponse("ok")
+
+
+async def async_ok_view(request):
+    """Async downstream returning 200 OK; triggers the middleware's __acall__."""
+    return HttpResponse("ok")
+
+
+def build(**middleware_config):
+    """Build a RateLimitMiddleware with the given RATELIMIT_MIDDLEWARE dict.
+
+    ``BACKEND`` is intentionally never injected so the middleware resolves the
+    backend from ``RATELIMIT_BACKEND`` (which the ``real_backend`` /
+    ``use_backend`` fixtures set to the live store under test).
+    """
+    return RateLimitMiddleware(ok_view)
+
+
+# The production-like site config reused across the headline scenarios.
+SITE_CONFIG = {
+    "DEFAULT_RATE": "100/m",
+    "BLOCK": True,
+    "SKIP_PATHS": ["/admin/", "/health/"],
+    "RATE_LIMITS": {
+        "/api/": "1000/h",
+        "/auth/": "5/m",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_RATE — the site-wide bucket.
+# ---------------------------------------------------------------------------
+
+
+def test_default_rate_blocks_after_limit_then_serves_headers(real_backend):
+    """Site default 5/m: the 6th hit from one IP is blocked with 429+headers.
+
+    A small explicit default keeps the scenario fast while still exercising the
+    real incr-per-request path: five requests pass (200) and the sixth trips the
+    limit (429), proving the middleware enforces DEFAULT_RATE against real
+    storage.
+    """
+    with override_settings(RATELIMIT_MIDDLEWARE={"DEFAULT_RATE": "5/m", "BLOCK": True}):
+        mw = build()
+        codes = exhaust(mw, 6, ip="198.51.100.1")
+
+    assert codes[:5] == [200, 200, 200, 200, 200]
+    assert codes[5] == 429
+
+    # A passing response carries the standard rate-limit headers.
+    ok = mw(make_request(ip="198.51.100.2"))
+    assert ok.status_code == 200
+    assert ok.headers["X-RateLimit-Limit"] == "5"
+    assert ok.headers["X-RateLimit-Remaining"] == "4"
+    assert "X-RateLimit-Reset" in ok.headers
+
+
+def test_default_rate_independent_buckets_per_ip(real_backend):
+    """Default 3/m per IP: an attacker hammering one IP cannot affect another.
+
+    The middleware keys on client IP, so two distinct REMOTE_ADDRs get two
+    independent buckets — a real-life DoS from one source must not exhaust a
+    legitimate user's allowance.
+    """
+    with override_settings(RATELIMIT_MIDDLEWARE={"DEFAULT_RATE": "3/m", "BLOCK": True}):
+        mw = build()
+        attacker = exhaust(mw, 5, ip="203.0.113.50")
+        # Legitimate user from a different IP is untouched.
+        victim = mw(make_request(ip="203.0.113.51"))
+
+    assert attacker == [200, 200, 200, 429, 429]
+    assert victim.status_code == 200
+    assert victim.headers["X-RateLimit-Remaining"] == "2"
+
+
+def test_429_response_has_retry_after_and_zero_remaining(real_backend):
+    """A blocked request returns Retry-After and X-RateLimit-Remaining: 0.
+
+    Operators and well-behaved clients rely on these headers to back off; assert
+    the real 429 carries them.
+    """
+    with override_settings(RATELIMIT_MIDDLEWARE={"DEFAULT_RATE": "2/m", "BLOCK": True}):
+        mw = build()
+        codes = exhaust(mw, 3, ip="198.51.100.9")
+        blocked = mw(make_request(ip="198.51.100.9"))
+
+    assert codes == [200, 200, 429]
+    assert blocked.status_code == 429
+    assert blocked.headers["X-RateLimit-Limit"] == "2"
+    assert blocked.headers["X-RateLimit-Remaining"] == "0"
+    assert "Retry-After" in blocked.headers
+    assert int(blocked.headers["Retry-After"]) >= 0
+
+
+# ---------------------------------------------------------------------------
+# RATE_LIMITS — per-path overrides with isolated buckets.
+# ---------------------------------------------------------------------------
+
+
+def test_auth_path_stricter_than_default(real_backend):
+    """/auth/ login is 5/m even though the site default is 100/m.
+
+    An attacker credential-stuffing /auth/login/ from one IP is blocked after 5
+    attempts, while the same IP can still browse the 100/m default site.
+    """
+    with override_settings(RATELIMIT_MIDDLEWARE=SITE_CONFIG):
+        mw = build()
+        login = exhaust(mw, 7, ip="198.51.100.20", path="/auth/login/")
+        # Same IP, default-rate page: untouched by the /auth/ bucket.
+        home = mw(make_request(ip="198.51.100.20", path="/"))
+
+    assert login[:5] == [200, 200, 200, 200, 200]
+    assert login[5] == 429 and login[6] == 429
+    assert home.status_code == 200
+    # The default page sees the 100/m limit, not 5/m.
+    assert home.headers["X-RateLimit-Limit"] == "100"
+
+
+def test_path_specific_buckets_are_isolated_from_each_other(real_backend):
+    """/auth/ (5/m) and /api/ (1000/h) keep separate buckets for the same IP.
+
+    Exhausting the strict /auth/ bucket leaves the generous /api/ bucket fully
+    available — path-specific limits include the path in the key so they never
+    cross-contaminate.
+    """
+    with override_settings(RATELIMIT_MIDDLEWARE=SITE_CONFIG):
+        mw = build()
+        auth = exhaust(mw, 6, ip="198.51.100.21", path="/auth/login/")
+        api = mw(make_request(ip="198.51.100.21", path="/api/users/"))
+
+    assert auth[5] == 429
+    assert api.status_code == 200
+    assert api.headers["X-RateLimit-Limit"] == "1000"
+    assert api.headers["X-RateLimit-Remaining"] == "999"
+
+
+def test_longest_prefix_first_match_wins(real_backend):
+    """RATE_LIMITS matches by prefix; /api/ traffic uses the 1000/h bucket.
+
+    A burst of API calls well under 1000/h all pass and report the API limit,
+    confirming get_rate_for_path picks the configured /api/ rate rather than the
+    site default.
+    """
+    with override_settings(RATELIMIT_MIDDLEWARE=SITE_CONFIG):
+        mw = build()
+        codes = exhaust(mw, 20, ip="198.51.100.22", path="/api/items/")
+        sample = mw(make_request(ip="198.51.100.23", path="/api/items/"))
+
+    assert codes == [200] * 20
+    assert sample.headers["X-RateLimit-Limit"] == "1000"
+
+
+# ---------------------------------------------------------------------------
+# SKIP_PATHS — health checks and admin are never throttled.
+# ---------------------------------------------------------------------------
+
+
+def test_skip_paths_never_rate_limited(real_backend):
+    """/health/ is skipped: a load balancer polling it is never throttled.
+
+    Far more requests than any configured limit are issued to /health/ and all
+    succeed with no rate-limit headers (the middleware returns before evaluating
+    the limiter).
+    """
+    with override_settings(
+        RATELIMIT_MIDDLEWARE={
+            "DEFAULT_RATE": "2/m",
+            "BLOCK": True,
+            "SKIP_PATHS": ["/health/", "/admin/"],
+        }
+    ):
+        mw = build()
+        health = exhaust(mw, 10, ip="198.51.100.30", path="/health/live")
+        admin = mw(make_request(ip="198.51.100.30", path="/admin/login/"))
+        # A non-skipped path from the same IP still enforces 2/m.
+        normal = exhaust(mw, 3, ip="198.51.100.30", path="/dashboard/")
+
+    assert health == [200] * 10
+    assert "X-RateLimit-Limit" not in health and admin.status_code == 200
+    # Skipped traffic did not consume the /dashboard/ bucket.
+    assert normal == [200, 200, 429]
+
+
+# ---------------------------------------------------------------------------
+# ALLOW_LIST — internal CIDR bypasses rate limiting.
+# ---------------------------------------------------------------------------
+
+
+def test_allow_list_cidr_bypasses_limit(real_backend):
+    """Internal 10.0.0.0/8 office range is allow-listed and bypasses 2/m.
+
+    Requests from inside the allow-listed CIDR are never counted (and carry no
+    rate-limit headers), while an outside IP is still capped at the default.
+    """
+    with override_settings(
+        RATELIMIT_MIDDLEWARE={
+            "DEFAULT_RATE": "2/m",
+            "BLOCK": True,
+            "ALLOW_LIST": ["10.0.0.0/8"],
+        }
+    ):
+        mw = build()
+        internal = exhaust(mw, 8, ip="10.4.5.6", path="/reports/")
+        external = exhaust(mw, 3, ip="198.51.100.40", path="/reports/")
+
+    assert internal == [200] * 8
+    # Allow-listed bypass returns before headers are attached.
+    last_internal = mw(make_request(ip="10.4.5.6", path="/reports/"))
+    assert last_internal.status_code == 200
+    assert "X-RateLimit-Limit" not in last_internal.headers
+    # Outside the CIDR, the 2/m default still applies.
+    assert external == [200, 200, 429]
+
+
+# ---------------------------------------------------------------------------
+# DENY_LIST — known abuser CIDR is force-blocked. Deny wins over allow.
+# ---------------------------------------------------------------------------
+
+
+def test_deny_list_force_blocks_immediately(real_backend):
+    """A deny-listed abuser is 429'd on the very first request.
+
+    No allowance is granted to deny-listed IPs — the first hit is blocked with a
+    429 carrying zeroed rate-limit headers, while a clean IP sails through.
+    """
+    with override_settings(
+        RATELIMIT_MIDDLEWARE={
+            "DEFAULT_RATE": "100/m",
+            "BLOCK": True,
+            "DENY_LIST": ["192.0.2.0/24"],
+        }
+    ):
+        mw = build()
+        abuser = mw(make_request(ip="192.0.2.66", path="/"))
+        clean = mw(make_request(ip="198.51.100.50", path="/"))
+
+    assert abuser.status_code == 429
+    assert abuser.headers["X-RateLimit-Limit"] == "0"
+    assert abuser.headers["X-RateLimit-Remaining"] == "0"
+    assert clean.status_code == 200
+
+
+def test_deny_wins_over_allow_for_overlapping_ranges(real_backend):
+    """When an IP is in both lists, deny takes precedence (fail-closed).
+
+    A surgical deny entry inside a broadly allow-listed range is still blocked —
+    the canonical "the office is trusted, but this one compromised host is not"
+    scenario.
+    """
+    with override_settings(
+        RATELIMIT_MIDDLEWARE={
+            "DEFAULT_RATE": "100/m",
+            "BLOCK": True,
+            "ALLOW_LIST": ["10.0.0.0/8"],
+            "DENY_LIST": ["10.9.9.9"],
+        }
+    ):
+        mw = build()
+        compromised = mw(make_request(ip="10.9.9.9", path="/"))
+        trusted = mw(make_request(ip="10.1.2.3", path="/"))
+
+    assert compromised.status_code == 429
+    assert trusted.status_code == 200
+    # Trusted (allow-listed) traffic bypasses, so it carries no limit headers.
+    assert "X-RateLimit-Limit" not in trusted.headers
+
+
+# ---------------------------------------------------------------------------
+# BLOCK — when False, over-limit requests pass through (monitoring posture).
+# ---------------------------------------------------------------------------
+
+
+def test_block_false_lets_over_limit_requests_through(real_backend):
+    """BLOCK=False: over-limit requests are NOT 429'd, they pass with 200.
+
+    Some deployments want to measure traffic against a limit without rejecting
+    anyone yet. With BLOCK=False the counter still increments (real storage) but
+    the response stays 200 even past the limit.
+    """
+    with override_settings(
+        RATELIMIT_MIDDLEWARE={"DEFAULT_RATE": "2/m", "BLOCK": False}
+    ):
+        mw = build()
+        codes = exhaust(mw, 5, ip="198.51.100.60")
+
+    assert codes == [200] * 5
+
+
+def test_block_false_reports_zero_remaining_when_over(real_backend):
+    """BLOCK=False still reflects exhaustion in X-RateLimit-Remaining.
+
+    Operators reading headers see remaining clamp to 0 once the bucket is spent,
+    even though the request was allowed through.
+    """
+    with override_settings(
+        RATELIMIT_MIDDLEWARE={"DEFAULT_RATE": "2/m", "BLOCK": False}
+    ):
+        mw = build()
+        exhaust(mw, 2, ip="198.51.100.61")
+        over = mw(make_request(ip="198.51.100.61"))
+
+    assert over.status_code == 200
+    assert over.headers["X-RateLimit-Limit"] == "2"
+    assert over.headers["X-RateLimit-Remaining"] == "0"
+
+
+# ---------------------------------------------------------------------------
+# SHADOW — a new limit logs would-be blocks but does not enforce them.
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_mode_allows_but_logs_would_be_block(real_backend, caplog):
+    """SHADOW rollout: over-limit requests are allowed but logged, not blocked.
+
+    The standard "run the new limit in shadow for a day" workflow — exhaust the
+    bucket, observe that nothing is 429'd, and confirm the structured
+    SHADOW_RATE_LIMIT_BLOCK log line fired for the would-be block.
+    """
+    with override_settings(
+        RATELIMIT_MIDDLEWARE={"DEFAULT_RATE": "2/m", "BLOCK": True, "SHADOW": True}
+    ):
+        mw = build()
+        with caplog.at_level("INFO", logger="django_smart_ratelimit.pipeline"):
+            codes = exhaust(mw, 4, ip="198.51.100.70")
+
+    # Nothing blocked despite blowing past the 2/m limit.
+    assert codes == [200] * 4
+    shadow_logs = [
+        r for r in caplog.records if r.getMessage() == "SHADOW_RATE_LIMIT_BLOCK"
+    ]
+    assert shadow_logs, "expected a shadow block log line for the over-limit request"
+    assert getattr(shadow_logs[0], "event", None) == "ratelimit.shadow.block"
+
+
+def test_shadow_mode_does_not_block_deny_list(real_backend, caplog):
+    """SHADOW also downgrades a deny-list block to an allow-with-log.
+
+    Before enforcing a freshly added deny list, operators run it in shadow: the
+    deny-listed IP is allowed through but a shadow log line is emitted so they
+    can confirm the list matches the right traffic.
+    """
+    with override_settings(
+        RATELIMIT_MIDDLEWARE={
+            "DEFAULT_RATE": "100/m",
+            "BLOCK": True,
+            "SHADOW": True,
+            "DENY_LIST": ["192.0.2.0/24"],
+        }
+    ):
+        mw = build()
+        with caplog.at_level("INFO", logger="django_smart_ratelimit.pipeline"):
+            resp = mw(make_request(ip="192.0.2.77", path="/"))
+
+    assert resp.status_code == 200
+    keys = [getattr(r, "key", None) for r in caplog.records]
+    assert "deny_list" in keys
+
+
+# ---------------------------------------------------------------------------
+# KEY_FUNCTION — custom keying (per-user instead of per-IP).
+# ---------------------------------------------------------------------------
+
+
+def test_user_key_function_buckets_per_user(real_backend):
+    """KEY_FUNCTION=user_key_function: two authed users share an IP but not a bucket.
+
+    With the bundled user_key_function, the bucket is keyed on user id, so two
+    logged-in users behind the same NAT'd office IP each get their own 3/m
+    allowance instead of competing for one.
+    """
+    with override_settings(
+        RATELIMIT_MIDDLEWARE={
+            "DEFAULT_RATE": "3/m",
+            "BLOCK": True,
+            "KEY_FUNCTION": ("django_smart_ratelimit.middleware.user_key_function"),
+        }
+    ):
+        mw = build()
+        shared_ip = "198.51.100.80"
+        user_a = AuthedUser(uid=9001)
+        user_b = AuthedUser(uid=9002)
+        a_codes = [
+            mw(make_request(ip=shared_ip, user=user_a)).status_code for _ in range(4)
+        ]
+        b_first = mw(make_request(ip=shared_ip, user=user_b))
+
+    assert a_codes == [200, 200, 200, 429]
+    # Different user id => fresh bucket even on the same IP.
+    assert b_first.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Async path — the same enforcement via __acall__ on a real backend.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_call_enforces_limit(real_backend):
+    """Async __acall__: an ASGI app's middleware blocks the 4th of a 3/m bucket.
+
+    Driving the middleware with an async get_response exercises __acall__ and
+    backend.aincr against real storage; behavior must match the sync path.
+    """
+    with override_settings(
+        RATELIMIT_MIDDLEWARE={"DEFAULT_RATE": "3/m", "BLOCK": True, "SKIP_PATHS": []}
+    ):
+        mw = RateLimitMiddleware(async_ok_view)
+        assert mw.async_mode
+        codes = []
+        for _ in range(4):
+            resp = await mw(make_request(ip="198.51.100.90", path="/async/"))
+            codes.append(resp.status_code)
+        # A fresh IP still has its full allowance and reports headers.
+        ok = await mw(make_request(ip="198.51.100.91", path="/async/"))
+
+    assert codes == [200, 200, 200, 429]
+    assert ok.status_code == 200
+    assert ok.headers["X-RateLimit-Limit"] == "3"
+    assert ok.headers["X-RateLimit-Remaining"] == "2"
+
+
+@pytest.mark.asyncio
+async def test_async_call_honors_skip_and_deny(real_backend):
+    """Async __acall__ respects SKIP_PATHS and DENY_LIST just like the sync path.
+
+    /health/ probes are never throttled and a deny-listed IP is 429'd on the
+    first async request — proving the v3 policy pipeline runs in both call paths.
+    """
+    with override_settings(
+        RATELIMIT_MIDDLEWARE={
+            "DEFAULT_RATE": "1/m",
+            "BLOCK": True,
+            "SKIP_PATHS": ["/health/"],
+            "DENY_LIST": ["192.0.2.0/24"],
+        }
+    ):
+        mw = RateLimitMiddleware(async_ok_view)
+        health_codes = []
+        for _ in range(5):
+            r = await mw(make_request(ip="198.51.100.92", path="/health/ready"))
+            health_codes.append(r.status_code)
+        denied = await mw(make_request(ip="192.0.2.88", path="/"))
+
+    assert health_codes == [200] * 5
+    assert denied.status_code == 429
+
+
+# ---------------------------------------------------------------------------
+# RATELIMIT_ENABLE — global kill switch short-circuits the middleware.
+# ---------------------------------------------------------------------------
+
+
+def test_global_disable_short_circuits_middleware(real_backend):
+    """RATELIMIT_ENABLE=False disables all enforcement site-wide.
+
+    The kill switch must let everything through even with an aggressive 1/m
+    default — used for incident response when the limiter itself is suspect.
+    """
+    with override_settings(
+        RATELIMIT_ENABLE=False,
+        RATELIMIT_MIDDLEWARE={"DEFAULT_RATE": "1/m", "BLOCK": True},
+    ):
+        mw = build()
+        codes = exhaust(mw, 5, ip="198.51.100.99")
+
+    assert codes == [200] * 5
+
+
+# ---------------------------------------------------------------------------
+# Header semantics across consecutive allowed requests.
+# ---------------------------------------------------------------------------
+
+
+def test_remaining_header_counts_down(real_backend):
+    """X-RateLimit-Remaining decrements on each allowed request.
+
+    Clients implementing client-side backoff depend on a monotonically
+    decreasing remaining counter; assert it walks 4 -> 3 -> 2 -> 1 -> 0 for a
+    5/m bucket against real storage.
+    """
+    with override_settings(RATELIMIT_MIDDLEWARE={"DEFAULT_RATE": "5/m", "BLOCK": True}):
+        mw = build()
+        remaining = []
+        for _ in range(5):
+            resp = mw(make_request(ip="198.51.100.100"))
+            remaining.append(int(resp.headers["X-RateLimit-Remaining"]))
+
+    assert remaining == [4, 3, 2, 1, 0]
+
+
+def test_does_not_clobber_existing_decorator_headers(real_backend):
+    """Middleware respects stricter decorator-set headers already on the response.
+
+    When a downstream view (simulating a @rate_limit decorator) has already set a
+    tighter X-RateLimit-Limit, the lenient site default must not overwrite it
+    with looser numbers.
+    """
+
+    def decorated_view(request):
+        resp = JsonResponse({"ok": True})
+        resp.headers["X-RateLimit-Limit"] = "5"
+        resp.headers["X-RateLimit-Remaining"] = "1"
+        return resp
+
+    with override_settings(
+        RATELIMIT_MIDDLEWARE={"DEFAULT_RATE": "1000/m", "BLOCK": True}
+    ):
+        mw = RateLimitMiddleware(decorated_view)
+        resp = mw(make_request(ip="198.51.100.101"))
+
+    assert resp.status_code == 200
+    # The stricter decorator limit (5) survives the lenient 1000/m middleware.
+    assert resp.headers["X-RateLimit-Limit"] == "5"
+    assert resp.headers["X-RateLimit-Remaining"] == "1"
+
+
+def test_reset_header_is_a_future_timestamp(real_backend):
+    """X-RateLimit-Reset points to a future epoch second (now + period).
+
+    Clients use Reset to know when the window clears; verify it is plausibly in
+    the future for a 60s window.
+    """
+    before = int(time.time())
+    with override_settings(
+        RATELIMIT_MIDDLEWARE={"DEFAULT_RATE": "10/m", "BLOCK": True}
+    ):
+        mw = build()
+        resp = mw(make_request(ip="198.51.100.102"))
+
+    reset = int(resp.headers["X-RateLimit-Reset"])
+    assert reset >= before
+    assert reset <= int(time.time()) + 120

--- a/tests/e2e/test_observability_e2e.py
+++ b/tests/e2e/test_observability_e2e.py
@@ -1,0 +1,840 @@
+"""Real-backend end-to-end tests for the observability surface.
+
+These scenarios drive REAL rate-limited traffic against REAL storage (live
+Redis / live MongoDB / in-process memory) and then assert on the three
+observability integrations the library ships:
+
+* Prometheus (``django_smart_ratelimit.prometheus``): with ``RATELIMIT_PROMETHEUS``
+  enabled, real requests are recorded through ``PrometheusMetrics.record_request``
+  and scraped back via ``generate_metrics()`` / ``prometheus_metrics_view``. We
+  assert request/denied counters increase, that the low-cardinality labels
+  (``backend`` / ``result``) are present, and that the per-key value is NEVER a
+  label (cardinality safety).
+* OpenTelemetry (``django_smart_ratelimit.observability``): ``instrument_rate_limit``
+  is called and ``record_check`` is exercised from real decorator traffic. We
+  assert it never raises; OTel-specific span/metric assertions are made only
+  when the SDK is installed.
+* Structured logging (``django_smart_ratelimit.logging``): with
+  ``RATELIMIT_LOGGING`` configured for JSON, a real block is triggered and we
+  assert a parseable single-line JSON log record is emitted (via ``caplog``).
+
+The backend is never mocked: the ``@rate_limit`` decorator hits the real store
+selected by the ``real_backend`` fixture, and we read the observable result
+codes (200 vs 429) plus the emitted telemetry. Every test uses distinct IPs /
+keys so they are independent and order-free.
+"""
+
+import json
+import logging
+
+import pytest
+
+from django.http import HttpResponse
+
+from django_smart_ratelimit import rate_limit
+from django_smart_ratelimit.logging import (
+    JSONFormatter,
+    RateLimitLogEvent,
+    clear_request_context,
+    log_circuit_breaker_event,
+    log_rate_limit_check,
+    set_request_context,
+)
+from django_smart_ratelimit.prometheus import (
+    PrometheusMetrics,
+    get_prometheus_metrics,
+    prometheus_metrics_view,
+)
+
+from .conftest import AuthedUser, exhaust, make_request
+
+# NOTE: the ``real_backend`` fixture is provided by tests/e2e/conftest.py and is
+# auto-discovered by pytest; it is intentionally NOT imported here (importing a
+# fixture only triggers F401/F811 lint noise).
+
+# OpenTelemetry SDK is optional. When present we assert on real spans/metrics;
+# when absent we still verify the no-op path never raises.
+try:
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    HAS_OTEL_SDK = True
+except ImportError:  # pragma: no cover - depends on optional dependency
+    HAS_OTEL_SDK = False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fresh_prometheus(prefix="e2e_ratelimit"):
+    """Return a freshly-initialized PrometheusMetrics singleton.
+
+    The metrics object is a process-wide singleton, so we reset it per test to
+    get clean counters and a stable, test-specific metric-name prefix.
+    """
+    PrometheusMetrics.reset()
+    metrics = PrometheusMetrics()
+    metrics._initialize(prefix=prefix)
+    return metrics
+
+
+def _counter_value(text, metric_name, **labels):
+    """Parse a Prometheus exposition string for a single counter sample.
+
+    Returns the float value of the line ``metric_name{labels...} value`` whose
+    label set is a superset of the requested ``labels``. Returns ``None`` if no
+    matching sample is found.
+    """
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "{" in line:
+            name, rest = line.split("{", 1)
+            label_blob, value = rest.rsplit("}", 1)
+        else:
+            name, value = line.rsplit(" ", 1)
+            label_blob = ""
+        if name != metric_name:
+            continue
+        present = {}
+        for chunk in label_blob.split(","):
+            chunk = chunk.strip()
+            if not chunk or "=" not in chunk:
+                continue
+            k, v = chunk.split("=", 1)
+            present[k.strip()] = v.strip().strip('"')
+        if all(present.get(k) == v for k, v in labels.items()):
+            return float(value.strip())
+    return None
+
+
+def _build_view(rate, key="ip"):
+    """Build a real @rate_limit-decorated view backed by the live store."""
+
+    @rate_limit(key=key, rate=rate)
+    def view(request):
+        return HttpResponse("ok")
+
+    return view
+
+
+# ===========================================================================
+# Prometheus: real traffic recorded + scraped
+# ===========================================================================
+
+
+class TestPrometheusRealTraffic:
+    """Prometheus metrics scraped after real rate-limited traffic."""
+
+    def test_request_and_denied_counters_increase_on_real_backend(self, real_backend):
+        """Public API endpoint: 3/min per IP.
+
+        Five real requests hit the live backend; the first three are allowed
+        and the last two are blocked (429). Each decision is recorded through
+        ``PrometheusMetrics.record_request`` keyed on the real per-IP key, and
+        we scrape ``generate_metrics()`` and assert the allowed counter shows
+        3, the denied counter shows 2, and the denied-total matches.
+        """
+        metrics = _fresh_prometheus()
+        view = _build_view("3/m")
+        ip = "198.51.100.21"
+
+        for code in exhaust(view, 5, ip=ip):
+            # Record exactly what the live backend decided for this real call.
+            metrics.record_request(
+                key=f"ip:{ip}",
+                backend=real_backend,
+                allowed=(code == 200),
+                duration_seconds=0.001,
+            )
+
+        text = metrics.generate_metrics()
+
+        allowed = _counter_value(
+            text,
+            "e2e_ratelimit_requests_total",
+            backend=real_backend,
+            result="allowed",
+        )
+        denied = _counter_value(
+            text,
+            "e2e_ratelimit_requests_total",
+            backend=real_backend,
+            result="denied",
+        )
+        denied_total = _counter_value(
+            text,
+            "e2e_ratelimit_requests_denied_total",
+            backend=real_backend,
+        )
+
+        assert allowed == 3.0
+        assert denied == 2.0
+        assert denied_total == 2.0
+
+    def test_low_cardinality_labels_present_and_key_not_a_label(self, real_backend):
+        """Cardinality safety: per-key value must never become a label.
+
+        Drive traffic from three DISTINCT IPs against a 1/min limit so every IP
+        is allowed once then denied. We record each with its unique per-IP key,
+        then assert the scrape exposes only the low-cardinality ``backend`` and
+        ``result`` labels and that NONE of the per-IP key strings leak into the
+        exposition as a label value (which would explode cardinality).
+        """
+        metrics = _fresh_prometheus()
+        view = _build_view("1/m")
+        ips = ["203.0.113.41", "203.0.113.42", "203.0.113.43"]
+
+        for ip in ips:
+            for code in exhaust(view, 2, ip=ip):
+                metrics.record_request(
+                    key=f"ip:{ip}",
+                    backend=real_backend,
+                    allowed=(code == 200),
+                    duration_seconds=0.0005,
+                )
+
+        text = metrics.generate_metrics()
+
+        # The low-cardinality labels are present on the requests_total counter.
+        assert 'backend="%s"' % real_backend in text
+        assert 'result="allowed"' in text
+        assert 'result="denied"' in text
+
+        # The per-key value is NOT used as a label anywhere in the exposition.
+        for ip in ips:
+            assert ip not in text
+            assert f"ip:{ip}" not in text
+        assert "key=" not in text
+
+        # Each of the 3 IPs got exactly one allow and one deny.
+        assert (
+            _counter_value(
+                text,
+                "e2e_ratelimit_requests_total",
+                backend=real_backend,
+                result="allowed",
+            )
+            == 3.0
+        )
+        assert (
+            _counter_value(
+                text,
+                "e2e_ratelimit_requests_total",
+                backend=real_backend,
+                result="denied",
+            )
+            == 3.0
+        )
+
+    def test_metrics_view_is_routable_and_scrapeable(self, real_backend):
+        """The metrics endpoint exposes counters in Prometheus text format.
+
+        After real traffic, calling ``prometheus_metrics_view`` returns a 200
+        with the Prometheus exposition content-type and the recorded counters
+        embedded in the body, so a Prometheus scraper hitting ``/metrics`` would
+        see the rate-limit metrics.
+        """
+        metrics = _fresh_prometheus()
+        view = _build_view("2/m")
+        ip = "198.51.100.77"
+
+        for code in exhaust(view, 4, ip=ip):
+            metrics.record_request(
+                key=f"ip:{ip}",
+                backend=real_backend,
+                allowed=(code == 200),
+                duration_seconds=0.001,
+            )
+
+        # get_prometheus_metrics() must return the same singleton we recorded
+        # into, so the view scrapes the same registry.
+        assert get_prometheus_metrics() is metrics
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "django_smart_ratelimit.prometheus._get_prometheus_config",
+                lambda: {"enabled": True, "prefix": "e2e_ratelimit"},
+            )
+            response = prometheus_metrics_view(make_request(path="/metrics/"))
+
+        assert response.status_code == 200
+        assert "text/plain" in response["Content-Type"]
+        body = response.content.decode("utf-8")
+        assert "e2e_ratelimit_requests_total" in body
+        assert 'backend="%s"' % real_backend in body
+        # 2 allowed + 2 denied recorded from real traffic.
+        assert (
+            _counter_value(
+                body,
+                "e2e_ratelimit_requests_total",
+                backend=real_backend,
+                result="denied",
+            )
+            == 2.0
+        )
+
+    def test_duration_histogram_observed_per_backend(self, real_backend):
+        """Latency histogram: duration is observed and labeled by backend only.
+
+        Real checks feed durations into the ``request_duration_seconds``
+        histogram. We assert the histogram ``_count`` reflects every recorded
+        check and is labeled by the low-cardinality ``backend`` label only.
+        """
+        metrics = _fresh_prometheus()
+        view = _build_view("5/m")
+        ip = "198.51.100.90"
+
+        codes = exhaust(view, 6, ip=ip)
+        for code in codes:
+            metrics.record_request(
+                key=f"ip:{ip}",
+                backend=real_backend,
+                allowed=(code == 200),
+                duration_seconds=0.003,
+            )
+
+        text = metrics.generate_metrics()
+        count = _counter_value(
+            text,
+            "e2e_ratelimit_request_duration_seconds_count",
+            backend=real_backend,
+        )
+        assert count == float(len(codes))
+        # Histogram is labeled by backend, never by key.
+        assert "key=" not in text
+
+    def test_independent_buckets_recorded_per_distinct_backend_label(self):
+        """Two backends recorded side-by-side keep independent counters.
+
+        Simulate a deployment reporting metrics for two backends at once and
+        assert each ``backend`` label carries its own counter values without
+        cross-contamination.
+        """
+        metrics = _fresh_prometheus()
+
+        for _ in range(4):
+            metrics.record_request(
+                key="ip:a", backend="redis", allowed=True, duration_seconds=0.001
+            )
+        for _ in range(2):
+            metrics.record_request(
+                key="ip:b", backend="memory", allowed=False, duration_seconds=0.001
+            )
+
+        text = metrics.generate_metrics()
+        assert (
+            _counter_value(
+                text,
+                "e2e_ratelimit_requests_total",
+                backend="redis",
+                result="allowed",
+            )
+            == 4.0
+        )
+        assert (
+            _counter_value(
+                text,
+                "e2e_ratelimit_requests_total",
+                backend="memory",
+                result="denied",
+            )
+            == 2.0
+        )
+        # The memory backend recorded zero allows; that sample is simply absent.
+        assert (
+            _counter_value(
+                text,
+                "e2e_ratelimit_requests_total",
+                backend="memory",
+                result="allowed",
+            )
+            is None
+        )
+
+
+# ===========================================================================
+# OpenTelemetry: instrument + record_check from real traffic
+# ===========================================================================
+
+
+def _backend_class_name():
+    """Return the live backend's class name, as emitted in OTel attributes.
+
+    The decorator records ``backend=type(backend_instance).__name__`` on every
+    real check (see pipeline.handle_shadow_decision -> record_check), so spans
+    carry e.g. ``MemoryBackend`` / ``RedisBackend`` rather than the short name.
+    """
+    from django_smart_ratelimit.backends import get_backend
+
+    return type(get_backend()).__name__
+
+
+def _spans_for_key(spans, key):
+    """Filter exported spans down to those for a specific rate-limit key."""
+    return [s for s in spans if s.attributes.get("ratelimit.key") == key]
+
+
+def _sum_total_points(metric_reader):
+    """Sum the ratelimit.requests.total counter and collect decision labels."""
+    data = metric_reader.get_metrics_data()
+    points = []
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name == "ratelimit.requests.total":
+                    points.extend(metric.data.data_points)
+    return points
+
+
+class TestOpenTelemetryRealTraffic:
+    """OpenTelemetry instrumentation driven by real decorator traffic.
+
+    The decorator AUTO-emits ``record_check`` for every real rate-limit
+    decision (via pipeline.handle_shadow_decision), so these scenarios drive
+    real traffic and then scrape the spans/metrics the library itself produced
+    against the live backend — no manual mirroring.
+    """
+
+    def _reset_otel_globals(self):
+        from django_smart_ratelimit.observability import otel
+
+        otel._global_tracer = None
+        otel._global_meter = None
+        otel._fallback_tracer = None
+        otel._fallback_meter = None
+
+    def test_instrument_and_real_traffic_never_errors_on_real_backend(
+        self, real_backend
+    ):
+        """instrument_rate_limit() + real traffic never raises.
+
+        Initialize instrumentation and drive a 3/min endpoint with real
+        requests. Instrumentation must be invisible to the caller: the observed
+        429-after-3 behavior is unchanged and nothing raised, regardless of
+        whether the OTel SDK is installed (no-op fallback path).
+        """
+        self._reset_otel_globals()
+        from django_smart_ratelimit.observability import instrument_rate_limit
+
+        instrument_rate_limit()  # idempotent, safe without OTel installed
+
+        view = _build_view("3/m")
+        codes = exhaust(view, 5, ip="192.0.2.55")
+
+        # Observable real behavior is unchanged by instrumentation.
+        assert codes[:3] == [200, 200, 200]
+        assert codes[3:] == [429, 429]
+
+    @pytest.mark.skipif(not HAS_OTEL_SDK, reason="opentelemetry SDK not installed")
+    def test_real_traffic_auto_emits_spans_and_metrics(self, real_backend):
+        """With the OTel SDK installed, real traffic auto-emits spans + metrics.
+
+        Wire in-memory OTel exporters via ``instrument_rate_limit`` providers,
+        drive a real 2/min endpoint, and assert the library captured one
+        ``ratelimit.check`` span per request (2 allowed + 2 denied) with the
+        real backend CLASS name on ``ratelimit.backend`` and that the
+        ``ratelimit.requests.total`` counter recorded matching low-cardinality
+        decision attributes (allowed/denied only).
+        """
+        self._reset_otel_globals()
+        from django_smart_ratelimit.observability import otel
+
+        span_exporter = InMemorySpanExporter()
+        tracer_provider = TracerProvider()
+        tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+        metric_reader = InMemoryMetricReader()
+        meter_provider = MeterProvider(metric_readers=[metric_reader])
+
+        otel.instrument_rate_limit(
+            tracer_provider=tracer_provider, meter_provider=meter_provider
+        )
+
+        backend_cls = _backend_class_name()
+        view = _build_view("2/m")
+        ip = "192.0.2.66"
+        key = f"ip:{ip}"
+        codes = exhaust(view, 4, ip=ip)
+        assert codes == [200, 200, 429, 429]
+
+        # Spans for THIS key only (exporter is process-global within OTel).
+        spans = _spans_for_key(span_exporter.get_finished_spans(), key)
+        assert len(spans) == 4
+        decisions = [s.attributes["ratelimit.decision"] for s in spans]
+        assert decisions.count("allowed") == 2
+        assert decisions.count("denied") == 2
+        # Backend attribute carries the real backend CLASS name, not the key.
+        for span in spans:
+            assert span.attributes["ratelimit.backend"] == backend_cls
+            assert span.name == "ratelimit.check"
+            # The per-key value lives on a span attribute (fine for traces), not
+            # on a metric label.
+            assert span.attributes["ratelimit.key"] == key
+
+        # The requests.total counter recorded decisions with low-cardinality
+        # decision attributes. The exporter is global, so scope to our backend.
+        points = [
+            p
+            for p in _sum_total_points(metric_reader)
+            if p.attributes.get("backend") == backend_cls
+        ]
+        assert points, "expected ratelimit.requests.total data points"
+        seen_decisions = {p.attributes.get("decision") for p in points}
+        assert seen_decisions <= {"allowed", "denied"}
+        assert "allowed" in seen_decisions and "denied" in seen_decisions
+        # No data point carries the per-key value as an attribute.
+        for p in points:
+            assert "key" not in p.attributes
+            assert ip not in str(dict(p.attributes))
+
+    @pytest.mark.skipif(not HAS_OTEL_SDK, reason="opentelemetry SDK not installed")
+    def test_shadow_mode_decision_recorded_without_enforcement(self, real_backend):
+        """Shadow mode: would-be-denied checks are recorded but never enforced.
+
+        A shadow=True endpoint never returns 429 (real traffic stays 200), yet
+        the auto-emitted spans still mark the over-limit checks as denied with
+        ``ratelimit.shadow`` set. This proves observability sees what WOULD be
+        blocked before enforcement is flipped on.
+        """
+        self._reset_otel_globals()
+        from django_smart_ratelimit.observability import otel
+
+        span_exporter = InMemorySpanExporter()
+        tracer_provider = TracerProvider()
+        tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+        otel.instrument_rate_limit(tracer_provider=tracer_provider)
+
+        @rate_limit(key="ip", rate="2/m", shadow=True)
+        def shadow_view(request):
+            return HttpResponse("ok")
+
+        ip = "192.0.2.77"
+        key = f"ip:{ip}"
+        codes = exhaust(shadow_view, 4, ip=ip)
+        # Shadow mode never enforces: all real responses are 200.
+        assert codes == [200, 200, 200, 200]
+
+        spans = _spans_for_key(span_exporter.get_finished_spans(), key)
+        assert len(spans) == 4
+        assert all(s.attributes["ratelimit.shadow"] is True for s in spans)
+        # The 3rd and 4th checks are recorded as denied even though nothing was
+        # actually enforced (responses were all 200).
+        denied = [s for s in spans if s.attributes["ratelimit.decision"] == "denied"]
+        assert len(denied) == 2
+
+
+# ===========================================================================
+# Structured JSON logging: real block emits parseable JSON
+# ===========================================================================
+
+JSON_LOGGING_ENABLED = {
+    "RATELIMIT_LOGGING": {
+        "ENABLED": True,
+        "FORMAT": "json",
+        "LOGGER_NAME": "django_smart_ratelimit",
+        "INCLUDE_TIMESTAMP": True,
+        "INCLUDE_REQUEST_ID": True,
+    }
+}
+
+
+def _parse_json_records(caplog, logger_name="django_smart_ratelimit"):
+    """Render caplog records through JSONFormatter and parse them as JSON.
+
+    This mimics how a real deployment formats these records, proving each line
+    is a single parseable JSON object.
+    """
+    formatter = JSONFormatter()
+    parsed = []
+    for record in caplog.records:
+        if record.name != logger_name:
+            continue
+        line = formatter.format(record)
+        # A JSON log line must be a single line and parse cleanly.
+        assert "\n" not in line
+        parsed.append(json.loads(line))
+    return parsed
+
+
+class TestStructuredLoggingRealBlock:
+    """Structured JSON logging on real rate-limit decisions."""
+
+    def teardown_method(self):
+        clear_request_context()
+
+    def test_real_block_emits_parseable_json_log(self, real_backend, caplog, settings):
+        """Login endpoint: 2/min per IP. The block emits a JSON log line.
+
+        Enable JSON structured logging, drive a real 2/min endpoint until the
+        live backend blocks (429), then emit the structured check log for the
+        denied decision. We assert a single-line, parseable JSON record was
+        produced carrying event/backend/allowed=false and the rate-limit key.
+        """
+        settings.RATELIMIT_LOGGING = JSON_LOGGING_ENABLED["RATELIMIT_LOGGING"]
+
+        view = _build_view("2/m")
+        ip = "198.51.100.150"
+        key = f"ip:{ip}"
+
+        with caplog.at_level(logging.INFO, logger="django_smart_ratelimit"):
+            codes = exhaust(view, 3, ip=ip)
+            # The real backend denied the third request.
+            assert codes == [200, 200, 429]
+            # Emit the structured log for the real denied decision.
+            log_rate_limit_check(
+                key=key,
+                backend=real_backend,
+                allowed=False,
+                remaining=0,
+                limit=2,
+                window=60,
+                algorithm="sliding_window",
+            )
+
+        records = _parse_json_records(caplog)
+        denied = [
+            r
+            for r in records
+            if r.get("event") == "rate_limit_check" and r.get("allowed") is False
+        ]
+        assert denied, "expected a structured denied rate_limit_check log"
+        entry = denied[-1]
+        assert entry["backend"] == real_backend
+        assert entry["key"] == key
+        assert entry["limit"] == 2
+        assert entry["remaining"] == 0
+        # WARNING level is used for denials.
+        assert any(
+            r.levelname == "WARNING"
+            for r in caplog.records
+            if r.name == "django_smart_ratelimit"
+        )
+
+    def test_allowed_and_denied_emit_distinct_levels(self, real_backend, caplog):
+        """Allowed checks log at INFO, denials at WARNING.
+
+        Across a real 1/min endpoint, the allowed request and the denied
+        request each produce a structured JSON record at the appropriate level,
+        both carrying the same low-cardinality backend label.
+        """
+        clear_request_context()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "django_smart_ratelimit.logging._get_logging_settings",
+                lambda: {
+                    "ENABLED": True,
+                    "FORMAT": "json",
+                    "LOGGER_NAME": "django_smart_ratelimit",
+                    "INCLUDE_TIMESTAMP": True,
+                    "INCLUDE_REQUEST_ID": True,
+                    "EXTRA_FIELDS": {},
+                },
+            )
+
+            view = _build_view("1/m")
+            ip = "198.51.100.160"
+            key = f"ip:{ip}"
+
+            with caplog.at_level(logging.INFO, logger="django_smart_ratelimit"):
+                codes = exhaust(view, 2, ip=ip)
+                assert codes == [200, 429]
+                log_rate_limit_check(
+                    key=key,
+                    backend=real_backend,
+                    allowed=True,
+                    remaining=0,
+                    limit=1,
+                    window=60,
+                )
+                log_rate_limit_check(
+                    key=key,
+                    backend=real_backend,
+                    allowed=False,
+                    remaining=0,
+                    limit=1,
+                    window=60,
+                )
+
+            records = _parse_json_records(caplog)
+            checks = [r for r in records if r.get("event") == "rate_limit_check"]
+            assert any(r.get("allowed") is True for r in checks)
+            assert any(r.get("allowed") is False for r in checks)
+            assert all(r["backend"] == real_backend for r in checks)
+
+    def test_request_context_enriches_json_log(self, real_backend, caplog):
+        """Structured logs carry request context (request id / ip / path).
+
+        Set thread-local request context (as the StructuredLoggingMiddleware
+        would for a real request), trigger a real block, and assert the emitted
+        JSON record nests the request metadata under a ``request`` object.
+        """
+        clear_request_context()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "django_smart_ratelimit.logging._get_logging_settings",
+                lambda: {
+                    "ENABLED": True,
+                    "FORMAT": "json",
+                    "LOGGER_NAME": "django_smart_ratelimit",
+                    "INCLUDE_TIMESTAMP": True,
+                    "INCLUDE_REQUEST_ID": True,
+                    "EXTRA_FIELDS": {},
+                },
+            )
+
+            view = _build_view("1/m", key="user")
+            user = AuthedUser(uid=4242)
+            req = make_request(ip="198.51.100.170", user=user, path="/account/")
+            assert view(req).status_code == 200
+            assert (
+                view(
+                    make_request(ip="198.51.100.170", user=user, path="/account/")
+                ).status_code
+                == 429
+            )
+
+            set_request_context(
+                request_id="req-abc123",
+                ip="198.51.100.170",
+                path="/account/",
+                method="GET",
+                user="4242",
+            )
+            with caplog.at_level(logging.INFO, logger="django_smart_ratelimit"):
+                log_rate_limit_check(
+                    key="user:4242",
+                    backend=real_backend,
+                    allowed=False,
+                    remaining=0,
+                    limit=1,
+                    window=60,
+                )
+
+            records = _parse_json_records(caplog)
+            assert records
+            entry = records[-1]
+            assert entry["request"]["request_id"] == "req-abc123"
+            assert entry["request"]["ip"] == "198.51.100.170"
+            assert entry["request"]["path"] == "/account/"
+
+    def test_circuit_breaker_open_logs_warning_json(self, real_backend, caplog):
+        """A circuit-breaker open transition emits a WARNING JSON event.
+
+        Beyond per-request checks, the structured logging API also records
+        backend lifecycle events. We assert ``log_circuit_breaker_event`` for an
+        open transition produces a parseable JSON record at WARNING level with
+        the new state and backend label.
+        """
+        clear_request_context()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "django_smart_ratelimit.logging._get_logging_settings",
+                lambda: {
+                    "ENABLED": True,
+                    "FORMAT": "json",
+                    "LOGGER_NAME": "django_smart_ratelimit",
+                    "INCLUDE_TIMESTAMP": True,
+                    "INCLUDE_REQUEST_ID": True,
+                    "EXTRA_FIELDS": {},
+                },
+            )
+            with caplog.at_level(logging.INFO, logger="django_smart_ratelimit"):
+                log_circuit_breaker_event(
+                    backend=real_backend,
+                    previous_state="closed",
+                    new_state="open",
+                    reason="connection refused",
+                    failure_count=5,
+                )
+
+            records = _parse_json_records(caplog)
+            cb = [
+                r for r in records if r.get("event") == "circuit_breaker_state_change"
+            ]
+            assert cb
+            entry = cb[-1]
+            assert entry["new_state"] == "open"
+            assert entry["backend"] == real_backend
+            assert entry["failure_count"] == 5
+            assert any(
+                r.levelname == "WARNING"
+                for r in caplog.records
+                if r.name == "django_smart_ratelimit"
+            )
+
+    def test_logging_disabled_emits_nothing(self, real_backend, caplog):
+        """When JSON logging is disabled, the convenience helpers stay silent.
+
+        With ``RATELIMIT_LOGGING`` not enabled (the default), a real block emits
+        no structured records via ``log_rate_limit_check`` — the integration is
+        strictly opt-in.
+        """
+        clear_request_context()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "django_smart_ratelimit.logging._get_logging_settings",
+                lambda: {
+                    "ENABLED": False,
+                    "FORMAT": "text",
+                    "LOGGER_NAME": "django_smart_ratelimit",
+                },
+            )
+            view = _build_view("1/m")
+            ip = "198.51.100.180"
+            with caplog.at_level(logging.INFO, logger="django_smart_ratelimit"):
+                assert exhaust(view, 2, ip=ip) == [200, 429]
+                log_rate_limit_check(
+                    key=f"ip:{ip}",
+                    backend=real_backend,
+                    allowed=False,
+                    remaining=0,
+                    limit=1,
+                    window=60,
+                )
+
+            structured = [
+                r
+                for r in caplog.records
+                if r.name == "django_smart_ratelimit"
+                and getattr(r, "structured", None) is not None
+            ]
+            assert structured == []
+
+
+# ===========================================================================
+# Cross-cutting: the JSON log event schema keeps the key out of metric labels
+# ===========================================================================
+
+
+def test_log_event_schema_is_json_serializable_and_keyed():
+    """Event builder renders a self-describing, JSON-serializable dict.
+
+    The structured event surfaces the per-key value (high-cardinality) in the
+    LOG payload — which is correct for logs — while the Prometheus path keeps it
+    out of labels. This guards the event builder's public schema.
+    """
+    event = RateLimitLogEvent(
+        event="rate_limit_check",
+        key="ip:198.51.100.200",
+        backend="memory",
+        algorithm="sliding_window",
+    )
+    event.set_result(allowed=False, remaining=0, limit=5, window=60)
+    event.set_duration(0.0021)
+    payload = event.as_dict()
+
+    # Round-trips through JSON cleanly.
+    reloaded = json.loads(json.dumps(payload, default=str))
+    assert reloaded["event"] == "rate_limit_check"
+    assert reloaded["key"] == "ip:198.51.100.200"
+    assert reloaded["backend"] == "memory"
+    assert reloaded["allowed"] is False
+    assert reloaded["duration_ms"] == 2.1

--- a/tests/e2e/test_reliability_e2e.py
+++ b/tests/e2e/test_reliability_e2e.py
@@ -1,0 +1,677 @@
+"""Real-backend end-to-end tests for the reliability feature surface.
+
+These scenarios exercise the public reliability APIs against REAL infrastructure
+(a live Redis for distributed circuit-breaker state, a dead TCP port for the
+fail-open/fail-closed scenarios, and the real Django test database for the
+cleanup command) -- never a mocked backend or a mocked state store.
+
+Covered API surface:
+    - ``circuit_breaker`` decorator + ``circuit_breaker_registry``: a repeatedly
+      failing function trips the breaker (``CircuitBreakerError``) and recovers
+      after the recovery timeout; the distributed variant keeps its state on a
+      REAL Redis (``RATELIMIT_CIRCUIT_BREAKER_STORAGE="redis"`` + a real URL).
+    - ``fail_open`` vs fail-closed: a ``RedisBackend`` pointed at a dead port
+      either allows (fail-open) or denies/raises (fail-closed), both at the
+      backend layer and end-to-end through the ``rate_limit`` decorator.
+    - Adaptive limiting: a registered ``AdaptiveRateLimiter`` driven by a real
+      ``CustomLoadIndicator`` changes the effective limit the decorator enforces.
+    - Management commands via ``call_command``: ``ratelimit_health`` reports a
+      real backend as healthy/unhealthy, and ``ratelimit_cleanup`` reports and
+      removes expired rows on the real database backend.
+"""
+
+import time
+import uuid
+from io import StringIO
+
+import pytest
+
+from django.core.management import call_command
+from django.http import HttpResponse
+from django.test import override_settings
+
+from django_smart_ratelimit import (
+    AdaptiveRateLimiter,
+    rate_limit,
+    register_adaptive_limiter,
+    unregister_adaptive_limiter,
+)
+from django_smart_ratelimit.adaptive import CustomLoadIndicator
+from django_smart_ratelimit.backends import clear_backend_cache
+from django_smart_ratelimit.backends.redis_backend import RedisBackend
+
+# NOTE: the package root re-exports a *different* CircuitBreakerError (from
+# ``exceptions``); the ``circuit_breaker`` decorator actually raises the one
+# defined in ``circuit_breaker``, so import the matching class from there.
+from django_smart_ratelimit.circuit_breaker import (
+    CircuitBreakerError,
+    circuit_breaker,
+    circuit_breaker_registry,
+)
+from django_smart_ratelimit.config import reset_settings
+
+from .conftest import (
+    REDIS,
+    REDIS_HOST,
+    REDIS_PORT,
+    make_request,
+    skip_without_redis,
+    use_backend,
+)
+
+# A TCP port nothing listens on -- used to simulate an unreachable Redis.
+DEAD_REDIS_PORT = 1
+
+
+# ---------------------------------------------------------------------------
+# circuit_breaker decorator + registry (in-process / memory state)
+# ---------------------------------------------------------------------------
+
+
+def test_circuit_breaker_trips_after_repeated_failures():
+    """A flaky dependency that keeps raising trips the breaker after N failures.
+
+    Real-life: an upstream API call keeps failing. After ``failure_threshold``
+    consecutive failures the breaker OPENs and short-circuits further calls,
+    raising ``CircuitBreakerError`` instead of hammering the dead dependency.
+    """
+    name = f"cb-trip-{uuid.uuid4().hex}"
+    calls = {"n": 0}
+
+    @circuit_breaker(failure_threshold=3, recovery_timeout=60, name=name)
+    def flaky_upstream():
+        calls["n"] += 1
+        raise ConnectionError("upstream down")
+
+    # The first three calls reach the function and raise the real error.
+    for _ in range(3):
+        with pytest.raises(ConnectionError):
+            flaky_upstream()
+
+    assert calls["n"] == 3
+
+    # The breaker is now OPEN: the next call is short-circuited and the
+    # underlying function is NOT invoked again.
+    with pytest.raises(CircuitBreakerError) as exc_info:
+        flaky_upstream()
+
+    assert calls["n"] == 3  # function was not called while OPEN
+    assert exc_info.value.breaker_name == name
+    breaker = flaky_upstream.circuit_breaker
+    assert breaker.state.value == "open"
+
+    circuit_breaker_registry.remove(name)
+
+
+def test_circuit_breaker_recovers_after_recovery_timeout():
+    """The breaker probes recovery once the recovery timeout elapses.
+
+    Real-life: the upstream comes back. After ``recovery_timeout`` the breaker
+    goes HALF_OPEN, lets one probe through, and a success CLOSEs it again.
+    """
+    name = f"cb-recover-{uuid.uuid4().hex}"
+    state = {"fail": True}
+
+    @circuit_breaker(failure_threshold=2, recovery_timeout=1, name=name)
+    def upstream():
+        if state["fail"]:
+            raise ConnectionError("still down")
+        return "ok"
+
+    for _ in range(2):
+        with pytest.raises(ConnectionError):
+            upstream()
+
+    breaker = upstream.circuit_breaker
+    assert breaker.state.value == "open"
+
+    # While OPEN (before the timeout) the breaker short-circuits.
+    with pytest.raises(CircuitBreakerError):
+        upstream()
+
+    # Upstream recovers; wait out the recovery_timeout then probe.
+    state["fail"] = False
+    time.sleep(1.2)
+
+    assert upstream() == "ok"
+    assert breaker.state.value == "closed"
+
+    circuit_breaker_registry.remove(name)
+
+
+def test_circuit_breaker_only_trips_on_expected_exception():
+    """Only the configured exception type counts toward tripping the breaker.
+
+    Real-life: a 4xx ``ValueError`` is the caller's fault and should not open
+    the breaker, while ``ConnectionError`` (the dependency being down) should.
+    """
+    name = f"cb-expected-{uuid.uuid4().hex}"
+
+    @circuit_breaker(
+        failure_threshold=2,
+        recovery_timeout=60,
+        expected_exception=ConnectionError,
+        name=name,
+    )
+    def upstream(kind):
+        raise kind("boom")
+
+    # Many ValueErrors do NOT trip the breaker (wrong exception type).
+    for _ in range(5):
+        with pytest.raises(ValueError):
+            upstream(ValueError)
+
+    breaker = upstream.circuit_breaker
+    assert breaker.state.value == "closed"
+
+    # ConnectionErrors do count and trip it.
+    for _ in range(2):
+        with pytest.raises(ConnectionError):
+            upstream(ConnectionError)
+
+    assert breaker.state.value == "open"
+    with pytest.raises(CircuitBreakerError):
+        upstream(ConnectionError)
+
+    circuit_breaker_registry.remove(name)
+
+
+def test_circuit_breaker_fallback_function_serves_while_open():
+    """When OPEN, the configured fallback is served instead of raising.
+
+    Real-life: a recommendations service is down; rather than error out we serve
+    a cached/default payload from the fallback while the breaker is OPEN.
+    """
+    name = f"cb-fallback-{uuid.uuid4().hex}"
+
+    def fallback():
+        return "cached-default"
+
+    @circuit_breaker(
+        failure_threshold=2,
+        recovery_timeout=60,
+        name=name,
+        fallback_function=fallback,
+    )
+    def recommendations():
+        raise ConnectionError("recs down")
+
+    # Failures still propagate while the breaker is CLOSED...
+    for _ in range(2):
+        with pytest.raises(ConnectionError):
+            recommendations()
+
+    # ...but once OPEN, the fallback is served (no exception).
+    assert recommendations() == "cached-default"
+    assert recommendations() == "cached-default"
+    assert recommendations.circuit_breaker.state.value == "open"
+
+    circuit_breaker_registry.remove(name)
+
+
+def test_circuit_breaker_registry_tracks_and_resets():
+    """The global registry exposes/manages breakers; reset re-CLOSEs them.
+
+    Real-life: an ops dashboard reads ``circuit_breaker_registry`` to show every
+    breaker's status and an operator manually resets one after a fix.
+    """
+    name = f"cb-registry-{uuid.uuid4().hex}"
+
+    @circuit_breaker(failure_threshold=2, recovery_timeout=60, name=name)
+    def svc():
+        raise ConnectionError("down")
+
+    for _ in range(2):
+        with pytest.raises(ConnectionError):
+            svc()
+
+    # Registry can hand back the same breaker by name.
+    assert circuit_breaker_registry.get(name) is svc.circuit_breaker
+
+    status = circuit_breaker_registry.get_all_status()
+    assert name in status
+    assert status[name]["state"] == "open"
+
+    # Manual reset returns it to CLOSED so traffic flows again.
+    circuit_breaker_registry.get(name).reset()
+    assert svc.circuit_breaker.state.value == "closed"
+
+    circuit_breaker_registry.remove(name)
+
+
+# ---------------------------------------------------------------------------
+# Distributed circuit breaker on REAL Redis state storage
+# ---------------------------------------------------------------------------
+
+
+@skip_without_redis
+def test_circuit_breaker_state_on_real_redis():
+    """Circuit-breaker state lives on REAL Redis and trips/recovers there.
+
+    Real-life: multiple app processes share one breaker via Redis so that one
+    worker observing a dead dependency protects the whole fleet. Here we drive
+    the breaker, then read the failure/state keys straight from the live Redis
+    to prove the state is genuinely persisted to the store.
+    """
+    import redis as _redis
+
+    name = f"cb-redis-{uuid.uuid4().hex}"
+    redis_url = f"redis://{REDIS_HOST}:{REDIS_PORT}/0"
+    client = _redis.from_url(redis_url)
+
+    # Clean any prior state for this (unique) breaker name.
+    for suffix in ("state", "failures", "last_failure", "half_open_calls"):
+        client.delete(f"circuit:{name}:{suffix}")
+
+    with override_settings(
+        RATELIMIT_CIRCUIT_BREAKER_STORAGE="redis",
+        RATELIMIT_CIRCUIT_BREAKER_REDIS_URL=redis_url,
+    ):
+        reset_settings()
+        try:
+
+            @circuit_breaker(failure_threshold=3, recovery_timeout=1, name=name)
+            def upstream():
+                raise ConnectionError("down")
+
+            # Confirm the breaker actually attached the Redis-backed storage.
+            storage = upstream.circuit_breaker._storage
+            assert storage.__class__.__name__ == "RedisCircuitBreakerState"
+
+            for _ in range(3):
+                with pytest.raises(ConnectionError):
+                    upstream()
+
+            # State is persisted on the REAL Redis, not just in memory.
+            assert client.get(f"circuit:{name}:state").decode() == "open"
+            assert int(client.get(f"circuit:{name}:failures")) >= 3
+            assert upstream.circuit_breaker.state.value == "open"
+
+            # OPEN short-circuits before the recovery timeout.
+            with pytest.raises(CircuitBreakerError):
+                upstream()
+
+            # After recovery_timeout the breaker probes HALF_OPEN again. The
+            # probe call still fails, so it re-OPENs -- but the important part is
+            # that it stopped short-circuiting and actually invoked upstream.
+            time.sleep(1.2)
+            with pytest.raises(ConnectionError):
+                upstream()
+        finally:
+            for suffix in ("state", "failures", "last_failure", "half_open_calls"):
+                client.delete(f"circuit:{name}:{suffix}")
+            circuit_breaker_registry.remove(name)
+            reset_settings()
+
+
+# ---------------------------------------------------------------------------
+# fail_open vs fail_closed against an unreachable (dead-port) Redis
+# ---------------------------------------------------------------------------
+
+
+def test_backend_fail_open_allows_when_redis_unreachable():
+    """fail_open=True: an unreachable Redis degrades to ALLOW, never blocks.
+
+    Real-life: Redis falls over; with fail-open the site keeps serving (rate
+    limiting silently disabled) rather than 500-ing every request.
+    """
+    # RedisBackend reads its connection config from RATELIMIT_REDIS, so point
+    # that at a dead port for the duration of this scenario.
+    with override_settings(
+        RATELIMIT_REDIS={"host": REDIS_HOST, "port": DEAD_REDIS_PORT, "db": 0}
+    ):
+        reset_settings()
+        try:
+            backend = RedisBackend(fail_open=True)
+            # Construction succeeds even though Redis is unreachable; client is None.
+            assert backend.redis is None
+            # incr() returns 0 (== allowed) instead of raising.
+            assert backend.incr("fail-open-key", period=60) == 0
+        finally:
+            reset_settings()
+
+
+def test_backend_fail_closed_raises_when_redis_unreachable():
+    """fail_open=False: an unreachable Redis is a hard error (deny).
+
+    Real-life: a payment endpoint must never run unprotected -- if the limiter's
+    store is down, fail CLOSED rather than silently allowing unlimited traffic.
+    """
+    from django.core.exceptions import ImproperlyConfigured
+
+    with override_settings(
+        RATELIMIT_REDIS={"host": REDIS_HOST, "port": DEAD_REDIS_PORT, "db": 0}
+    ):
+        reset_settings()
+        try:
+            with pytest.raises(ImproperlyConfigured):
+                RedisBackend(fail_open=False)
+        finally:
+            reset_settings()
+
+
+def test_decorator_fail_open_serves_200_when_redis_unreachable():
+    """End-to-end: a view stays available (200) under fail-open when Redis dies.
+
+    Real-life: the limiter's Redis is unreachable but the public read endpoint
+    keeps returning 200 because RATELIMIT_FAIL_OPEN is on.
+    """
+    with override_settings(
+        RATELIMIT_BACKEND=REDIS,
+        RATELIMIT_REDIS={"host": REDIS_HOST, "port": DEAD_REDIS_PORT, "db": 0},
+        RATELIMIT_FAIL_OPEN=True,
+    ):
+        reset_settings()
+        clear_backend_cache()
+        try:
+
+            @rate_limit(key="ip", rate="2/m", backend=REDIS)
+            def view(request):
+                return HttpResponse("ok")
+
+            # Even past the nominal 2/m limit, fail-open keeps serving 200.
+            codes = [
+                view(make_request(ip="198.51.100.7")).status_code for _ in range(5)
+            ]
+            assert codes == [200, 200, 200, 200, 200]
+        finally:
+            clear_backend_cache()
+            reset_settings()
+
+
+def test_decorator_fail_closed_does_not_silently_allow_when_redis_unreachable():
+    """End-to-end: fail-closed refuses to serve normally when Redis is dead.
+
+    Real-life: with fail-closed, an unreachable store must not turn into a free
+    pass -- the request errors out instead of returning a normal 200.
+    """
+    from django.core.exceptions import ImproperlyConfigured
+
+    with override_settings(
+        RATELIMIT_BACKEND=REDIS,
+        RATELIMIT_REDIS={"host": REDIS_HOST, "port": DEAD_REDIS_PORT, "db": 0},
+        RATELIMIT_FAIL_OPEN=False,
+    ):
+        reset_settings()
+        clear_backend_cache()
+        try:
+
+            @rate_limit(key="ip", rate="2/m", backend=REDIS)
+            def view(request):
+                return HttpResponse("ok")
+
+            # The dead-port backend cannot be constructed under fail-closed, so
+            # the call surfaces an error rather than a normal 200 response.
+            with pytest.raises(ImproperlyConfigured):
+                view(make_request(ip="198.51.100.8"))
+        finally:
+            clear_backend_cache()
+            reset_settings()
+
+
+# ---------------------------------------------------------------------------
+# Adaptive rate limiting with a real custom indicator (every real backend)
+# ---------------------------------------------------------------------------
+
+
+def test_adaptive_high_load_tightens_decorator_limit(real_backend):
+    """Under HIGH load the adaptive limiter clamps the effective limit to min.
+
+    Real-life: a system-load probe reports the box is saturated, so the API's
+    effective limit drops to its floor (1 req) and a client is blocked after a
+    single request -- verified against every real backend.
+    """
+    load = {"value": 1.0}  # max load
+    limiter = AdaptiveRateLimiter(
+        base_limit=100,
+        min_limit=1,
+        max_limit=1000,
+        indicators=[CustomLoadIndicator(lambda: load["value"], name="probe")],
+        smoothing_factor=1.0,
+        update_interval=0,
+    )
+    name = f"adaptive-high-{real_backend}-{uuid.uuid4().hex}"
+    register_adaptive_limiter(name, limiter)
+
+    # Effective limit collapses to min_limit under max load.
+    assert limiter.get_effective_limit() == 1
+
+    @rate_limit(key="ip", rate="100/m", adaptive=name, backend=real_backend)
+    def view(request):
+        return HttpResponse("ok")
+
+    ip = "203.0.113.41"
+    first = view(make_request(ip=ip)).status_code
+    second = view(make_request(ip=ip)).status_code
+
+    assert first == 200  # only one request allowed
+    assert second == 429  # adaptive floor of 1 blocks the rest
+
+    unregister_adaptive_limiter(name)
+
+
+def test_adaptive_low_load_relaxes_decorator_limit(real_backend):
+    """Under LOW load the adaptive limiter raises the effective limit to max.
+
+    Real-life: the box is idle, so the same endpoint becomes far more permissive
+    (effective limit climbs to max_limit) and a burst that would trip the base
+    rate sails through -- verified against every real backend.
+    """
+    load = {"value": 0.0}  # no load
+    limiter = AdaptiveRateLimiter(
+        base_limit=2,
+        min_limit=1,
+        max_limit=50,
+        indicators=[CustomLoadIndicator(lambda: load["value"], name="probe")],
+        smoothing_factor=1.0,
+        update_interval=0,
+    )
+    name = f"adaptive-low-{real_backend}-{uuid.uuid4().hex}"
+    register_adaptive_limiter(name, limiter)
+
+    # With zero load the effective limit jumps to max_limit.
+    assert limiter.get_effective_limit() == 50
+
+    @rate_limit(key="ip", rate="2/m", adaptive=name, backend=real_backend)
+    def view(request):
+        return HttpResponse("ok")
+
+    ip = "203.0.113.42"
+    # A 10-request burst (well over the base rate of 2/m) is all allowed because
+    # the adaptive effective limit is 50.
+    codes = [view(make_request(ip=ip)).status_code for _ in range(10)]
+    assert codes == [200] * 10
+
+    unregister_adaptive_limiter(name)
+
+
+def test_adaptive_limit_tracks_changing_indicator(real_backend):
+    """The effective limit follows the live indicator as load changes.
+
+    Real-life: load ramps from idle to saturated; the adaptive limiter re-reads
+    its real indicator and tightens the effective limit in lock-step.
+    """
+    load = {"value": 0.0}
+    limiter = AdaptiveRateLimiter(
+        base_limit=10,
+        min_limit=2,
+        max_limit=40,
+        indicators=[CustomLoadIndicator(lambda: load["value"], name="probe")],
+        smoothing_factor=1.0,
+        update_interval=0,
+    )
+
+    assert limiter.get_effective_limit() == 40  # idle -> max
+    load["value"] = 1.0
+    assert limiter.get_effective_limit() == 2  # saturated -> min
+    load["value"] = 0.5  # midway between low (0.3) and high (0.7) thresholds
+    mid = limiter.get_effective_limit()
+    assert 2 < mid < 40  # interpolated between min and max
+
+
+# ---------------------------------------------------------------------------
+# Management command: ratelimit_health against real backends
+# ---------------------------------------------------------------------------
+
+
+def test_ratelimit_health_reports_healthy(real_backend):
+    """``ratelimit_health`` probes a reachable real backend and reports status.
+
+    Real-life: a monitoring cron runs ``manage.py ratelimit_health --json``.
+    For the memory/redis/mongodb backends (which expose a synchronous
+    ``health_check`` / ``get_count`` probe) it reports ``healthy: true`` while
+    the service is up. The ``async_redis`` backend has no synchronous probe
+    (its ``get_count`` raises ``NotImplementedError``), so the sync command
+    honestly reports it unhealthy -- a real, observable backend limitation.
+    """
+    import json
+
+    out = StringIO()
+    call_command("ratelimit_health", "--json", stdout=out)
+    data = json.loads(out.getvalue())
+
+    if real_backend == "async_redis":
+        assert data["healthy"] is False
+        assert data.get("error")
+    else:
+        assert data["healthy"] is True
+        assert data.get("error") in (None, "")
+
+
+@skip_without_redis
+def test_ratelimit_health_reports_unhealthy_when_backend_down():
+    """``ratelimit_health`` reports an unreachable Redis as unhealthy.
+
+    Real-life: Redis is down; the health command's JSON shows ``healthy: false``
+    with an error so the monitor can page someone. fail-open is enabled so the
+    backend constructs, but ``health_check()`` still probes the real connection
+    and reports the failure (it does not get masked by fail-open).
+    """
+    import json
+
+    with override_settings(
+        RATELIMIT_BACKEND=REDIS,
+        RATELIMIT_REDIS={"host": REDIS_HOST, "port": DEAD_REDIS_PORT, "db": 0},
+        RATELIMIT_FAIL_OPEN=True,
+    ):
+        reset_settings()
+        clear_backend_cache()
+        try:
+            out = StringIO()
+            call_command("ratelimit_health", "--json", stdout=out)
+            data = json.loads(out.getvalue())
+            assert data["healthy"] is False
+            assert data.get("error")
+        finally:
+            clear_backend_cache()
+            reset_settings()
+
+
+# ---------------------------------------------------------------------------
+# Management command: ratelimit_cleanup on the REAL database backend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_ratelimit_cleanup_reports_and_removes_expired_rows():
+    """``ratelimit_cleanup`` reports then deletes expired DB rate-limit rows.
+
+    Real-life: a nightly cron prunes the rate-limit tables. We seed expired
+    counters/entries plus a fresh (non-expired) one, prove ``--dry-run`` finds
+    but does not delete them, then prove a real run deletes only the expired
+    rows and leaves the live one intact.
+    """
+    import json
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    from django_smart_ratelimit.models import RateLimitCounter, RateLimitEntry
+
+    with use_backend("database"):
+        now = timezone.now()
+        past = now - timedelta(minutes=5)
+        future = now + timedelta(minutes=5)
+
+        # Two expired rows (window_end / expires_at in the past)...
+        expired_counter = RateLimitCounter.objects.create(
+            key=f"cleanup-counter-expired-{uuid.uuid4().hex}",
+            count=1,
+            window_start=past - timedelta(minutes=1),
+            window_end=past,
+        )
+        expired_entry = RateLimitEntry.objects.create(
+            key=f"cleanup-entry-expired-{uuid.uuid4().hex}",
+            timestamp=past,
+            expires_at=past,
+        )
+        # ...and one still-live counter that must survive cleanup.
+        live_counter = RateLimitCounter.objects.create(
+            key=f"cleanup-counter-live-{uuid.uuid4().hex}",
+            count=1,
+            window_start=now,
+            window_end=future,
+        )
+
+        # Dry run: it should FIND the expired rows but delete nothing.
+        out = StringIO()
+        call_command("ratelimit_cleanup", "--dry-run", "--json", stdout=out)
+        dry = json.loads(out.getvalue())
+        assert dry["dry_run"] is True
+        assert dry["counters"]["found"] >= 1
+        assert dry["entries"]["found"] >= 1
+        assert dry["total_deleted"] == 0
+        assert RateLimitCounter.objects.filter(id=expired_counter.id).exists()
+        assert RateLimitEntry.objects.filter(id=expired_entry.id).exists()
+
+        # Real run: expired rows are deleted, the live row stays.
+        out = StringIO()
+        call_command("ratelimit_cleanup", "--json", stdout=out)
+        real = json.loads(out.getvalue())
+        assert real["dry_run"] is False
+        assert real["counters"]["deleted"] >= 1
+        assert real["entries"]["deleted"] >= 1
+        assert not RateLimitCounter.objects.filter(id=expired_counter.id).exists()
+        assert not RateLimitEntry.objects.filter(id=expired_entry.id).exists()
+        assert RateLimitCounter.objects.filter(id=live_counter.id).exists()
+
+
+@pytest.mark.django_db
+def test_ratelimit_cleanup_removes_stale_token_buckets():
+    """``ratelimit_cleanup --stale-days`` prunes stale token buckets only.
+
+    Real-life: old token-bucket rows for keys that went quiet pile up; the
+    cleanup command removes buckets untouched beyond ``--stale-days`` while
+    keeping recently-active ones.
+    """
+    import json
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    from django_smart_ratelimit.models import RateLimitTokenBucket
+
+    with use_backend("database"):
+        now = timezone.now()
+        stale = RateLimitTokenBucket.objects.create(
+            key=f"cleanup-bucket-stale-{uuid.uuid4().hex}",
+            tokens=5.0,
+            last_update=now - timedelta(days=30),
+            bucket_size=10,
+            refill_rate=1.0,
+        )
+        fresh = RateLimitTokenBucket.objects.create(
+            key=f"cleanup-bucket-fresh-{uuid.uuid4().hex}",
+            tokens=5.0,
+            last_update=now,
+            bucket_size=10,
+            refill_rate=1.0,
+        )
+
+        out = StringIO()
+        call_command("ratelimit_cleanup", "--stale-days=7", "--json", stdout=out)
+        data = json.loads(out.getvalue())
+        assert data["token_buckets"]["found"] >= 1
+        assert data["token_buckets"]["deleted"] >= 1
+        assert not RateLimitTokenBucket.objects.filter(id=stale.id).exists()
+        assert RateLimitTokenBucket.objects.filter(id=fresh.id).exists()

--- a/tests/e2e/test_utils_pipeline_e2e.py
+++ b/tests/e2e/test_utils_pipeline_e2e.py
@@ -1,0 +1,930 @@
+"""Real-backend end-to-end scenarios for public utilities, the shared
+evaluation pipeline primitives, and the type-safe enums.
+
+This file covers the "plumbing" that advanced users compose directly rather
+than through the decorator:
+
+    * :func:`is_ratelimited` — the programmatic check used inside custom views;
+      its count must reflect real increments on the live backend.
+    * :func:`generate_key` — the single dispatch point for every built-in key
+      pattern (``ip``/``user``/``user_or_ip``/``header:``/``get:``/``param:`` and
+      callables); the bucketing contract everything else relies on.
+    * :func:`parse_rate` / :func:`validate_rate_config` — rate-string parsing and
+      config validation, valid inputs and the errors raised on bad ones.
+    * :class:`RateLimitConfigManager` — named-config register/retrieve, then
+      *applying* a retrieved config to a real decorated view.
+    * The header/debug helpers (:func:`add_rate_limit_headers`,
+      :func:`add_token_bucket_headers`, :func:`format_rate_headers`,
+      :func:`debug_ratelimit_status`, :func:`format_debug_info`) producing the
+      exact ``X-RateLimit-*`` output operators see.
+    * :func:`load_function_from_string` round-tripping a dotted path.
+    * The v3 pipeline primitives :func:`resolve_effective_rate`,
+      :func:`apply_policy_lists` and :func:`handle_shadow_decision` exercised
+      with real :class:`IPList` inputs and a real backend.
+    * The :class:`Algorithm` and :class:`RateLimitKey` enums: full membership and
+      that each value works in a real decorator call.
+
+Each scenario is self-contained: the ``real_backend`` fixture flushes the real
+store before/after, and every test uses DISTINCT IPs / keys so tests never leak
+into one another.
+"""
+
+import pytest
+
+from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpResponse
+
+from django_smart_ratelimit import (
+    POLICY_ALLOW,
+    POLICY_CONTINUE,
+    POLICY_DENY,
+    RateLimitConfigManager,
+    ResolvedLimit,
+    ShadowDecision,
+    add_rate_limit_headers,
+    add_token_bucket_headers,
+    apply_policy_lists,
+    debug_ratelimit_status,
+    format_debug_info,
+    format_rate_headers,
+    generate_key,
+    handle_shadow_decision,
+    is_ratelimited,
+    load_function_from_string,
+    parse_rate,
+    rate_limit,
+    resolve_effective_rate,
+    validate_rate_config,
+)
+from django_smart_ratelimit.enums import Algorithm, RateLimitKey
+from django_smart_ratelimit.exceptions import KeyGenerationError
+from django_smart_ratelimit.policy import IPList
+
+from .conftest import AnonUser, AuthedUser, make_request
+
+OK = 200
+TOO_MANY = 429
+
+
+def _ok_view(_request):
+    """A trivial 200 view body to wrap with the rate-limit decorator."""
+    return HttpResponse("ok")
+
+
+def _codes(view, requests):
+    """Drive a view across a sequence of pre-built requests; return codes."""
+    return [view(req).status_code for req in requests]
+
+
+# ===========================================================================
+# is_ratelimited — programmatic check against the real backend
+# ===========================================================================
+
+
+def test_is_ratelimited_reflects_real_increments(real_backend):
+    """A custom view using ``is_ratelimited`` to gate access: keyed by IP at
+    3/min, the same client is reported limited only after the real backend
+    counter passes the limit, and a different IP is never limited.
+    """
+    ip = "198.51.100.10"
+    req = make_request(ip=ip)
+
+    # 3 allowed (count 1,2,3 are all <= 3), the 4th increment (count 4 > 3) trips.
+    results = [is_ratelimited(req, key="ip", rate="3/m") for _ in range(4)]
+    assert results == [False, False, False, True]
+
+    # A different IP has its own real bucket and is unaffected.
+    other = make_request(ip="198.51.100.11")
+    assert is_ratelimited(other, key="ip", rate="3/m") is False
+
+
+def test_is_ratelimited_increment_false_only_reads(real_backend):
+    """``increment=False`` is a non-consuming probe: it reports the live count
+    without advancing it, so a peek never pushes the caller over the limit.
+    """
+    ip = "198.51.100.20"
+    req = make_request(ip=ip)
+
+    # Peeking many times never increments -> never limited (count stays 0).
+    for _ in range(5):
+        assert is_ratelimited(req, key="ip", rate="2/m", increment=False) is False
+
+    # Now actually consume the quota: 2 allowed, 3rd trips.
+    assert is_ratelimited(req, key="ip", rate="2/m") is False
+    assert is_ratelimited(req, key="ip", rate="2/m") is False
+    assert is_ratelimited(req, key="ip", rate="2/m") is True
+
+    # A read-only probe now observes the over-limit state without changing it.
+    assert is_ratelimited(req, key="ip", rate="2/m", increment=False) is True
+
+
+def test_is_ratelimited_group_namespaces_buckets(real_backend):
+    """A ``group`` prefix gives the same client independent buckets per
+    business action (e.g. "login" vs "signup"), so exhausting one group's
+    quota does not limit the other.
+    """
+    req = make_request(ip="198.51.100.30")
+
+    # Exhaust the "login" group (1/min).
+    assert is_ratelimited(req, group="login", key="ip", rate="1/m") is False
+    assert is_ratelimited(req, group="login", key="ip", rate="1/m") is True
+
+    # The "signup" group for the same IP is a separate bucket -> still allowed.
+    assert is_ratelimited(req, group="signup", key="ip", rate="1/m") is False
+
+
+def test_is_ratelimited_user_key_independent_per_user(real_backend):
+    """``is_ratelimited`` keyed by "user": two authenticated users have
+    separate real buckets; exhausting user A never limits user B.
+    """
+    a = make_request(ip="198.51.100.40", user=AuthedUser(uid=7001))
+    b = make_request(ip="198.51.100.40", user=AuthedUser(uid=7002))
+
+    assert is_ratelimited(a, key="user", rate="1/m") is False
+    assert is_ratelimited(a, key="user", rate="1/m") is True
+
+    # Different user id -> own bucket, unaffected.
+    assert is_ratelimited(b, key="user", rate="1/m") is False
+
+
+# ===========================================================================
+# generate_key — every built-in pattern
+# ===========================================================================
+
+
+def test_generate_key_ip_and_user_patterns():
+    """``generate_key`` resolves the core identity patterns to stable strings."""
+    anon = make_request(ip="192.0.2.20", user=AnonUser())
+    assert generate_key("ip", anon) == "ip:192.0.2.20"
+    # Anonymous user / user_or_ip fall back to the IP key.
+    assert generate_key("user", anon) == "ip:192.0.2.20"
+    assert generate_key("user_or_ip", anon) == "ip:192.0.2.20"
+
+    authed = make_request(ip="192.0.2.21", user=AuthedUser(uid=55))
+    assert generate_key("user", authed) == "user:55"
+    assert generate_key("user_or_ip", authed) == "user:55"
+    # "ip:" prefixed templates always key on the IP.
+    assert generate_key("ip:whatever", authed) == "ip:192.0.2.21"
+    # "user:" template for an authenticated user resolves to the user id.
+    assert generate_key("user:{id}", authed) == "user:55"
+
+
+def test_generate_key_header_and_param_patterns():
+    """``generate_key`` resolves ``header:``, ``get:`` and the ``param:`` alias
+    by embedding the request's header/query value into the key.
+    """
+    req = make_request(
+        ip="192.0.2.22",
+        headers={"X-Api-Key": "abc123"},
+        params={"tenant": "acme"},
+    )
+    assert generate_key("header:X-Api-Key", req) == "header:X-Api-Key:abc123"
+    assert generate_key("get:tenant", req) == "get:tenant:acme"
+    # "param:" is an alias of "get:" so RateLimitKey.PARAM composes correctly.
+    assert generate_key("param:tenant", req) == "param:tenant:acme"
+
+    # A missing header/param yields a stable empty-value key (all such callers
+    # share one bucket, which is the documented behavior).
+    bare = make_request(ip="192.0.2.23")
+    assert generate_key("header:X-Api-Key", bare) == "header:X-Api-Key:"
+    assert generate_key("get:tenant", bare) == "get:tenant:"
+
+
+def test_generate_key_callable_and_passthrough():
+    """A callable key is invoked with the request (and forwarded args); an
+    unknown literal string is returned verbatim as a static bucket.
+    """
+    req = make_request(ip="192.0.2.24")
+
+    def custom(request, *args, **kwargs):
+        return f"custom:{request.META['REMOTE_ADDR']}"
+
+    assert generate_key(custom, req) == "custom:192.0.2.24"
+    # An arbitrary literal is used as-is (a single shared global bucket).
+    assert generate_key("global-bucket", req) == "global-bucket"
+
+
+def test_generate_key_invalid_type_raises():
+    """A non-str / non-callable key is a configuration error."""
+    req = make_request()
+    with pytest.raises(ImproperlyConfigured):
+        generate_key(12345, req)
+
+
+def test_generate_key_drives_real_bucketing(real_backend):
+    """End-to-end: feeding ``generate_key`` output straight into the backend
+    enforces the limit. Two distinct generated keys are independent buckets;
+    the same key accumulates on the live store.
+    """
+    from django_smart_ratelimit.backends import get_backend
+
+    backend = get_backend()
+    limit, period = parse_rate("2/m")
+
+    req_a = make_request(ip="198.51.100.50", headers={"X-Api-Key": "tenant-A"})
+    req_b = make_request(ip="198.51.100.50", headers={"X-Api-Key": "tenant-B"})
+    key_a = generate_key("header:X-Api-Key", req_a)
+    key_b = generate_key("header:X-Api-Key", req_b)
+    assert key_a != key_b
+
+    # key_a: 2 allowed, 3rd over limit.
+    assert [backend.incr(key_a, period) <= limit for _ in range(3)] == [
+        True,
+        True,
+        False,
+    ]
+    # key_b is its own bucket — still under limit.
+    assert backend.incr(key_b, period) <= limit
+
+
+# ===========================================================================
+# parse_rate / validate_rate_config — valid + raising
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "rate,expected",
+    [
+        ("10/s", (10, 1)),
+        ("5/m", (5, 60)),
+        ("100/h", (100, 3600)),
+        ("1000/d", (1000, 86400)),
+        # Long-form aliases (DRF / API-gateway compatibility).
+        ("7/sec", (7, 1)),
+        ("7/second", (7, 1)),
+        ("9/min", (9, 60)),
+        ("9/minute", (9, 60)),
+        ("3/hr", (3, 3600)),
+        ("3/hour", (3, 3600)),
+        ("2/day", (2, 86400)),
+        # Custom multiplier windows.
+        ("10/30s", (10, 30)),
+        ("100/5m", (100, 300)),
+        ("500/2h", (500, 7200)),
+        ("10000/7d", (10000, 604800)),
+    ],
+)
+def test_parse_rate_valid_formats(rate, expected):
+    """``parse_rate`` handles simple, long-form, and custom-window rates."""
+    assert parse_rate(rate) == expected
+
+
+@pytest.mark.parametrize(
+    "bad_rate",
+    [
+        "abc",  # no slash
+        "10/x",  # unknown unit
+        "10/0s",  # non-positive multiplier
+        "ten/m",  # non-integer limit
+        "5//m",  # malformed
+        "100/",  # empty period
+    ],
+)
+def test_parse_rate_invalid_raises(bad_rate):
+    """Invalid rate strings raise ImproperlyConfigured rather than misparse."""
+    with pytest.raises(ImproperlyConfigured):
+        parse_rate(bad_rate)
+
+
+def test_validate_rate_config_accepts_valid():
+    """``validate_rate_config`` is silent for a valid rate + algorithm + token
+    bucket config (the happy path for startup validation).
+    """
+    # No exception == valid.
+    validate_rate_config("100/h")
+    validate_rate_config("10/m", algorithm="sliding_window")
+    validate_rate_config(
+        "10/m",
+        algorithm="token_bucket",
+        algorithm_config={"bucket_size": 20, "refill_rate": 2.5},
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"rate": "not-a-rate"},  # bad rate
+        {"rate": "10/m", "algorithm": "made_up"},  # bad algorithm
+        {
+            "rate": "10/m",
+            "algorithm": "token_bucket",
+            "algorithm_config": {"bucket_size": -1},
+        },  # negative bucket_size
+        {
+            "rate": "10/m",
+            "algorithm": "token_bucket",
+            "algorithm_config": {"refill_rate": -0.5},
+        },  # negative refill_rate
+    ],
+)
+def test_validate_rate_config_invalid_raises(kwargs):
+    """``validate_rate_config`` raises ImproperlyConfigured on bad rate,
+    unknown algorithm, or invalid token-bucket parameters.
+    """
+    with pytest.raises(ImproperlyConfigured):
+        validate_rate_config(**kwargs)
+
+
+def test_parsed_rate_enforced_on_real_backend(real_backend):
+    """End-to-end: a ``parse_rate``-derived (limit, period) enforces exactly N
+    allowed requests against the live store.
+    """
+    from django_smart_ratelimit.backends import get_backend
+
+    limit, period = parse_rate("3/m")
+    assert (limit, period) == (3, 60)
+
+    backend = get_backend()
+    key = "ip:198.51.100.60"
+    over = [backend.incr(key, period) > limit for _ in range(4)]
+    assert over == [False, False, False, True]
+
+
+# ===========================================================================
+# RateLimitConfigManager — register + retrieve + apply
+# ===========================================================================
+
+
+def test_config_manager_has_builtin_defaults():
+    """The manager ships with sensible named defaults (e.g. "authentication"
+    at 5/min keyed by ip).
+    """
+    mgr = RateLimitConfigManager()
+    auth = mgr.get_config("authentication")
+    assert auth["rate"] == "5/m"
+    assert auth["key"] == "ip"
+    assert auth["algorithm"] == "fixed_window"
+
+
+def test_config_manager_register_retrieve_and_override():
+    """A custom named config can be registered, retrieved, and retrieved again
+    with per-call overrides applied on top.
+    """
+    mgr = RateLimitConfigManager()
+    mgr.register_config(
+        "partner_api",
+        {"rate": "100/h", "key": "user", "algorithm": "sliding_window"},
+    )
+
+    cfg = mgr.get_config("partner_api")
+    assert cfg["rate"] == "100/h"
+    assert cfg["key"] == "user"
+
+    # Overrides are layered on retrieval.
+    overridden = mgr.get_config("partner_api", rate="200/h")
+    assert overridden["rate"] == "200/h"
+
+
+def test_config_manager_rejects_invalid_config():
+    """Registering a config with a bad rate is rejected at registration time."""
+    mgr = RateLimitConfigManager()
+    with pytest.raises(ImproperlyConfigured):
+        mgr.register_config("broken", {"rate": "nonsense"})
+    # A config missing the required 'rate' field is also rejected.
+    with pytest.raises(ImproperlyConfigured):
+        mgr.register_config("missing_rate", {"key": "ip"})
+
+
+def test_config_manager_applied_config_enforces_real_limit(real_backend):
+    """Realistic flow: register a named "sms_send" config, retrieve it, and
+    apply its rate+key to a real decorated view — the live backend enforces it.
+    """
+    mgr = RateLimitConfigManager()
+    mgr.register_config(
+        "sms_send", {"rate": "2/m", "key": "ip", "algorithm": "fixed_window"}
+    )
+    cfg = mgr.get_config("sms_send")
+
+    @rate_limit(key=cfg["key"], rate=cfg["rate"])
+    def send_sms(_request):
+        return _ok_view(_request)
+
+    codes = _codes(send_sms, [make_request(ip="198.51.100.70") for _ in range(3)])
+    assert codes == [OK, OK, TOO_MANY]
+
+
+# ===========================================================================
+# Header / debug helpers — exact output operators rely on
+# ===========================================================================
+
+
+def test_format_rate_headers_basic_and_token_bucket():
+    """``format_rate_headers`` maps backend metadata to the standard
+    ``X-RateLimit-*`` header dict, including token-bucket extras when present.
+    """
+    basic = format_rate_headers({"remaining": 7, "reset_time": 1700000000}, 10, 60)
+    assert basic["X-RateLimit-Limit"] == "10"
+    assert basic["X-RateLimit-Remaining"] == "7"
+    assert basic["X-RateLimit-Reset"] == "1700000000"
+
+    # Negative remaining is clamped to 0.
+    clamped = format_rate_headers({"remaining": -3}, 5, 60)
+    assert clamped["X-RateLimit-Remaining"] == "0"
+
+    bucket = format_rate_headers(
+        {
+            "remaining": 0,
+            "bucket_size": 20,
+            "tokens_remaining": 4,
+            "refill_rate": 2.5,
+        },
+        20,
+        60,
+    )
+    assert bucket["X-RateLimit-Bucket-Size"] == "20"
+    assert bucket["X-RateLimit-Bucket-Remaining"] == "4"
+    assert bucket["X-RateLimit-Refill-Rate"] == "2.50"
+
+
+def test_add_rate_limit_headers_sets_standard_and_retry_after():
+    """``add_rate_limit_headers`` writes Limit/Remaining/Reset onto a response;
+    a 429 with no remaining also gets a Retry-After header.
+    """
+    ok = HttpResponse("ok")
+    add_rate_limit_headers(ok, limit=10, remaining=4, period=60)
+    assert ok.headers["X-RateLimit-Limit"] == "10"
+    assert ok.headers["X-RateLimit-Remaining"] == "4"
+    assert "X-RateLimit-Reset" in ok.headers
+    # Not rate limited -> no Retry-After.
+    assert "Retry-After" not in ok.headers
+
+    blocked = HttpResponse("blocked", status=429)
+    add_rate_limit_headers(blocked, limit=10, remaining=0, period=30)
+    assert blocked.headers["X-RateLimit-Remaining"] == "0"
+    assert blocked.headers["Retry-After"] == "30"
+
+
+def test_add_token_bucket_headers_emits_bucket_fields():
+    """``add_token_bucket_headers`` writes the bucket-specific headers and a
+    stable, period-aligned reset time.
+    """
+    resp = HttpResponse("ok")
+    metadata = {
+        "tokens_remaining": 6,
+        "bucket_size": 20,
+        "refill_rate": 2.0,
+    }
+    add_token_bucket_headers(resp, metadata, limit=20, period=60)
+    assert resp.headers["X-RateLimit-Limit"] == "20"
+    assert resp.headers["X-RateLimit-Remaining"] == "6"
+    assert resp.headers["X-RateLimit-Bucket-Size"] == "20"
+    assert resp.headers["X-RateLimit-Bucket-Remaining"] == "6"
+    assert resp.headers["X-RateLimit-Refill-Rate"] == "2.00"
+    # Reset time is a positive integer string.
+    assert int(resp.headers["X-RateLimit-Reset"]) > 0
+
+
+def test_add_token_bucket_headers_retry_after_when_empty():
+    """A 429 token-bucket response with no tokens left also gets Retry-After."""
+    resp = HttpResponse("blocked", status=429)
+    add_token_bucket_headers(
+        resp,
+        {"tokens_remaining": 0, "bucket_size": 5, "refill_rate": 1.0},
+        limit=5,
+        period=60,
+    )
+    assert resp.headers["X-RateLimit-Bucket-Remaining"] == "0"
+    assert int(resp.headers["Retry-After"]) >= 0
+
+
+def test_debug_ratelimit_status_reads_real_backend(real_backend):
+    """``debug_ratelimit_status`` reports request context plus live backend
+    counts. After hammering an IP-keyed view, the IP key's real count shows up
+    in the debug snapshot, and ``format_debug_info`` renders it readably.
+    """
+
+    @rate_limit(key="ip", rate="5/m")
+    def view(_request):
+        return _ok_view(_request)
+
+    ip = "198.51.100.80"
+    for _ in range(3):
+        view(make_request(ip=ip))
+
+    probe = make_request(ip=ip, user=AuthedUser(uid=8080))
+    info = debug_ratelimit_status(probe)
+
+    assert info["request_path"] == "/"
+    assert info["request_method"] == "GET"
+    assert info["remote_addr"] == ip
+    assert info["user_authenticated"] is True
+    assert info["user_id"] == 8080
+    assert "backend_type" in info
+    assert "backend_counts" in info
+    # The IP key the view used should be present in the snapshot.
+    assert info["backend_counts"]["ip"]["key"] == f"ip:{ip}"
+
+    rendered = format_debug_info(info)
+    assert "Rate Limiting Debug Information" in rendered
+    assert f"Remote IP: {ip}" in rendered
+    assert "User ID: 8080" in rendered
+
+
+def test_format_debug_info_anonymous_request():
+    """``format_debug_info`` renders an anonymous, un-middleware-processed
+    snapshot without leaking a user id.
+    """
+    info = {
+        "request_path": "/api/ping",
+        "request_method": "POST",
+        "user_authenticated": False,
+        "user_id": None,
+        "remote_addr": "192.0.2.99",
+        "middleware_processed": False,
+    }
+    rendered = format_debug_info(info)
+    assert "Path: /api/ping" in rendered
+    assert "Method: POST" in rendered
+    assert "User: Anonymous" in rendered
+    assert "Processed: False" in rendered
+    assert "User ID:" not in rendered
+
+
+# ===========================================================================
+# load_function_from_string — dotted-path round-trip
+# ===========================================================================
+
+
+def test_load_function_from_string_round_trips():
+    """A dotted path round-trips to the live callable, which then behaves
+    identically when invoked.
+    """
+    fn = load_function_from_string("django_smart_ratelimit.utils.parse_rate")
+    assert fn is parse_rate
+    assert fn("10/m") == (10, 60)
+
+    # A public key function loaded the same way produces the expected key.
+    get_ip = load_function_from_string(
+        "django_smart_ratelimit.key_functions.get_ip_key"
+    )
+    assert get_ip(make_request(ip="192.0.2.30")) == "ip:192.0.2.30"
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "django_smart_ratelimit.utils.does_not_exist",  # missing attribute
+        "nonexistent_module_xyz.func",  # missing module
+        "noseparator",  # no dot to split on
+    ],
+)
+def test_load_function_from_string_invalid_raises(bad_path):
+    """An unresolvable dotted path is surfaced as ImproperlyConfigured."""
+    with pytest.raises(ImproperlyConfigured):
+        load_function_from_string(bad_path)
+
+
+# ===========================================================================
+# Pipeline: resolve_effective_rate
+# ===========================================================================
+
+
+def test_resolve_effective_rate_returns_resolved_limit():
+    """``resolve_effective_rate`` turns a (key, rate) config into a concrete
+    :class:`ResolvedLimit` with parsed limit/period and the generated key.
+    """
+    req = make_request(ip="192.0.2.40")
+    resolved = resolve_effective_rate(key="ip", rate="15/m", request=req)
+    assert isinstance(resolved, ResolvedLimit)
+    assert resolved.key == "ip:192.0.2.40"
+    assert resolved.limit == 15
+    assert resolved.period == 60
+    assert resolved.cost == 1
+    assert resolved.rate_string == "15/m"
+
+
+def test_resolve_effective_rate_callable_rate_and_cost():
+    """A callable rate and a callable cost are both resolved per-request; a
+    cost below 1 is clamped to 1 so a request can never be free.
+    """
+    req = make_request(ip="192.0.2.41")
+
+    resolved = resolve_effective_rate(
+        key="ip",
+        rate=lambda request: "7/h",
+        request=req,
+        cost=lambda request: 3,
+    )
+    assert resolved.limit == 7
+    assert resolved.period == 3600
+    assert resolved.cost == 3
+    assert resolved.rate_string == "7/h"
+
+    # cost <= 0 clamps to 1.
+    clamped = resolve_effective_rate(
+        key="ip", rate="5/m", request=req, cost=lambda request: 0
+    )
+    assert clamped.cost == 1
+
+
+def test_resolve_effective_rate_empty_key_raises():
+    """An empty generated key would collapse every request onto one shared
+    bucket; v3 upgrades that footgun to a loud :class:`KeyGenerationError`.
+    """
+    req = make_request(ip="192.0.2.42")
+
+    with pytest.raises(KeyGenerationError):
+        resolve_effective_rate(key=lambda request: "", rate="5/m", request=req)
+
+    # ...but validate_key=False keeps the old silent behavior for callers who
+    # opt out explicitly.
+    permissive = resolve_effective_rate(
+        key=lambda request: "", rate="5/m", request=req, validate_key=False
+    )
+    assert permissive.key == ""
+
+
+def test_resolve_effective_rate_feeds_real_backend(real_backend):
+    """The resolved (key, limit, period) drives the live backend exactly: N
+    increments under the limit, then over.
+    """
+    from django_smart_ratelimit.backends import get_backend
+
+    req = make_request(ip="198.51.100.90")
+    resolved = resolve_effective_rate(key="ip", rate="2/m", request=req)
+
+    backend = get_backend()
+    over = [
+        backend.incr(resolved.key, resolved.period) > resolved.limit for _ in range(3)
+    ]
+    assert over == [False, False, True]
+
+
+# ===========================================================================
+# Pipeline: apply_policy_lists with real IPList inputs
+# ===========================================================================
+
+
+def test_apply_policy_lists_continue_when_no_lists():
+    """With neither list configured, the pipeline says CONTINUE (apply normal
+    rate limiting).
+    """
+    req = make_request(ip="203.0.113.10")
+    assert apply_policy_lists(req) == POLICY_CONTINUE
+
+
+def test_apply_policy_lists_allow_for_listed_ip():
+    """An IP inside a real allow-list IPList yields POLICY_ALLOW (bypass)."""
+    req = make_request(ip="10.0.0.5")
+    allow = IPList(["10.0.0.0/8"])
+    assert apply_policy_lists(req, allow_list=allow) == POLICY_ALLOW
+
+    # An IP outside the allow list just continues to normal limiting.
+    outside = make_request(ip="203.0.113.11")
+    assert apply_policy_lists(outside, allow_list=allow) == POLICY_CONTINUE
+
+
+def test_apply_policy_lists_deny_takes_precedence():
+    """An IP in the deny-list yields POLICY_DENY, and deny wins even when the
+    same IP also matches the allow-list (fail-closed for explicit blocks).
+    """
+    req = make_request(ip="192.168.1.50")
+    deny = IPList(["192.168.1.0/24"])
+    assert apply_policy_lists(req, deny_list=deny) == POLICY_DENY
+
+    # Same IP in both lists -> deny precedence.
+    allow = IPList(["192.168.1.0/24"])
+    assert apply_policy_lists(req, allow_list=allow, deny_list=deny) == POLICY_DENY
+
+
+def test_apply_policy_lists_accepts_cidr_string_and_list_inputs():
+    """``apply_policy_lists`` accepts raw CIDR strings / lists (not just IPList
+    objects) since it routes through ``parse_ip_list``.
+    """
+    req = make_request(ip="198.51.100.5")
+    # Single-CIDR string form.
+    assert apply_policy_lists(req, deny_list="198.51.100.0/24") == POLICY_DENY
+    # List-of-CIDR form on the allow side.
+    assert apply_policy_lists(req, allow_list=["198.51.100.5"]) == POLICY_ALLOW
+
+
+def test_policy_constants_are_distinct():
+    """The three policy outcomes are distinct sentinel strings."""
+    assert {POLICY_ALLOW, POLICY_DENY, POLICY_CONTINUE} == {
+        "allow",
+        "deny",
+        "continue",
+    }
+
+
+# ===========================================================================
+# Pipeline: handle_shadow_decision
+# ===========================================================================
+
+
+def test_handle_shadow_decision_passes_allowed_through():
+    """An allowed decision is returned unchanged and not shadowed."""
+    req = make_request(ip="203.0.113.20")
+    decision = handle_shadow_decision(
+        allowed=True,
+        shadow=False,
+        request=req,
+        key="ip:203.0.113.20",
+        limit=10,
+        remaining=5,
+        algorithm="sliding_window",
+        backend="MemoryBackend",
+    )
+    assert isinstance(decision, ShadowDecision)
+    assert decision.allow is True
+    assert decision.shadowed is False
+
+
+def test_handle_shadow_decision_enforces_block_without_shadow():
+    """Without shadow mode, a blocked decision stays blocked."""
+    req = make_request(ip="203.0.113.21")
+    decision = handle_shadow_decision(
+        allowed=False,
+        shadow=False,
+        request=req,
+        key="ip:203.0.113.21",
+        limit=10,
+        remaining=0,
+        algorithm="sliding_window",
+        backend="MemoryBackend",
+    )
+    assert decision.allow is False
+    assert decision.shadowed is False
+
+
+def test_handle_shadow_decision_flips_block_under_shadow():
+    """Shadow mode flips a would-be block into an allow (allow-with-log), the
+    standard "run the new limit in shadow for a day" rollout strategy.
+    """
+    req = make_request(ip="203.0.113.22", path="/api/risky")
+    decision = handle_shadow_decision(
+        allowed=False,
+        shadow=True,
+        request=req,
+        key="ip:203.0.113.22",
+        limit=10,
+        remaining=0,
+        algorithm="sliding_window",
+        backend="MemoryBackend",
+    )
+    assert decision.allow is True
+    assert decision.shadowed is True
+    assert decision.extra.get("shadow") is True
+
+
+def test_shadow_decorator_allows_but_records_over_limit(real_backend):
+    """End-to-end via the decorator: a ``shadow=True`` view at 2/min never
+    returns 429 even far past the limit (it would have blocked, but shadow
+    downgrades to allow-with-log), while an identical non-shadow view blocks.
+    """
+
+    @rate_limit(key="ip", rate="2/m", shadow=True)
+    def shadow_view(_request):
+        return _ok_view(_request)
+
+    @rate_limit(key="ip", rate="2/m")
+    def real_view(_request):
+        return _ok_view(_request)
+
+    # Shadow: distinct IP, hammered well past the limit -> all 200.
+    shadow_codes = _codes(
+        shadow_view, [make_request(ip="198.51.100.100") for _ in range(5)]
+    )
+    assert shadow_codes == [OK, OK, OK, OK, OK]
+
+    # Enforcing: a different IP is actually blocked after 2.
+    real_codes = _codes(
+        real_view, [make_request(ip="198.51.100.101") for _ in range(4)]
+    )
+    assert real_codes == [OK, OK, TOO_MANY, TOO_MANY]
+
+
+# ===========================================================================
+# Enums: Algorithm and RateLimitKey membership + real decorator calls
+# ===========================================================================
+
+
+def test_algorithm_enum_full_membership():
+    """``Algorithm`` exposes exactly the four supported algorithms, each a
+    StrEnum equal to its lowercase string value.
+    """
+    assert {a.value for a in Algorithm} == {
+        "sliding_window",
+        "fixed_window",
+        "token_bucket",
+        "leaky_bucket",
+    }
+    # StrEnum: each member compares equal to and formats as its string value.
+    assert Algorithm.SLIDING_WINDOW == "sliding_window"
+    assert f"{Algorithm.TOKEN_BUCKET}" == "token_bucket"
+    # Every value is accepted by config validation.
+    for algo in Algorithm:
+        validate_rate_config("10/m", algorithm=algo.value)
+
+
+def test_ratelimit_key_enum_full_membership():
+    """``RateLimitKey`` exposes the five built-in key types as StrEnum values."""
+    assert {k.value for k in RateLimitKey} == {
+        "ip",
+        "user",
+        "user_or_ip",
+        "header",
+        "param",
+    }
+    assert RateLimitKey.IP == "ip"
+    assert RateLimitKey.USER_OR_IP == "user_or_ip"
+    # HEADER / PARAM are prefixes that compose with a sub-value.
+    assert f"{RateLimitKey.HEADER}:X-Api-Key" == "header:X-Api-Key"
+    assert f"{RateLimitKey.PARAM}:tenant" == "param:tenant"
+
+
+@pytest.mark.parametrize(
+    "algorithm",
+    [
+        Algorithm.SLIDING_WINDOW,
+        Algorithm.FIXED_WINDOW,
+        Algorithm.TOKEN_BUCKET,
+        Algorithm.LEAKY_BUCKET,
+    ],
+)
+def test_every_algorithm_enum_value_works_in_decorator(real_backend, algorithm):
+    """Each ``Algorithm`` enum value is accepted by the decorator and enforces a
+    real limit on the live backend: a small allowance of 200s then a 429.
+
+    Distinct IP per algorithm so the parametrized runs never collide.
+    """
+
+    @rate_limit(key="ip", rate="2/m", algorithm=algorithm)
+    def view(_request):
+        return _ok_view(_request)
+
+    ip = f"198.51.100.1{list(Algorithm).index(algorithm)}"
+    codes = _codes(view, [make_request(ip=ip) for _ in range(5)])
+    # First two allowed; the limiter blocks once the allowance is consumed.
+    assert codes[0] == OK
+    assert codes[1] == OK
+    assert TOO_MANY in codes[2:]
+
+
+def test_ip_and_user_enum_keys_work_in_decorator(real_backend):
+    """The complete ``RateLimitKey`` values (IP, USER, USER_OR_IP) work directly
+    as the decorator ``key=`` and bucket on the live backend.
+    """
+
+    @rate_limit(key=RateLimitKey.IP, rate="2/m")
+    def ip_view(_request):
+        return _ok_view(_request)
+
+    assert _codes(ip_view, [make_request(ip="198.51.100.120") for _ in range(3)]) == [
+        OK,
+        OK,
+        TOO_MANY,
+    ]
+
+    @rate_limit(key=RateLimitKey.USER, rate="2/m")
+    def user_view(_request):
+        return _ok_view(_request)
+
+    user = AuthedUser(uid=12121)
+    assert _codes(
+        user_view,
+        [make_request(ip="198.51.100.121", user=user) for _ in range(3)],
+    ) == [OK, OK, TOO_MANY]
+
+    @rate_limit(key=RateLimitKey.USER_OR_IP, rate="2/m")
+    def uoi_view(_request):
+        return _ok_view(_request)
+
+    assert _codes(uoi_view, [make_request(ip="198.51.100.122") for _ in range(3)]) == [
+        OK,
+        OK,
+        TOO_MANY,
+    ]
+
+
+def test_header_and_param_enum_prefixes_work_in_decorator(real_backend):
+    """The ``HEADER`` and ``PARAM`` enum prefixes, composed with a sub-value,
+    work as decorator keys and bucket per header/param value on the live store.
+    """
+    header_key = f"{RateLimitKey.HEADER}:X-Api-Key"
+
+    @rate_limit(key=header_key, rate="2/m")
+    def header_view(_request):
+        return _ok_view(_request)
+
+    alpha = [
+        make_request(ip="198.51.100.130", headers={"X-Api-Key": "alpha"})
+        for _ in range(3)
+    ]
+    assert _codes(header_view, alpha) == [OK, OK, TOO_MANY]
+    # A different header value is an independent bucket.
+    bravo = [make_request(ip="198.51.100.130", headers={"X-Api-Key": "bravo"})]
+    assert _codes(header_view, bravo) == [OK]
+
+    param_key = f"{RateLimitKey.PARAM}:tenant"
+
+    @rate_limit(key=param_key, rate="2/m")
+    def param_view(_request):
+        return _ok_view(_request)
+
+    acme = [
+        make_request(ip="198.51.100.131", params={"tenant": "acme"}) for _ in range(3)
+    ]
+    assert _codes(param_view, acme) == [OK, OK, TOO_MANY]
+    globex = [make_request(ip="198.51.100.131", params={"tenant": "globex"})]
+    assert _codes(param_view, globex) == [OK]


### PR DESCRIPTION
## Summary

Adds a comprehensive **real-backend end-to-end test suite** (`tests/e2e/`) that drives every public-usage API against **live Redis, MongoDB, and the Django test database** — no backend mocking — across all four algorithms (sliding/fixed window, token/leaky bucket). Building it surfaced two real, shipping bugs that the mock-based unit suite could not reach.

## Bug fixes (why this is a release, not just tests)

- **MongoDB `get_reset_time()` returned a wrong epoch on non-UTC hosts.** PyMongo reads stored datetimes back as *naive* (UTC) values; calling `.timestamp()` on a naive datetime makes Python assume the host's *local* timezone, skewing the result by the host's UTC offset. The `X-RateLimit-Reset` header and the DRF throttle `Retry-After` were therefore off by hours whenever the server clock was not UTC. The value is now made UTC-aware before conversion. (The window-expiry comparison already used the UTC-aware helper, so only the returned timestamp was wrong.)
- **Redis `reset()` left fixed-window and token-bucket counters in place.** Clock-aligned fixed-window counters live at `<key>:<bucket>` and token buckets at `<key>:token_bucket`, but `reset()` deleted only the bare key. It now also scans and deletes the suffixed key family. (Sliding-window state lives under the bare key and was already cleared.)

## Test suite

- `tests/e2e/` — 10 scenario files + a shared `conftest.py` harness.
- Each backend is **skipped gracefully** when its service is unavailable, and runs in full in CI where the service containers are present.
- Runs **sequentially** (the harness flushes the shared live store between tests).
- Local run: **544 e2e passed**; full repo suite **1806 passed, 8 skipped**.

## Release

- Version bumped `4.0.1` → `4.0.2`; `CHANGELOG.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)