### PR TITLE
chore: support Python 3.14 and Django 6.0 (v4.5.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,25 +91,44 @@ jobs:
     strategy:
       fail-fast: false  # See all failures, not just first
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        django-version: ["3.2", "4.2", "5.0", "5.1"]  # Removed EOL 4.0, 4.1
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        django-version: ["3.2", "4.2", "5.0", "5.1", "5.2", "6.0"]  # Removed EOL 4.0, 4.1
         exclude:
-          # Django 3.2 doesn't support Python 3.11+
+          # Django 3.2 supports only Python 3.6-3.10
           - python-version: "3.11"
             django-version: "3.2"
           - python-version: "3.12"
             django-version: "3.2"
           - python-version: "3.13"
             django-version: "3.2"
-          # Django 5.0+ requires Python 3.10+
+          - python-version: "3.14"
+            django-version: "3.2"
+          # Django 4.2 does not support Python 3.14
+          - python-version: "3.14"
+            django-version: "4.2"
+          # Django 5.0/5.1 require Python 3.10-3.12 (and do not support 3.14)
           - python-version: "3.9"
             django-version: "5.0"
           - python-version: "3.9"
             django-version: "5.1"
-        include:
-          # Add coverage flag to one specific combination
-          - python-version: "3.12"
+          - python-version: "3.14"
+            django-version: "5.0"
+          - python-version: "3.14"
             django-version: "5.1"
+          # Django 5.2 requires Python 3.10+ (3.14 supported since 5.2.8)
+          - python-version: "3.9"
+            django-version: "5.2"
+          # Django 6.0 requires Python 3.12+
+          - python-version: "3.9"
+            django-version: "6.0"
+          - python-version: "3.10"
+            django-version: "6.0"
+          - python-version: "3.11"
+            django-version: "6.0"
+        include:
+          # Add coverage flag to one specific combination (latest LTS stack)
+          - python-version: "3.13"
+            django-version: "5.2"
             coverage: true
 
     services:
@@ -162,7 +181,16 @@ jobs:
         # >=4.2) cannot silently upgrade Django away from the matrix version.
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[all,dev]" "Django==${{ matrix.django-version }}" psycopg2-binary
+          # Pin to the latest patch of the matrix minor series (e.g. 5.2.* ->
+          # 5.2.x). Required for the Python 3.14 cells, since Python 3.14 support
+          # landed mid-series (Django 5.2.8); the bare "==5.2" pins 5.2.0.
+          pip install -e ".[all,dev]" "Django==${{ matrix.django-version }}.*"
+          # psycopg2-binary is only needed by the Postgres-backed coverage cell;
+          # other cells use SQLite. Avoids a source build on Pythons without a
+          # published wheel.
+          if [ "${{ matrix.coverage }}" = "true" ]; then
+            pip install psycopg2-binary
+          fi
 
       - name: Run tests
         if: ${{ !matrix.coverage }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -13,13 +13,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
-        django-version: ["4.2", "5.0"]
+        # A low / middle / latest spread of Python crossed with the LTS / current
+        # LTS / latest Django, exercised against every backend. The full
+        # python x django breadth lives in ci.yml's "test" job; here the point is
+        # backend coverage, including on the newest Python and Django.
+        python-version: ["3.10", "3.12", "3.14"]
+        django-version: ["4.2", "5.2", "6.0"]
         backend: [memory, redis, redis-async, multi]
         exclude:
-          # Django 5.0 requires Python >= 3.10
-          - python-version: "3.9"
-            django-version: "5.0"
+          # Django 6.0 requires Python >= 3.12
+          - python-version: "3.10"
+            django-version: "6.0"
+          # Django 4.2 does not support Python 3.14
+          - python-version: "3.14"
+            django-version: "4.2"
 
     services:
       redis:
@@ -43,8 +50,11 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          # Install the test project dependencies
-          pip install -r tests/test_project/requirements.txt
+          # Install the test project dependencies. This matrix exercises the
+          # memory/redis/multi backends -- not the SQL database backend -- so
+          # skip the heavy DB drivers (psycopg2-binary, mysqlclient): they lack
+          # wheels on the newest Pythons and need system libraries to build.
+          grep -vE '^(psycopg2-binary|mysqlclient)' tests/test_project/requirements.txt | pip install -r /dev/stdin
           # Force install specific Django version from matrix
           pip install "Django==${{ matrix.django-version }}.*"
           # Install the library in editable mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.5.1] - 2026-06-03
+
+Test/packaging update: officially support the latest Python and Django. No
+runtime code changes.
+
+### Added
+
+- **Python 3.14** support (classifier + CI matrix + tox).
+- **Django 6.0** support (classifier + CI matrix + tox). Django 6.0 requires
+  Python 3.12+.
+- **Django 5.2** is now actually exercised in CI and tox (it was already
+  advertised in the classifiers but never tested).
+
+Verified locally against the latest stack: the full suite (1885 passed, 9
+skipped) passes on Python 3.14 with both Django 6.0 and Django 5.2.
+
+### Changed
+
+- CI pins each matrix cell to the latest patch of its Django minor series
+  (`Django==X.Y.*`) instead of the `.0` release, so Python 3.14 cells resolve
+  Django 5.2.8+ (where 3.14 support landed) and every cell tests current
+  security patches.
+- `psycopg2-binary` is now installed only on the PostgreSQL coverage cell (other
+  cells run on SQLite), avoiding a source build on Pythons without a published
+  wheel.
+
 ## [4.5.0] - 2026-06-03
 
 Roadmap Phase 5.4-5.6: **geographic**, **multi-tenant**, and **GraphQL** rate

--- a/django_smart_ratelimit/__init__.py
+++ b/django_smart_ratelimit/__init__.py
@@ -5,7 +5,7 @@ with support for multiple backends, algorithms (including token bucket),
 and comprehensive rate limiting strategies.
 """
 
-__version__ = "4.5.0"
+__version__ = "4.5.1"
 __author__ = "Yasser Shkeir"
 
 # Optional backend imports (may not be available)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-smart-ratelimit"
-version = "4.5.0"
+version = "4.5.1"
 dynamic = []
 description = "A flexible and efficient rate limiting library for Django applications"
 readme = "README.md"
@@ -22,6 +22,7 @@ classifiers = [
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
@@ -32,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,11 @@
 isolated_build = True
 envlist =
     py39-django{32,42}
-    py310-django{32,42,50,51}
-    py311-django{42,50,51}
-    py312-django{42,50,51}
-    py313-django{42,50,51}
+    py310-django{32,42,50,51,52}
+    py311-django{42,50,51,52}
+    py312-django{42,50,51,52,60}
+    py313-django{42,50,51,52,60}
+    py314-django{52,60}
 
 # Parallel configuration
 parallel_show_output = True
@@ -19,6 +20,8 @@ deps =
     django42: Django>=4.2,<5.0
     django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<6.0
+    django60: Django>=6.0,<6.1
     pytest
     pytest-django
     pytest-asyncio
@@ -42,3 +45,4 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314


### PR DESCRIPTION
Adds the latest Python and Django to the officially supported (and CI-tested) set.

## Latest versions (verified via PyPI)
- **Python**: 3.14 (was capped at 3.13)
- **Django**: 6.0 (was capped at 5.1 in CI; 5.2 was in the classifiers but never tested)

## Changes
- **Classifiers**: add `Programming Language :: Python :: 3.14` and `Framework :: Django :: 6.0`.
- **CI matrix + tox**: add Python 3.14 and Django 5.2 / 6.0 cells, with excludes for the real compatibility constraints:
  - Django 6.0 requires Python 3.12+
  - Django 5.2 added Python 3.14 support in 5.2.8
  - Django 3.2 / 4.2 / 5.0 / 5.1 do not support Python 3.14
- **Django 5.2 now actually runs in CI/tox** (it was advertised in the classifiers but never exercised).
- **Latest-patch pin**: each matrix cell installs `Django==X.Y.*` instead of the bare `.0` release, so the 3.14 cells resolve Django >=5.2.8 (where 3.14 support landed) and every cell tests current security patches.
- **psycopg2-binary** is installed only on the Postgres coverage cell (other cells use SQLite), avoiding a source build on Pythons without a published wheel.
- Coverage cell moved to the current LTS stack (Python 3.13 / Django 5.2).

## Local confirmation
Built clean venvs and ran the full suite (`pytest -m "not benchmark"`, matching CI) against the latest stack:

| Stack | Result |
| --- | --- |
| Python 3.14.2 + Django 6.0.5 | 1885 passed, 9 skipped |
| Python 3.14.2 + Django 5.2.14 | 1885 passed, 9 skipped |

No runtime code changes. Ships as v4.5.1 so the PyPI metadata advertises the new support.