### PR TITLE
test(e2e): close coverage gaps from the public-API audit (concurrency, DB/multi buckets, middleware outage, true auto-emit)

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -19,7 +19,9 @@ Helpers:
     - ``exhaust(view, n, ...)``: drive a view/callable n times and collect codes.
 """
 
+import os
 from contextlib import contextmanager
+from urllib.parse import urlparse
 
 import pytest
 
@@ -33,10 +35,26 @@ ASYNC_REDIS = "django_smart_ratelimit.backends.redis_backend.AsyncRedisBackend"
 MONGODB = "django_smart_ratelimit.backends.mongodb.MongoDBBackend"
 DATABASE = "django_smart_ratelimit.backends.database.DatabaseBackend"
 
-REDIS_HOST = "localhost"
-REDIS_PORT = 6379
-MONGO_HOST = "localhost"
-MONGO_PORT = 27017
+
+def _host_port(env_var, default_host, default_port):
+    """Derive (host, port) from a service URL env var, falling back to defaults.
+
+    CI exports REDIS_URL / MONGODB_URL; honoring them lets the e2e suite target a
+    non-localhost service instead of silently skipping it. Parsing failures fall
+    back to the localhost defaults so a malformed URL never breaks collection.
+    """
+    raw = os.environ.get(env_var)
+    if not raw:
+        return default_host, default_port
+    try:
+        parsed = urlparse(raw)
+        return (parsed.hostname or default_host, parsed.port or default_port)
+    except Exception:
+        return default_host, default_port
+
+
+REDIS_HOST, REDIS_PORT = _host_port("REDIS_URL", "localhost", 6379)
+MONGO_HOST, MONGO_PORT = _host_port("MONGODB_URL", "localhost", 27017)
 
 
 def redis_available():
@@ -64,9 +82,35 @@ def mongo_available():
 REDIS_UP = redis_available()
 MONGO_UP = mongo_available()
 
+# CI safety valve: a green run that silently skipped every Redis/Mongo scenario
+# looks identical to a run that exercised them. Set RATELIMIT_E2E_REQUIRE_SERVICES=1
+# (in CI, where the service containers must be present) to turn those skips into a
+# hard collection error instead. Default unset -> skip gracefully, as before.
+if os.environ.get("RATELIMIT_E2E_REQUIRE_SERVICES", "").lower() in ("1", "true", "yes"):
+    _missing = [n for n, up in (("Redis", REDIS_UP), ("MongoDB", MONGO_UP)) if not up]
+    if _missing:
+        raise RuntimeError(
+            "RATELIMIT_E2E_REQUIRE_SERVICES is set but these services are "
+            f"unavailable: {', '.join(_missing)}. The e2e suite would otherwise "
+            "silently skip their scenarios."
+        )
+
 # Mark factories so tests/files can build their own parametrizations.
 skip_without_redis = pytest.mark.skipif(not REDIS_UP, reason="live Redis unavailable")
 skip_without_mongo = pytest.mark.skipif(not MONGO_UP, reason="live MongoDB unavailable")
+
+
+@pytest.fixture(autouse=True)
+def _clear_backend_cache_between_tests():
+    """Safety net: drop any cached backend after every e2e test.
+
+    Tests that go through ``use_backend`` / the ``*_real_backend`` fixtures
+    already clear the cache, but this guards a future test that grabs
+    ``get_backend()`` directly from leaking a stale cached instance into the next
+    test on the shared live stores.
+    """
+    yield
+    clear_backend_cache()
 
 
 def flush_store(name):

--- a/tests/e2e/test_algorithms_e2e.py
+++ b/tests/e2e/test_algorithms_e2e.py
@@ -37,8 +37,11 @@ from django_smart_ratelimit.backends import clear_backend_cache, get_backend
 from django_smart_ratelimit.enums import Algorithm
 
 from .conftest import (
+    MEMORY,
+    REDIS,
     exhaust,
     make_request,
+    skip_without_redis,
     use_backend,
 )
 
@@ -482,3 +485,98 @@ def test_leaky_bucket_isolated_per_key_database():
         )
         assert exhaust(view, 3, ip="192.0.2.44") == [200, 200, 429]
         assert exhaust(view, 2, ip="192.0.2.45") == [200, 200]
+
+
+# ===========================================================================
+# TOKEN BUCKET  (database backend — native token_bucket_check)
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_token_bucket_burst_then_block_database():
+    """Token bucket on the database backend uses the native token_bucket_check.
+
+    bucket_size=3, refill_rate=0: the first 3 requests burst through and the
+    rest are blocked. The database backend implements a native, row-locked
+    ``token_bucket_check`` (it does NOT silently fall back to window counting),
+    so this exercises the DB bucket path directly — the analogue of the
+    Redis/memory native-bucket tests above.
+    """
+    with use_backend("database"):
+        backend = get_backend()
+        assert hasattr(backend, "token_bucket_check")
+
+        view = _ok_view(
+            key="ip",
+            rate="3/m",
+            algorithm=Algorithm.TOKEN_BUCKET,
+            algorithm_config={"bucket_size": 3, "refill_rate": 0},
+        )
+        assert exhaust(view, 5, ip="192.0.2.51") == [200, 200, 200, 429, 429]
+
+
+@pytest.mark.django_db
+def test_token_bucket_isolated_per_key_database():
+    """Native DB token buckets are independent per key.
+
+    Two IPs each get their own capacity-2 bucket; draining one leaves the other
+    with its full allowance.
+    """
+    with use_backend("database"):
+        view = _ok_view(
+            key="ip",
+            rate="2/m",
+            algorithm=Algorithm.TOKEN_BUCKET,
+            algorithm_config={"bucket_size": 2, "refill_rate": 0},
+        )
+        assert exhaust(view, 3, ip="192.0.2.52") == [200, 200, 429]
+        assert exhaust(view, 2, ip="192.0.2.53") == [200, 200]
+
+
+# ===========================================================================
+# MULTI BACKEND  (bucket algorithms degrade to window counting)
+# ===========================================================================
+
+
+@skip_without_redis
+def test_multibackend_token_bucket_falls_back_to_window():
+    """A MultiBackend has no native bucket op, so token_bucket degrades to window.
+
+    ``MultiBackend`` delegates ``incr()`` / ``get_count()`` to its child backends
+    but does not implement ``token_bucket_check``, so the decorator catches the
+    ``NotImplementedError`` and falls back to plain window counting (the same
+    graceful degradation MongoDB uses). This test PINS that documented behavior:
+    with ``rate=2/m`` the ``bucket_size=5`` config is ignored and exactly 2
+    requests pass per window — NOT a 5-token burst. If ``MultiBackend`` ever
+    gains native bucket routing, update this test to assert burst semantics.
+    """
+    redis_module = pytest.importorskip("redis")
+    client = redis_module.Redis(host="localhost", port=6379, db=0)
+    client.flushdb()
+    ov = override_settings(
+        RATELIMIT_BACKEND="django_smart_ratelimit.backends.multi.MultiBackend",
+        RATELIMIT_BACKENDS=[
+            {
+                "name": "primary",
+                "backend": REDIS,
+                "config": {"host": "localhost", "port": 6379, "db": 0},
+            },
+            {"name": "fallback", "backend": MEMORY, "config": {}},
+        ],
+        RATELIMIT_MULTI_BACKEND_STRATEGY="first_healthy",
+    )
+    ov.enable()
+    clear_backend_cache()
+    try:
+        view = _ok_view(
+            key="ip",
+            rate="2/m",
+            algorithm=Algorithm.TOKEN_BUCKET,
+            algorithm_config={"bucket_size": 5, "refill_rate": 0},
+        )
+        # Native bucket_size=5 would allow a 5-burst; window fallback allows 2.
+        assert exhaust(view, 5, ip="192.0.2.61") == [200, 200, 429, 429, 429]
+    finally:
+        clear_backend_cache()
+        client.flushdb()
+        ov.disable()

--- a/tests/e2e/test_concurrency_e2e.py
+++ b/tests/e2e/test_concurrency_e2e.py
@@ -1,0 +1,147 @@
+"""Real-backend end-to-end concurrency tests.
+
+Fire many requests at a single rate-limited key SIMULTANEOUSLY against a REAL
+store and assert EXACT admission -- no over-count (the failure that lets extra
+traffic through) and no under-count. This proves the atomic check-and-increment
+contract of the enforcement primitives under genuine contention, which is the
+one property a single-threaded or mock-based test can never demonstrate.
+
+Only backends whose increment is atomic are asserted exactly:
+
+* ``memory``      -- guarded by an in-process lock,
+* ``redis``       -- atomic server-side Lua (sliding window and token bucket),
+* ``async_redis`` -- the same Lua, driven concurrently via ``asyncio.gather``.
+
+MongoDB standalone has no atomic sliding-window increment (it would need a
+replica set), so it is intentionally excluded from exact-admission assertions
+rather than asserted with a fudge factor that would hide real over-admission.
+"""
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from django.http import HttpResponse
+
+from django_smart_ratelimit import rate_limit
+from django_smart_ratelimit.enums import Algorithm
+
+from .conftest import make_request, skip_without_redis, use_backend
+
+# Backends with an atomic sync increment -> exact admission is a hard guarantee.
+_ATOMIC_SYNC = [
+    pytest.param("memory", id="memory"),
+    pytest.param("redis", id="redis", marks=skip_without_redis),
+]
+
+_CONCURRENCY = 50
+_WORKERS = 16
+
+
+def _drive_sync(view, n, ip):
+    """Fire ``n`` requests from the same IP concurrently; return status codes."""
+
+    def hit(_):
+        return view(make_request(ip=ip)).status_code
+
+    with ThreadPoolExecutor(max_workers=_WORKERS) as pool:
+        return list(pool.map(hit, range(n)))
+
+
+@pytest.mark.parametrize("backend_name", _ATOMIC_SYNC)
+def test_concurrent_sliding_window_admits_exactly_the_limit(backend_name):
+    """50 simultaneous requests at 10/min -> exactly 10 pass, 40 are blocked.
+
+    A non-atomic check-then-increment would let several racing requests all read
+    "9 used" and admit together (over-admission). Asserting an exact split proves
+    the real store enforces the limit atomically under contention.
+    """
+    with use_backend(backend_name):
+
+        @rate_limit(key="ip", rate="10/m")
+        def view(_request):
+            return HttpResponse("ok")
+
+        codes = _drive_sync(view, _CONCURRENCY, ip="100.64.0.1")
+        assert codes.count(200) == 10
+        assert codes.count(429) == _CONCURRENCY - 10
+
+
+@pytest.mark.parametrize("backend_name", _ATOMIC_SYNC)
+def test_concurrent_token_bucket_admits_exactly_bucket_size(backend_name):
+    """50 simultaneous requests drain a 10-token bucket to exactly 10 allowed.
+
+    bucket_size=10, refill_rate=0 (no refill during the test). The native token
+    bucket (memory lock / Redis Lua) must hand out each token to exactly one
+    racing request.
+    """
+    with use_backend(backend_name):
+
+        @rate_limit(
+            key="ip",
+            rate="100/m",
+            algorithm=Algorithm.TOKEN_BUCKET,
+            algorithm_config={"bucket_size": 10, "refill_rate": 0},
+        )
+        def view(_request):
+            return HttpResponse("ok")
+
+        codes = _drive_sync(view, _CONCURRENCY, ip="100.64.0.2")
+        assert codes.count(200) == 10
+        assert codes.count(429) == _CONCURRENCY - 10
+
+
+@pytest.mark.parametrize("backend_name", _ATOMIC_SYNC)
+def test_concurrent_independent_keys_do_not_interfere(backend_name):
+    """Two IPs hammering concurrently each get their own full budget.
+
+    Interleaved traffic on key A must not consume key B's allowance; each IP
+    sees exactly its 10 admissions.
+    """
+    with use_backend(backend_name):
+
+        @rate_limit(key="ip", rate="10/m")
+        def view(_request):
+            return HttpResponse("ok")
+
+        def hit(i):
+            ip = "100.64.1.1" if i % 2 == 0 else "100.64.1.2"
+            return ip, view(make_request(ip=ip)).status_code
+
+        with ThreadPoolExecutor(max_workers=_WORKERS) as pool:
+            results = list(pool.map(hit, range(80)))
+
+        for ip in ("100.64.1.1", "100.64.1.2"):
+            allowed = sum(1 for got_ip, code in results if got_ip == ip and code == 200)
+            assert allowed == 10, f"{ip} admitted {allowed}, expected 10"
+
+
+@skip_without_redis
+async def test_concurrent_async_redis_admits_exactly_the_limit():
+    """40 coroutines awaited together on async Redis -> exactly 10 admitted.
+
+    Exercises the async enforcement path (``@rate_limit`` on an ``async def``
+    view, async Redis backend) under real ``asyncio`` concurrency. A warm-up call
+    on a separate key primes the Lua script cache so the burst measures admission,
+    not first-use script reloads.
+    """
+    with use_backend("async_redis"):
+
+        @rate_limit(key="ip", rate="10/m")
+        async def view(_request):
+            return HttpResponse("ok")
+
+        async def hit(ip):
+            result = view(make_request(ip=ip))
+            if asyncio.iscoroutine(result):
+                result = await result
+            return result.status_code
+
+        # Warm the script cache (distinct key, does not affect the measured IP).
+        await hit("100.64.2.254")
+
+        ip = "100.64.2.3"
+        codes = await asyncio.gather(*[hit(ip) for _ in range(40)])
+        assert codes.count(200) == 10
+        assert codes.count(429) == 30

--- a/tests/e2e/test_middleware_e2e.py
+++ b/tests/e2e/test_middleware_e2e.py
@@ -26,9 +26,11 @@ import time
 
 import pytest
 
+from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse, JsonResponse
 from django.test import override_settings
 
+from django_smart_ratelimit.backends import clear_backend_cache
 from django_smart_ratelimit.middleware import RateLimitMiddleware
 
 from .conftest import AuthedUser, exhaust, make_request
@@ -577,3 +579,52 @@ def test_reset_header_is_a_future_timestamp(real_backend):
     reset = int(resp.headers["X-RateLimit-Reset"])
     assert reset >= before
     assert reset <= int(time.time()) + 120
+
+
+# ---------------------------------------------------------------------------
+# Backend-outage behavior. The middleware has its own error-handling path,
+# distinct from the decorator's, so it gets its own real-outage coverage: point
+# it at a dead Redis port and verify the documented fail-open vs fail-closed
+# modes. (Port 6399 is deliberately not listening; these tests need no live
+# service and run on every environment.)
+# ---------------------------------------------------------------------------
+
+_DEAD_REDIS = {
+    "RATELIMIT_BACKEND": "django_smart_ratelimit.backends.redis_backend.RedisBackend",
+    "RATELIMIT_REDIS": {"host": "127.0.0.1", "port": 6399, "db": 0},
+    "RATELIMIT_MIDDLEWARE": {"DEFAULT_RATE": "1/m", "BLOCK": True},
+}
+
+
+def test_middleware_fail_open_serves_traffic_when_backend_is_down():
+    """FAIL_OPEN=True: an unreachable backend must not take the site down.
+
+    With the backend dead and ``RATELIMIT_FAIL_OPEN=True`` the middleware lets
+    the request through (200) instead of blocking or erroring — rate limiting
+    must never become a hard dependency in fail-open mode.
+    """
+    with override_settings(RATELIMIT_FAIL_OPEN=True, **_DEAD_REDIS):
+        clear_backend_cache()
+        try:
+            middleware = RateLimitMiddleware(ok_view)
+            resp = middleware(make_request(ip="198.51.100.150", path="/"))
+            assert resp.status_code == 200
+        finally:
+            clear_backend_cache()
+
+
+def test_middleware_fail_closed_refuses_to_start_when_backend_is_down():
+    """FAIL_OPEN=False: an unreachable backend fails loudly, not silently open.
+
+    With ``RATELIMIT_FAIL_OPEN=False`` the Redis backend's eager connection check
+    raises ``ImproperlyConfigured`` at construction, so the middleware cannot
+    start against a dead backend rather than quietly serving traffic through an
+    unprotected limiter.
+    """
+    with override_settings(RATELIMIT_FAIL_OPEN=False, **_DEAD_REDIS):
+        clear_backend_cache()
+        try:
+            with pytest.raises(ImproperlyConfigured):
+                RateLimitMiddleware(ok_view)
+        finally:
+            clear_backend_cache()

--- a/tests/e2e/test_observability_e2e.py
+++ b/tests/e2e/test_observability_e2e.py
@@ -4,19 +4,25 @@ These scenarios drive REAL rate-limited traffic against REAL storage (live
 Redis / live MongoDB / in-process memory) and then assert on the three
 observability integrations the library ships:
 
-* Prometheus (``django_smart_ratelimit.prometheus``): with ``RATELIMIT_PROMETHEUS``
-  enabled, real requests are recorded through ``PrometheusMetrics.record_request``
-  and scraped back via ``generate_metrics()`` / ``prometheus_metrics_view``. We
-  assert request/denied counters increase, that the low-cardinality labels
-  (``backend`` / ``result``) are present, and that the per-key value is NEVER a
-  label (cardinality safety).
+* Prometheus (``django_smart_ratelimit.prometheus``): real requests are recorded
+  through the public ``PrometheusMetrics.record_request`` API (the supported
+  manual-instrumentation path) and scraped back via ``generate_metrics()`` /
+  ``prometheus_metrics_view``. We assert request/denied counters increase, that
+  the low-cardinality labels (``backend`` / ``result``) are present, and that the
+  per-key value is NEVER a label (cardinality safety). A SEPARATE test
+  (``test_prometheus_middleware_auto_emits_denials``) drives traffic through the
+  shipped ``PrometheusMetricsMiddleware`` to check fully-automatic instrumentation
+  end-to-end; it currently ``xfail``s on a real middleware bug (see its reason).
 * OpenTelemetry (``django_smart_ratelimit.observability``): ``instrument_rate_limit``
   is called and ``record_check`` is exercised from real decorator traffic. We
   assert it never raises; OTel-specific span/metric assertions are made only
   when the SDK is installed.
-* Structured logging (``django_smart_ratelimit.logging``): with
-  ``RATELIMIT_LOGGING`` configured for JSON, a real block is triggered and we
-  assert a parseable single-line JSON log record is emitted (via ``caplog``).
+* Structured logging (``django_smart_ratelimit.logging``): the public logging
+  API (``log_rate_limit_check`` + ``JSONFormatter``) is exercised on real
+  rate-limit decisions and asserted to produce parseable single-line JSON (via
+  ``caplog``). A separate test (``test_request_path_auto_emits_structured_logs``)
+  drives real traffic and asserts the enforcement path emits log records on its
+  own, with no manual logging call.
 
 The backend is never mocked: the ``@rate_limit`` decorator hits the real store
 selected by the ``real_backend`` fixture, and we read the observable result
@@ -42,6 +48,7 @@ from django_smart_ratelimit.logging import (
 )
 from django_smart_ratelimit.prometheus import (
     PrometheusMetrics,
+    PrometheusMetricsMiddleware,
     get_prometheus_metrics,
     prometheus_metrics_view,
 )
@@ -132,7 +139,51 @@ def _build_view(rate, key="ip"):
 
 
 class TestPrometheusRealTraffic:
-    """Prometheus metrics scraped after real rate-limited traffic."""
+    """Prometheus exposition scraped after real rate-limited traffic.
+
+    These tests record each real decision through the public
+    ``PrometheusMetrics.record_request`` API (the supported manual path) and
+    assert the scraped exposition is correct. Fully-automatic instrumentation via
+    ``PrometheusMetricsMiddleware`` is covered by
+    ``test_prometheus_middleware_auto_emits_denials`` below.
+    """
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "BUG: PrometheusMetricsMiddleware reads request.ratelimit.limited, but "
+            "the decorator attaches a RateLimitContext that exposes .allowed (and "
+            "leaves .backend unset). So every request -- including denials -- is "
+            'recorded as result="allowed", backend="unknown", and auto-'
+            "instrumentation cannot distinguish allowed from denied. Remove this "
+            "xfail when the middleware is fixed to read .allowed / a real backend."
+        ),
+    )
+    def test_prometheus_middleware_auto_emits_denials(self, real_backend):
+        """TRUE auto-emit: traffic through the shipped middleware, no manual call.
+
+        Installs ``PrometheusMetricsMiddleware`` around a real 2/min ``@rate_limit``
+        view, drives 5 real requests (2 allowed, 3 denied on the live store), and
+        scrapes the singleton WITHOUT any ``record_request`` call. Correct behavior
+        is 2 allowed + 3 denied; this currently xfails (see reason).
+        """
+        PrometheusMetrics.reset()
+        view = _build_view("2/m")
+        middleware = PrometheusMetricsMiddleware(lambda request: view(request))
+        ip = "198.51.100.210"
+
+        codes = [middleware(make_request(ip=ip)).status_code for _ in range(5)]
+        assert codes == [200, 200, 429, 429, 429]
+
+        text = get_prometheus_metrics().generate_metrics()
+        allowed = _counter_value(
+            text, "django_ratelimit_requests_total", result="allowed"
+        )
+        denied = _counter_value(
+            text, "django_ratelimit_requests_total", result="denied"
+        )
+        assert allowed == 2.0
+        assert denied == 3.0
 
     def test_request_and_denied_counters_increase_on_real_backend(self, real_backend):
         """Public API endpoint: 3/min per IP.
@@ -565,10 +616,37 @@ def _parse_json_records(caplog, logger_name="django_smart_ratelimit"):
 
 
 class TestStructuredLoggingRealBlock:
-    """Structured JSON logging on real rate-limit decisions."""
+    """Structured JSON logging API exercised on real rate-limit decisions.
+
+    These tests drive a real decision on the live store and then format it
+    through the public logging API (``log_rate_limit_check`` /
+    ``log_circuit_breaker_event`` + ``JSONFormatter``), asserting the JSON is
+    correct and single-line. That the ENFORCEMENT path emits logs on its own
+    (without a manual logging call) is asserted separately by
+    ``test_request_path_auto_emits_structured_logs``.
+    """
 
     def teardown_method(self):
         clear_request_context()
+
+    def test_request_path_auto_emits_structured_logs(self, real_backend, caplog):
+        """TRUE auto-emit: real enforcement logs with NO manual logging call.
+
+        Unlike the other tests in this class (which call the public logging API
+        directly), this drives real traffic through the decorator and asserts the
+        library ITSELF emitted log records describing the backend operation --
+        proving the request path is instrumented, with the test making no log
+        call of its own.
+        """
+        view = _build_view("2/m")
+        with caplog.at_level(logging.DEBUG, logger="django_smart_ratelimit"):
+            codes = exhaust(view, 3, ip="198.51.100.195")
+
+        assert codes == [200, 200, 429]
+        auto = [
+            r for r in caplog.records if r.name.startswith("django_smart_ratelimit")
+        ]
+        assert len(auto) >= 2, "enforcement path should auto-emit log records"
 
     def test_real_block_emits_parseable_json_log(self, real_backend, caplog, settings):
         """Login endpoint: 2/min per IP. The block emits a JSON log line.


### PR DESCRIPTION
## Summary

A multi-agent, adversarially-verified audit of the v4.0.2 e2e suite (does every public-usage API have real coverage?) surfaced concentrated, real gaps. This is a **test-only** PR closing them — **no library code changes, no version bump**. Each new assertion was validated against live backends before being written.

## Added

- **`test_concurrency_e2e.py` — atomic admission under REAL contention (the audit's #1 gap).** 50 simultaneous requests admit *exactly* the limit (no over-admission) on memory, redis, and async_redis (`asyncio.gather`), for both sliding window and token bucket, plus per-key independence. MongoDB is excluded on purpose (standalone has no atomic sliding-window increment). Enforcement race-safety was previously unproven by any executed test.
- **`token_bucket × database`** — native DB `token_bucket_check` burst-then-block + per-key isolation (only leaky-bucket-on-DB was covered before).
- **MultiBackend + token_bucket** — pins the *documented graceful degradation* to window counting (MultiBackend has no native bucket op; the decorator catches `NotImplementedError` and falls back — it does **not** crash; verified live).
- **Middleware on a dead backend** — fail-open serves `200`; fail-closed raises `ImproperlyConfigured` at construction (the middleware's own error path, distinct from the decorator's).
- **True observability auto-emit:**
  - `test_prometheus_middleware_auto_emits_denials` (**`xfail`, strict**) — drives real traffic through the shipped `PrometheusMetricsMiddleware` with **no** manual `record_request`. It documents a **real bug**: the middleware reads `request.ratelimit.limited`, but the decorator attaches a `RateLimitContext` exposing `.allowed` (and leaves `.backend` unset), so denials are recorded as `result="allowed", backend="unknown"`. The `xfail` flips to a failure (strict) the moment the middleware is fixed.
  - `test_request_path_auto_emits_structured_logs` — asserts the enforcement path emits log records on its own (`caplog`), no manual logging call.

## Hardened

- The Prometheus / structured-logging suites had docstrings implying they proved *auto-instrumentation*; they actually exercise the public `record_request` / `log_rate_limit_check` APIs on real decisions. Docstrings corrected; real auto-emit is now covered by the dedicated tests above.
- `conftest.py`: derive Redis/Mongo `host:port` from `REDIS_URL` / `MONGODB_URL` (was hardcoded `localhost`); add `RATELIMIT_E2E_REQUIRE_SERVICES` to turn silent service-unavailable skips into a hard error in CI; add an autouse `clear_backend_cache()` net so a stale cached backend can't leak between tests.

## Follow-up (not in this PR)

The Prometheus auto-instrumentation bug above is a genuine library defect (denials mislabeled as allowed). It's documented here as a strict `xfail`; fixing `PrometheusMetricsMiddleware` to read `.allowed` and a real backend label is a small follow-up that would warrant a patch release.

## Verification

Full repo suite: **1821 passed, 8 skipped, 3 xfailed, 0 failed** against live Redis + MongoDB; pre-commit (black/flake8/mypy/bandit) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)