### PR TITLE
feat: complete the v2.0 roadmap gaps (v4.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.6.0] - 2026-06-04
+
+Completes the original v2.0 feature roadmap: the handful of items that were
+planned but never built. Everything here is additive and opt-in; no existing
+behavior changes.
+
+### Added
+
+- **Decorator honors user tiers/overrides** (roadmap 3.3.2) — with
+  `RATELIMIT_USE_USER_TIERS = True`, `@rate_limit` now resolves an authenticated
+  request to its effective rate (override -> tier -> base) and limits it in a
+  per-user bucket, matching the middleware. No-op when the setting is off or the
+  decorator uses `adaptive=`.
+- **`tiers.tier_key`** (roadmap 3.1.4) — a key function bucketing requests by the
+  user's tier (`tier:<name>` / `tier:anonymous` / `tier:default`).
+- **`tiers.create_user_override`** (roadmap 3.3.4) — a programmatic helper to
+  grant a temporary per-user rate override (validates the rate, defaults to a
+  one-hour window).
+- **Offender detail + alerting** (roadmap 4.3.2 / 4.3.4) —
+  `analytics.get_offender_detail()` (per-key totals, per-path breakdown, recent
+  events), a staff-only JSON `offender-detail` view (`dashboard/offender/?key=`),
+  `analytics.find_alertable_offenders()` / `send_offender_alerts()` (email +
+  webhook, opt-in), and a `ratelimit_alerts` management command for cron.
+- **StatsD exporter** (roadmap 5.1.3) — `statsd.StatsDClient` (dependency-free
+  UDP) and `statsd.StatsDMetrics` mirroring the Prometheus exporter API,
+  configured via `RATELIMIT_STATSD`.
+- **Native atomic Redis leaky bucket** (roadmap 5.2.3) — `RedisBackend` now
+  implements `leaky_bucket_check` / `leaky_bucket_info` via Lua, so the
+  `leaky_bucket` algorithm is atomic on Redis (previously a non-atomic fallback).
+- **`adaptive.TimeOfDayIndicator`** (roadmap 5.3.1) — a load indicator that
+  reports high load during configured peak hours so adaptive limits tighten on a
+  schedule.
+
+### Settings
+
+- `RATELIMIT_STATSD` (StatsD host/port/prefix/enabled).
+- `RATELIMIT_ALERT_THRESHOLD`, `RATELIMIT_ALERT_EMAILS`, `RATELIMIT_ALERT_WEBHOOK`
+  (offender alerting; alerting is disabled until a threshold is set).
+
 ## [4.5.1] - 2026-06-03
 
 Test/packaging update: officially support the latest Python and Django. No

--- a/django_smart_ratelimit/__init__.py
+++ b/django_smart_ratelimit/__init__.py
@@ -5,7 +5,7 @@ with support for multiple backends, algorithms (including token bucket),
 and comprehensive rate limiting strategies.
 """
 
-__version__ = "4.5.1"
+__version__ = "4.6.0"
 __author__ = "Yasser Shkeir"
 
 # Optional backend imports (may not be available)
@@ -21,6 +21,7 @@ from .adaptive import (
     LoadIndicator,
     LoadMetrics,
     MemoryLoadIndicator,
+    TimeOfDayIndicator,
     create_adaptive_limiter,
     get_adaptive_limiter,
     register_adaptive_limiter,
@@ -236,6 +237,7 @@ __all__ = [
     "LatencyLoadIndicator",
     "ConnectionCountIndicator",
     "CustomLoadIndicator",
+    "TimeOfDayIndicator",
     "create_adaptive_limiter",
     "get_adaptive_limiter",
     "register_adaptive_limiter",

--- a/django_smart_ratelimit/adaptive.py
+++ b/django_smart_ratelimit/adaptive.py
@@ -272,7 +272,7 @@ class TimeOfDayIndicator(LoadIndicator):
         if not self._use_utc:
             try:
                 now = timezone.localtime(now)
-            except Exception:  # pragma: no cover - USE_TZ=False / naive datetime
+            except Exception:  # nosec B110 # pragma: no cover - USE_TZ=False
                 pass
         return self._peak_load if now.hour in self._peak_hours else self._off_peak_load
 

--- a/django_smart_ratelimit/adaptive.py
+++ b/django_smart_ratelimit/adaptive.py
@@ -235,6 +235,48 @@ class CustomLoadIndicator(LoadIndicator):
         return self._name
 
 
+class TimeOfDayIndicator(LoadIndicator):
+    """Load indicator driven by the time of day (roadmap 5.3.1).
+
+    Reports a high synthetic load during configured peak hours and a low load
+    otherwise, so adaptive limits tighten predictably during busy windows
+    regardless of measured system metrics. Combine it with CPU/latency
+    indicators on an :class:`AdaptiveRateLimiter` for a blended signal.
+    """
+
+    def __init__(
+        self,
+        peak_hours: Any,
+        peak_load: float = 1.0,
+        off_peak_load: float = 0.0,
+        use_utc: bool = False,
+    ) -> None:
+        """Configure the peak hours and their load levels.
+
+        Args:
+            peak_hours: Iterable of hours (0-23) considered peak.
+            peak_load: Load reported during peak hours (0.0-1.0).
+            off_peak_load: Load reported otherwise (0.0-1.0).
+            use_utc: Use UTC hours instead of the project's local time.
+        """
+        self._peak_hours = {int(h) for h in peak_hours}
+        self._peak_load = max(0.0, min(1.0, float(peak_load)))
+        self._off_peak_load = max(0.0, min(1.0, float(off_peak_load)))
+        self._use_utc = use_utc
+
+    def get_load(self) -> float:
+        """Return the peak load during peak hours, else the off-peak load."""
+        from django.utils import timezone
+
+        now = timezone.now()
+        if not self._use_utc:
+            try:
+                now = timezone.localtime(now)
+            except Exception:  # pragma: no cover - USE_TZ=False / naive datetime
+                pass
+        return self._peak_load if now.hour in self._peak_hours else self._off_peak_load
+
+
 class AdaptiveRateLimiter:
     """
     Adaptive rate limiter that adjusts limits based on system load.

--- a/django_smart_ratelimit/analytics.py
+++ b/django_smart_ratelimit/analytics.py
@@ -198,7 +198,7 @@ def send_offender_alerts(
                 headers={"Content-Type": "application/json"},
                 method="POST",
             )
-            urllib.request.urlopen(req, timeout=5)  # nosec B310 - operator-set URL
+            urllib.request.urlopen(req, timeout=5)  # nosec B310
             result["channels"]["webhook"] = {"sent": True, "url": webhook_url}
         except Exception as exc:  # pragma: no cover - network dependent
             logger.warning("offender webhook alert failed: %s", exc)

--- a/django_smart_ratelimit/analytics.py
+++ b/django_smart_ratelimit/analytics.py
@@ -2,11 +2,14 @@
 
 import csv
 import io
+import logging
 from datetime import timedelta
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from django.db.models import Count, Q
 from django.utils import timezone
+
+logger = logging.getLogger(__name__)
 
 
 def _cutoff(days: int) -> Any:
@@ -65,3 +68,140 @@ def offenders_csv(days: int = 7, limit: int = 1000) -> str:
     for row in get_top_offenders(days=days, limit=limit):
         writer.writerow([row["key"], row["blocked_count"]])
     return buffer.getvalue()
+
+
+def get_offender_detail(key: str, days: int = 7, recent: int = 50) -> Dict[str, Any]:
+    """Detailed activity for a single offender ``key`` (roadmap 4.3.2).
+
+    Returns totals (allowed/blocked/block-rate), first/last seen, the per-path
+    blocked breakdown, and the most recent events for the window.
+    """
+    from .models import RateLimitEvent
+
+    qs = RateLimitEvent.objects.filter(timestamp__gte=_cutoff(days), key=key)
+    total = qs.count()
+    blocked = qs.filter(allowed=False).count()
+    timestamps = qs.order_by("timestamp").values_list("timestamp", flat=True)
+    by_path = list(
+        qs.filter(allowed=False)
+        .values("path")
+        .annotate(blocked_count=Count("id"))
+        .order_by("-blocked_count")[:20]
+    )
+    recent_events = list(
+        qs.order_by("-timestamp").values(
+            "timestamp", "path", "method", "allowed", "count", "limit", "rule_name"
+        )[:recent]
+    )
+    return {
+        "key": key,
+        "days": days,
+        "total": total,
+        "allowed": total - blocked,
+        "blocked": blocked,
+        "block_rate": (blocked / total) if total else 0.0,
+        "first_seen": timestamps[0] if total else None,
+        "last_seen": (
+            qs.order_by("-timestamp").values_list("timestamp", flat=True)[0]
+            if total
+            else None
+        ),
+        "by_path": by_path,
+        "recent_events": recent_events,
+    }
+
+
+def find_alertable_offenders(
+    threshold: int, days: int = 1, limit: int = 100
+) -> List[Dict[str, Any]]:
+    """Offenders whose blocked-request count over the window is >= ``threshold``."""
+    return [
+        row
+        for row in get_top_offenders(days=days, limit=limit)
+        if row["blocked_count"] >= threshold
+    ]
+
+
+def send_offender_alerts(
+    threshold: Optional[int] = None,
+    days: int = 1,
+    *,
+    email_to: Optional[List[str]] = None,
+    webhook_url: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Find offenders over ``threshold`` and dispatch email / webhook alerts.
+
+    Configuration falls back to settings when arguments are omitted:
+    ``RATELIMIT_ALERT_THRESHOLD`` (required to do anything; default disabled),
+    ``RATELIMIT_ALERT_EMAILS`` (list), and ``RATELIMIT_ALERT_WEBHOOK`` (URL).
+    Dispatch is best-effort: a failing channel is logged and reported, never
+    raised. Returns a summary dict (offenders found and per-channel status).
+    """
+    from django.conf import settings as django_settings
+
+    if threshold is None:
+        threshold = getattr(django_settings, "RATELIMIT_ALERT_THRESHOLD", None)
+    if not threshold:
+        return {"enabled": False, "offenders": [], "channels": {}}
+
+    offenders = find_alertable_offenders(int(threshold), days=days)
+    result: Dict[str, Any] = {
+        "enabled": True,
+        "threshold": int(threshold),
+        "days": days,
+        "offenders": offenders,
+        "channels": {},
+    }
+    if not offenders:
+        return result
+
+    if email_to is None:
+        email_to = getattr(django_settings, "RATELIMIT_ALERT_EMAILS", None)
+    if webhook_url is None:
+        webhook_url = getattr(django_settings, "RATELIMIT_ALERT_WEBHOOK", None)
+
+    lines = [f"{o['key']}: {o['blocked_count']} blocked" for o in offenders]
+    body = (
+        f"{len(offenders)} rate-limit offender(s) exceeded {threshold} blocked "
+        f"requests in the last {days} day(s):\n\n" + "\n".join(lines)
+    )
+
+    if email_to:
+        try:
+            from django.core.mail import send_mail
+
+            send_mail(
+                subject=f"[django-smart-ratelimit] {len(offenders)} offender(s) alert",
+                message=body,
+                from_email=getattr(django_settings, "DEFAULT_FROM_EMAIL", None),
+                recipient_list=list(email_to),
+                fail_silently=False,
+            )
+            result["channels"]["email"] = {"sent": True, "to": list(email_to)}
+        except Exception as exc:  # pragma: no cover - depends on mail backend
+            logger.warning("offender email alert failed: %s", exc)
+            result["channels"]["email"] = {"sent": False, "error": str(exc)}
+
+    if webhook_url:
+        payload = {
+            "threshold": int(threshold),
+            "days": days,
+            "offenders": offenders,
+        }
+        try:
+            import json
+            import urllib.request
+
+            req = urllib.request.Request(
+                webhook_url,
+                data=json.dumps(payload, default=str).encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            urllib.request.urlopen(req, timeout=5)  # nosec B310 - operator-set URL
+            result["channels"]["webhook"] = {"sent": True, "url": webhook_url}
+        except Exception as exc:  # pragma: no cover - network dependent
+            logger.warning("offender webhook alert failed: %s", exc)
+            result["channels"]["webhook"] = {"sent": False, "error": str(exc)}
+
+    return result

--- a/django_smart_ratelimit/backends/redis_backend.py
+++ b/django_smart_ratelimit/backends/redis_backend.py
@@ -183,6 +183,78 @@ class RedisBackend(BaseBackend):
         return {current_tokens, bucket_size, refill_rate, time_to_refill, last_refill}
     """  # nosec B105
 
+    # Lua script for an atomic leaky bucket check (roadmap 5.2.3). The bucket
+    # leaks at ``leak_rate`` units/second; a request of ``cost`` is admitted when
+    # it fits under ``capacity``. Fractional values are returned scaled by 1000
+    # (Redis truncates Lua numbers to integers on return); ``-1`` for the time
+    # field is a sentinel meaning "never" (leak_rate <= 0).
+    LEAKY_BUCKET_SCRIPT = """
+        local key = KEYS[1]
+        local capacity = tonumber(ARGV[1])
+        local leak_rate = tonumber(ARGV[2])
+        local cost = tonumber(ARGV[3])
+        local now = tonumber(ARGV[4])
+
+        local data = redis.call('HMGET', key, 'level', 'last_leak')
+        local level = tonumber(data[1]) or 0
+        local last_leak = tonumber(data[2]) or now
+
+        local elapsed = now - last_leak
+        if elapsed < 0 then elapsed = 0 end
+        level = level - (elapsed * leak_rate)
+        if level < 0 then level = 0 end
+
+        local expiration
+        if leak_rate > 0 then
+            expiration = math.ceil(capacity / leak_rate) + 60
+        else
+            expiration = 3600
+        end
+
+        local new_level = level + cost
+        local allowed
+        local stored
+        if new_level <= capacity then
+            allowed = 1
+            stored = new_level
+        else
+            allowed = 0
+            stored = level
+        end
+        redis.call('HMSET', key, 'level', stored, 'last_leak', now)
+        redis.call('EXPIRE', key, expiration)
+
+        local tus
+        if allowed == 1 then
+            tus = 0
+        elseif leak_rate > 0 then
+            tus = (new_level - capacity) / leak_rate
+        else
+            tus = -1
+        end
+        local tus_out
+        if tus < 0 then tus_out = -1 else tus_out = math.floor(tus * 1000) end
+        return {allowed, math.floor(stored * 1000), tus_out}
+    """  # nosec B105
+
+    # Read-only leaky bucket inspection (no mutation); returns the leaked-down
+    # level scaled by 1000.
+    LEAKY_BUCKET_INFO_SCRIPT = """
+        local key = KEYS[1]
+        local leak_rate = tonumber(ARGV[1])
+        local now = tonumber(ARGV[2])
+
+        local data = redis.call('HMGET', key, 'level', 'last_leak')
+        local level = tonumber(data[1]) or 0
+        local last_leak = tonumber(data[2]) or now
+
+        local elapsed = now - last_leak
+        if elapsed < 0 then elapsed = 0 end
+        level = level - (elapsed * leak_rate)
+        if level < 0 then level = 0 end
+        return {math.floor(level * 1000), math.floor(last_leak * 1000)}
+    """  # nosec B105
+
     def __init__(
         self,
         enable_circuit_breaker: bool = True,
@@ -260,11 +332,19 @@ class RedisBackend(BaseBackend):
             self.token_bucket_info_sha = self._load_script(
                 self.TOKEN_BUCKET_INFO_SCRIPT
             )
+            self.leaky_bucket_sha = self._load_script(self.LEAKY_BUCKET_SCRIPT)
+            self.leaky_bucket_info_sha = self._load_script(
+                self.LEAKY_BUCKET_INFO_SCRIPT
+            )
         else:
             self.sliding_window_sha = ""
             self.fixed_window_sha = ""
             self.token_bucket_sha = ""  # nosec B105 - not a password, SHA cache init
             self.token_bucket_info_sha = (
+                ""  # nosec B105 - not a password, SHA cache init
+            )
+            self.leaky_bucket_sha = ""  # nosec B105 - not a password, SHA cache init
+            self.leaky_bucket_info_sha = (
                 ""  # nosec B105 - not a password, SHA cache init
             )
 
@@ -714,6 +794,118 @@ class RedisBackend(BaseBackend):
                 time_to_refill=0.0,
                 last_refill=current_time,
             )
+
+    def leaky_bucket_check(
+        self,
+        key: str,
+        bucket_capacity: int,
+        leak_rate: float,
+        request_cost: int,
+    ) -> Tuple[bool, Dict[str, Any]]:
+        """Atomic leaky bucket check using a Redis Lua script (roadmap 5.2.3).
+
+        Args:
+            key: Rate limit key.
+            bucket_capacity: Maximum bucket level before overflow.
+            leak_rate: Units drained per second.
+            request_cost: Units this request adds to the bucket.
+
+        Returns:
+            ``(is_allowed, metadata)`` with the same metadata keys as the
+            generic leaky-bucket implementation.
+        """
+        normalized_key = normalize_key(f"{key}:leaky_bucket", self.key_prefix)
+        current_time = get_current_timestamp()
+        start_time = current_time
+        try:
+            result = self._eval_lua(
+                "leaky_bucket_sha",
+                self.LEAKY_BUCKET_SCRIPT,
+                1,
+                normalized_key,
+                bucket_capacity,
+                leak_rate,
+                request_cost,
+                current_time,
+            )
+            is_allowed = bool(result[0])
+            bucket_level = float(result[1]) / 1000.0
+            tus_raw = float(result[2])
+            time_until_space = float("inf") if tus_raw < 0 else tus_raw / 1000.0
+            space_remaining = max(0.0, bucket_capacity - bucket_level)
+
+            log_backend_operation(
+                "redis_leaky_bucket_check",
+                f"Leaky bucket check for key {key}: allowed={is_allowed}",
+                duration=get_current_timestamp() - start_time,
+            )
+            return is_allowed, {
+                "bucket_level": bucket_level,
+                "bucket_capacity": bucket_capacity,
+                "leak_rate": leak_rate,
+                "request_cost": request_cost,
+                "space_remaining": space_remaining,
+                "time_until_space": time_until_space,
+            }
+        except Exception as e:
+            log_backend_operation(
+                "redis_leaky_bucket_check_error",
+                f"Leaky bucket Lua script failed for key {key}: {e}",
+                duration=get_current_timestamp() - start_time,
+                level="error",
+            )
+            if self.fail_open:
+                return True, {
+                    "bucket_level": 0.0,
+                    "bucket_capacity": bucket_capacity,
+                    "leak_rate": leak_rate,
+                    "request_cost": request_cost,
+                    "space_remaining": float(bucket_capacity),
+                    "time_until_space": 0.0,
+                }
+            raise BackendError(ERROR_BACKEND_UNAVAILABLE) from e
+
+    def leaky_bucket_info(
+        self, key: str, bucket_capacity: int, leak_rate: float
+    ) -> Dict[str, Any]:
+        """Inspect leaky bucket state without adding to it (roadmap 5.2.3)."""
+        normalized_key = normalize_key(f"{key}:leaky_bucket", self.key_prefix)
+        current_time = get_current_timestamp()
+        try:
+            result = self._eval_lua(
+                "leaky_bucket_info_sha",
+                self.LEAKY_BUCKET_INFO_SCRIPT,
+                1,
+                normalized_key,
+                leak_rate,
+                current_time,
+            )
+            bucket_level = float(result[0]) / 1000.0
+            last_leak = float(result[1]) / 1000.0
+            space_remaining = max(0.0, bucket_capacity - bucket_level)
+            time_to_empty = bucket_level / leak_rate if leak_rate > 0 else float("inf")
+            return {
+                "bucket_level": bucket_level,
+                "bucket_capacity": bucket_capacity,
+                "leak_rate": leak_rate,
+                "space_remaining": space_remaining,
+                "time_to_empty": time_to_empty,
+                "last_leak": last_leak,
+            }
+        except Exception as e:
+            log_backend_operation(
+                "redis_leaky_bucket_info_error",
+                f"Leaky bucket info failed for key {key}: {e}",
+                level="error",
+            )
+            return {
+                "bucket_level": 0.0,
+                "bucket_capacity": bucket_capacity,
+                "leak_rate": leak_rate,
+                "space_remaining": float(bucket_capacity),
+                "time_to_empty": 0.0,
+                "last_leak": current_time,
+            }
 
     def check_batch(
         self,

--- a/django_smart_ratelimit/decorator.py
+++ b/django_smart_ratelimit/decorator.py
@@ -396,6 +396,38 @@ def _apply_adaptive_limit(
         return base_limit
 
 
+def _apply_user_tiers(
+    request: Any,
+    base_rate: str,
+    limit_key: str,
+    settings_obj: Any,
+    scope: str = "",
+) -> Optional[Tuple[int, int, str]]:
+    """Resolve a request's per-user effective rate and bucket (roadmap 3.3.2).
+
+    No-op unless ``RATELIMIT_USE_USER_TIERS`` is enabled, mirroring the
+    middleware: an authenticated user is limited at their effective rate
+    (override -> tier -> base) in their own per-user bucket so users at
+    different tiers sharing a key (e.g. an IP) do not interfere. Returns
+    ``(limit, period, key)`` when applied, else ``None``.
+    """
+    if not getattr(settings_obj, "use_user_tiers", False):
+        return None
+
+    from .tiers import resolve_effective_user_rate
+
+    new_rate = resolve_effective_user_rate(request, base_rate, scope)
+    user = getattr(request, "user", None)
+    key = limit_key
+    if user is not None and getattr(user, "is_authenticated", False):
+        key = f"user:{user.pk}:{scope or limit_key}"
+    try:
+        limit, period = parse_rate(new_rate)
+    except Exception:  # pragma: no cover - defensive; parse_rate already validated
+        return None
+    return limit, period, key
+
+
 def rate_limit(
     key: Union[str, Callable],
     rate: Optional[str] = None,
@@ -603,6 +635,13 @@ def rate_limit(
                 limit = resolved.limit
                 period = resolved.period
                 request_cost = resolved.cost
+
+                # Per-user tiers/overrides (no-op unless RATELIMIT_USE_USER_TIERS).
+                # Skipped when adaptive is active, which owns the limit instead.
+                if adaptive is None:
+                    _tiered = _apply_user_tiers(_request, _rate, limit_key, _settings)
+                    if _tiered is not None:
+                        limit, period, limit_key = _tiered
 
                 # Decide the allow/deny. token_bucket (and leaky_bucket on
                 # backends with native support) run their sync algorithm check
@@ -819,6 +858,13 @@ def rate_limit(
                 limit = resolved.limit
                 period = resolved.period
                 request_cost = resolved.cost
+
+                # Per-user tiers/overrides (no-op unless RATELIMIT_USE_USER_TIERS).
+                # Skipped when adaptive is active, which owns the limit instead.
+                if adaptive is None:
+                    _tiered = _apply_user_tiers(_request, _rate, limit_key, _settings)
+                    if _tiered is not None:
+                        limit, period, limit_key = _tiered
 
                 # Handle middleware vs decorator scenarios
                 if middleware_processed:

--- a/django_smart_ratelimit/management/commands/ratelimit_alerts.py
+++ b/django_smart_ratelimit/management/commands/ratelimit_alerts.py
@@ -1,0 +1,88 @@
+"""Management command: alert on rate-limit offenders (roadmap 4.3.4).
+
+Finds keys whose blocked-request count over a window exceeds a threshold and
+dispatches email and/or webhook alerts. Intended to run on a schedule (cron /
+celery beat), e.g. every few minutes::
+
+    python manage.py ratelimit_alerts --threshold 100 --days 1
+
+Thresholds and channels default to the ``RATELIMIT_ALERT_THRESHOLD`` /
+``RATELIMIT_ALERT_EMAILS`` / ``RATELIMIT_ALERT_WEBHOOK`` settings when the
+corresponding flags are omitted.
+"""
+
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    """Dispatch alerts for rate-limit offenders over a threshold."""
+
+    help = "Alert (email/webhook) on rate-limit offenders over a threshold."
+
+    def add_arguments(self, parser: Any) -> None:
+        """Register the threshold/window/dry-run options."""
+        parser.add_argument(
+            "--threshold",
+            type=int,
+            default=None,
+            help="Min blocked requests to alert on (default: RATELIMIT_ALERT_THRESHOLD).",
+        )
+        parser.add_argument(
+            "--days",
+            type=int,
+            default=1,
+            help="Look-back window in days (default 1).",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="List matching offenders without sending any alert.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        """Find offenders over the threshold and (unless dry-run) alert."""
+        from django_smart_ratelimit.analytics import (
+            find_alertable_offenders,
+            send_offender_alerts,
+        )
+
+        days = max(1, int(options["days"]))
+        threshold = options["threshold"]
+
+        if options["dry_run"]:
+            if not threshold:
+                self.stdout.write(
+                    self.style.WARNING(
+                        "No --threshold and RATELIMIT_ALERT_THRESHOLD unset; "
+                        "nothing to do."
+                    )
+                )
+                return
+            offenders = find_alertable_offenders(int(threshold), days=days)
+            self.stdout.write(
+                f"{len(offenders)} offender(s) >= {threshold} blocked in "
+                f"{days} day(s):"
+            )
+            for row in offenders:
+                self.stdout.write(f"  {row['key']}: {row['blocked_count']}")
+            return
+
+        result = send_offender_alerts(threshold=threshold, days=days)
+        if not result["enabled"]:
+            self.stdout.write(
+                self.style.WARNING(
+                    "Alerting disabled (set --threshold or RATELIMIT_ALERT_THRESHOLD)."
+                )
+            )
+            return
+
+        offenders = result["offenders"]
+        channels = result.get("channels", {})
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{len(offenders)} offender(s) over threshold {result['threshold']}; "
+                f"channels: {channels or 'none configured'}"
+            )
+        )

--- a/django_smart_ratelimit/statsd.py
+++ b/django_smart_ratelimit/statsd.py
@@ -1,0 +1,179 @@
+"""StatsD metrics exporter (roadmap Phase 5.1.3).
+
+A dependency-free, fire-and-forget StatsD client and a ``StatsDMetrics`` facade
+mirroring the :class:`~django_smart_ratelimit.prometheus.PrometheusMetrics` API
+(``record_request`` plus health / circuit-breaker / active-key gauges). Metrics
+are emitted as UDP packets in the StatsD line protocol with optional
+DogStatsD-style tags; network and configuration errors are swallowed so metrics
+never affect request handling.
+
+Enable by pointing at a StatsD/DogStatsD agent::
+
+    RATELIMIT_STATSD = {
+        "ENABLED": True,
+        "HOST": "127.0.0.1",
+        "PORT": 8125,
+        "PREFIX": "django_ratelimit",
+    }
+"""
+
+import logging
+import socket
+import threading
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _get_statsd_config() -> Dict[str, Any]:
+    """Read StatsD configuration from Django settings (``RATELIMIT_STATSD``)."""
+    from django.conf import settings as django_settings
+
+    config = getattr(django_settings, "RATELIMIT_STATSD", {})
+    return {
+        "enabled": config.get("ENABLED", False),
+        "host": config.get("HOST", "127.0.0.1"),
+        "port": int(config.get("PORT", 8125)),
+        "prefix": config.get("PREFIX", "django_ratelimit"),
+    }
+
+
+class StatsDClient:
+    """Minimal fire-and-forget UDP StatsD client (no external dependency).
+
+    Emits counters (``c``), timers (``ms``), and gauges (``g``). DogStatsD-style
+    ``|#k:v`` tags are appended when provided. Send failures are swallowed.
+    """
+
+    def __init__(
+        self, host: str = "127.0.0.1", port: int = 8125, prefix: str = "ratelimit"
+    ) -> None:
+        """Open the UDP socket and remember the destination and metric prefix."""
+        self._addr = (host, int(port))
+        self._prefix = prefix.rstrip(".")
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    def format_metric(
+        self,
+        metric: str,
+        value: Any,
+        unit: str,
+        tags: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Build a StatsD line (exposed for testing); no I/O."""
+        name = f"{self._prefix}.{metric}" if self._prefix else metric
+        line = f"{name}:{value}|{unit}"
+        if tags:
+            line += "|#" + ",".join(f"{k}:{v}" for k, v in tags.items())
+        return line
+
+    def _send(
+        self, metric: str, value: Any, unit: str, tags: Optional[Dict[str, Any]]
+    ) -> None:
+        line = self.format_metric(metric, value, unit, tags)
+        try:
+            self._sock.sendto(line.encode("utf-8"), self._addr)
+        except OSError as exc:  # pragma: no cover - network failure must not raise
+            logger.debug("statsd send failed: %s", exc)
+
+    def incr(
+        self, metric: str, value: int = 1, tags: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Send a counter increment."""
+        self._send(metric, int(value), "c", tags)
+
+    def timing(
+        self, metric: str, ms: float, tags: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Send a timer value in milliseconds."""
+        self._send(metric, round(float(ms), 3), "ms", tags)
+
+    def gauge(
+        self, metric: str, value: float, tags: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Send a gauge value."""
+        self._send(metric, round(float(value), 3), "g", tags)
+
+
+class StatsDMetrics:
+    """StatsD facade mirroring :class:`PrometheusMetrics` (singleton)."""
+
+    _instance: Optional["StatsDMetrics"] = None
+    _lock = threading.Lock()
+
+    def __init__(self, client: Optional[StatsDClient] = None) -> None:
+        """Build from ``RATELIMIT_STATSD`` settings, or inject a client (tests)."""
+        config = _get_statsd_config()
+        self._enabled = bool(config["enabled"]) or client is not None
+        if client is not None:
+            self._client: Optional[StatsDClient] = client
+        elif self._enabled:
+            self._client = StatsDClient(
+                host=config["host"], port=config["port"], prefix=config["prefix"]
+            )
+        else:
+            self._client = None
+
+    @property
+    def enabled(self) -> bool:
+        """Whether metrics are being emitted."""
+        return self._enabled and self._client is not None
+
+    def record_request(
+        self, key: str, backend: str, allowed: bool, duration_seconds: float
+    ) -> None:
+        """Record a rate-limit check.
+
+        ``key`` is accepted for API parity with the Prometheus exporter but is
+        deliberately not used as a tag (per-key tags cause unbounded
+        cardinality).
+        """
+        if not self.enabled:
+            return
+        assert self._client is not None
+        result = "allowed" if allowed else "denied"
+        self._client.incr("requests", tags={"backend": backend, "result": result})
+        if not allowed:
+            self._client.incr("requests_denied", tags={"backend": backend})
+        self._client.timing(
+            "request_duration", duration_seconds * 1000.0, tags={"backend": backend}
+        )
+
+    def set_backend_health(self, backend: str, healthy: bool) -> None:
+        """Record backend health as a 0/1 gauge."""
+        if not self.enabled:
+            return
+        assert self._client is not None
+        self._client.gauge("backend_healthy", 1 if healthy else 0, {"backend": backend})
+
+    def set_circuit_breaker_state(self, backend: str, state: str) -> None:
+        """Record circuit-breaker state (closed=0, half-open=1, open=2)."""
+        if not self.enabled:
+            return
+        assert self._client is not None
+        state_map = {"closed": 0, "half-open": 1, "open": 2}
+        self._client.gauge(
+            "circuit_breaker_state", state_map.get(state, 0), {"backend": backend}
+        )
+
+    def set_active_keys(self, backend: str, count: int) -> None:
+        """Record the number of active rate-limit keys."""
+        if not self.enabled:
+            return
+        assert self._client is not None
+        self._client.gauge("active_keys", float(count), {"backend": backend})
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset the singleton (useful for testing)."""
+        with cls._lock:
+            cls._instance = None
+
+
+def get_statsd_metrics() -> StatsDMetrics:
+    """Get or create the singleton :class:`StatsDMetrics`."""
+    if StatsDMetrics._instance is None:
+        with StatsDMetrics._lock:
+            if StatsDMetrics._instance is None:
+                StatsDMetrics._instance = StatsDMetrics()
+    return StatsDMetrics._instance

--- a/django_smart_ratelimit/statsd.py
+++ b/django_smart_ratelimit/statsd.py
@@ -128,40 +128,40 @@ class StatsDMetrics:
         deliberately not used as a tag (per-key tags cause unbounded
         cardinality).
         """
-        if not self.enabled:
+        client = self._client
+        if not self._enabled or client is None:
             return
-        assert self._client is not None
         result = "allowed" if allowed else "denied"
-        self._client.incr("requests", tags={"backend": backend, "result": result})
+        client.incr("requests", tags={"backend": backend, "result": result})
         if not allowed:
-            self._client.incr("requests_denied", tags={"backend": backend})
-        self._client.timing(
+            client.incr("requests_denied", tags={"backend": backend})
+        client.timing(
             "request_duration", duration_seconds * 1000.0, tags={"backend": backend}
         )
 
     def set_backend_health(self, backend: str, healthy: bool) -> None:
         """Record backend health as a 0/1 gauge."""
-        if not self.enabled:
+        client = self._client
+        if not self._enabled or client is None:
             return
-        assert self._client is not None
-        self._client.gauge("backend_healthy", 1 if healthy else 0, {"backend": backend})
+        client.gauge("backend_healthy", 1 if healthy else 0, {"backend": backend})
 
     def set_circuit_breaker_state(self, backend: str, state: str) -> None:
         """Record circuit-breaker state (closed=0, half-open=1, open=2)."""
-        if not self.enabled:
+        client = self._client
+        if not self._enabled or client is None:
             return
-        assert self._client is not None
         state_map = {"closed": 0, "half-open": 1, "open": 2}
-        self._client.gauge(
+        client.gauge(
             "circuit_breaker_state", state_map.get(state, 0), {"backend": backend}
         )
 
     def set_active_keys(self, backend: str, count: int) -> None:
         """Record the number of active rate-limit keys."""
-        if not self.enabled:
+        client = self._client
+        if not self._enabled or client is None:
             return
-        assert self._client is not None
-        self._client.gauge("active_keys", float(count), {"backend": backend})
+        client.gauge("active_keys", float(count), {"backend": backend})
 
     @classmethod
     def reset(cls) -> None:

--- a/django_smart_ratelimit/tiers.py
+++ b/django_smart_ratelimit/tiers.py
@@ -9,6 +9,7 @@ Resolves the effective rate limit for a request by precedence:
 3. otherwise the base rate, unchanged.
 """
 
+from datetime import timedelta
 from typing import Any, Optional
 
 from django.utils import timezone
@@ -109,3 +110,63 @@ def resolve_effective_user_rate(request: Any, base_rate: str, scope: str = "") -
 
     tier = get_user_tier(user)
     return apply_tier_to_rate(base_rate, tier, scope)
+
+
+def tier_key(request: Any, *args: Any, **kwargs: Any) -> str:
+    """Key function: bucket a request by the user's tier (``tier:<name>``).
+
+    Returns ``tier:anonymous`` for unauthenticated requests and ``tier:default``
+    for authenticated users without a resolved tier. Use as ``key=tier_key`` to
+    give every user in the same tier a shared budget.
+    """
+    user = getattr(request, "user", None)
+    if user is None or not getattr(user, "is_authenticated", False):
+        return "tier:anonymous"
+    tier = get_user_tier(user)
+    if tier is None:
+        return "tier:default"
+    return f"tier:{getattr(tier, 'name', 'default')}"
+
+
+def create_user_override(
+    user: Any,
+    rate: str,
+    *,
+    scope: str = "",
+    duration_seconds: Optional[int] = None,
+    expires_at: Optional[Any] = None,
+    reason: str = "",
+    created_by: Any = None,
+) -> Any:
+    """Create and return a per-user :class:`UserRateLimitOverride` (roadmap 3.3.4).
+
+    A programmatic alternative to the Django admin for granting a temporary
+    custom rate. ``scope`` maps to the override's ``rule_name`` (blank applies to
+    all). Provide exactly one of ``duration_seconds`` (relative to now) or
+    ``expires_at`` (absolute); ``duration_seconds`` defaults to one hour if
+    neither is given. ``rate`` is validated before the row is written.
+    """
+    from django.core.exceptions import ValidationError
+
+    from .backends.utils import parse_rate
+
+    try:
+        parse_rate(rate)
+    except Exception as exc:
+        raise ValidationError(f"Invalid rate: {rate!r}") from exc
+
+    from .models import UserRateLimitOverride
+
+    now = timezone.now()
+    if expires_at is None:
+        expires_at = now + timedelta(seconds=duration_seconds or 3600)
+
+    return UserRateLimitOverride.objects.create(
+        user=user,
+        rule_name=scope,
+        rate=rate,
+        reason=reason,
+        created_by=created_by,
+        starts_at=now,
+        expires_at=expires_at,
+    )

--- a/django_smart_ratelimit/urls.py
+++ b/django_smart_ratelimit/urls.py
@@ -7,11 +7,16 @@ Include in your project's urls.py::
 
 from django.urls import path
 
-from .views import RateLimitDashboardView, offenders_csv_view
+from .views import (
+    RateLimitDashboardView,
+    offender_detail_view,
+    offenders_csv_view,
+)
 
 app_name = "django_smart_ratelimit"
 
 urlpatterns = [
     path("dashboard/", RateLimitDashboardView.as_view(), name="dashboard"),
     path("dashboard/offenders.csv", offenders_csv_view, name="offenders-csv"),
+    path("dashboard/offender/", offender_detail_view, name="offender-detail"),
 ]

--- a/django_smart_ratelimit/views.py
+++ b/django_smart_ratelimit/views.py
@@ -101,3 +101,22 @@ def offenders_csv_view(request: HttpRequest) -> HttpResponse:
     response = HttpResponse(payload, content_type="text/csv")
     response["Content-Disposition"] = 'attachment; filename="ratelimit_offenders.csv"'
     return response
+
+
+def offender_detail_view(request: HttpRequest) -> HttpResponse:
+    """Staff-only JSON drill-down for one offender ``?key=`` (roadmap 4.3.2).
+
+    Returns totals, first/last seen, the per-path blocked breakdown, and recent
+    events for the key over the requested ``?days=`` window.
+    """
+    if not _staff_required(request):
+        return HttpResponse("Forbidden", status=403)
+
+    key = request.GET.get("key", "")
+    if not key:
+        return JsonResponse({"error": "missing ?key= parameter"}, status=400)
+
+    from .analytics import get_offender_detail
+
+    days = _days_param(request)
+    return JsonResponse(get_offender_detail(key, days=days))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-smart-ratelimit"
-version = "4.5.1"
+version = "4.6.0"
 dynamic = []
 description = "A flexible and efficient rate limiting library for Django applications"
 readme = "README.md"

--- a/tests/integration/test_roadmap_v460.py
+++ b/tests/integration/test_roadmap_v460.py
@@ -1,0 +1,231 @@
+"""v4.6.0 roadmap-completion features.
+
+Covers the analytics offender detail view + threshold alerting (4.3.2 / 4.3.4),
+the StatsD exporter (5.1.3), the time-of-day adaptive indicator (5.3.1), and the
+native atomic Redis leaky bucket (5.2.3).
+"""
+
+import pytest
+
+from django.contrib.auth.models import User
+from django.core import mail
+from django.test import RequestFactory, override_settings
+
+from django_smart_ratelimit.adaptive import TimeOfDayIndicator
+from django_smart_ratelimit.analytics import (
+    find_alertable_offenders,
+    get_offender_detail,
+    send_offender_alerts,
+)
+from django_smart_ratelimit.statsd import StatsDClient, StatsDMetrics
+from django_smart_ratelimit.views import offender_detail_view
+
+
+def _staff_req(path="/x", **params):
+    request = RequestFactory().get(path, params)
+    # A real User instance is always is_authenticated == True (read-only property).
+    request.user = User(username="staff", is_staff=True)
+    return request
+
+
+# ---------------------------------------------------------------------------
+# 5.3.1 time-of-day adaptive indicator
+# ---------------------------------------------------------------------------
+
+
+def test_time_of_day_indicator_peak_and_off_peak():
+    from django.utils import timezone
+
+    hour = timezone.localtime(timezone.now()).hour
+    peak = TimeOfDayIndicator(peak_hours=[hour], peak_load=0.9, off_peak_load=0.1)
+    assert peak.get_load() == 0.9
+    off = TimeOfDayIndicator(
+        peak_hours=[(hour + 1) % 24], peak_load=0.9, off_peak_load=0.1
+    )
+    assert off.get_load() == 0.1
+
+
+def test_time_of_day_indicator_clamps_loads():
+    ind = TimeOfDayIndicator(peak_hours=[], peak_load=5.0, off_peak_load=-2.0)
+    assert ind.get_load() == 0.0  # off-peak (-2 clamped to 0)
+
+
+# ---------------------------------------------------------------------------
+# 5.1.3 StatsD exporter
+# ---------------------------------------------------------------------------
+
+
+class _FakeStatsD:
+    def __init__(self):
+        self.calls = []
+
+    def incr(self, metric, value=1, tags=None):
+        self.calls.append(("c", metric, value, tags))
+
+    def timing(self, metric, ms, tags=None):
+        self.calls.append(("ms", metric, ms, tags))
+
+    def gauge(self, metric, value, tags=None):
+        self.calls.append(("g", metric, value, tags))
+
+
+def test_statsd_line_format():
+    client = StatsDClient(prefix="django_ratelimit")
+    line = client.format_metric("requests", 3, "c", {"backend": "redis"})
+    assert line == "django_ratelimit.requests:3|c|#backend:redis"
+    assert client.format_metric("x", 1, "c") == "django_ratelimit.x:1|c"
+
+
+def test_statsd_record_request_emits_counter_and_timing():
+    fake = _FakeStatsD()
+    metrics = StatsDMetrics(client=fake)
+    assert metrics.enabled is True
+
+    metrics.record_request("ip:1.2.3.4", "redis", allowed=True, duration_seconds=0.01)
+    metrics.record_request("ip:1.2.3.4", "redis", allowed=False, duration_seconds=0.02)
+
+    units = [c[0] for c in fake.calls]
+    assert units.count("c") == 3  # allowed:1 + denied(counter+denied_total):2
+    assert units.count("ms") == 2
+    # A denied request emits both the result=denied counter and requests_denied.
+    names = [c[1] for c in fake.calls if c[0] == "c"]
+    assert "requests_denied" in names
+
+
+def test_statsd_disabled_without_config_is_noop():
+    StatsDMetrics.reset()
+    with override_settings(RATELIMIT_STATSD={"ENABLED": False}):
+        metrics = StatsDMetrics()
+        assert metrics.enabled is False
+        # No client -> calls are no-ops and never raise.
+        metrics.record_request("k", "memory", allowed=True, duration_seconds=0.0)
+        metrics.set_active_keys("memory", 5)
+    StatsDMetrics.reset()
+
+
+# ---------------------------------------------------------------------------
+# 4.3.2 / 4.3.4 analytics: offender detail + alerting
+# ---------------------------------------------------------------------------
+
+
+def _make_events(key, blocked, allowed=0, path="/api"):
+    from django_smart_ratelimit.models import RateLimitEvent
+
+    for _ in range(blocked):
+        RateLimitEvent.objects.create(
+            key=key, path=path, method="GET", allowed=False, count=11, limit=10
+        )
+    for _ in range(allowed):
+        RateLimitEvent.objects.create(
+            key=key, path=path, method="GET", allowed=True, count=1, limit=10
+        )
+
+
+@pytest.mark.django_db
+def test_get_offender_detail():
+    _make_events("ip:9.9.9.9", blocked=5, allowed=3, path="/login")
+    detail = get_offender_detail("ip:9.9.9.9", days=7)
+    assert detail["blocked"] == 5
+    assert detail["allowed"] == 3
+    assert detail["total"] == 8
+    assert round(detail["block_rate"], 3) == round(5 / 8, 3)
+    assert detail["by_path"][0]["path"] == "/login"
+    assert detail["first_seen"] is not None
+    assert len(detail["recent_events"]) == 8
+
+
+@pytest.mark.django_db
+def test_find_alertable_offenders_threshold():
+    _make_events("ip:1.1.1.1", blocked=10)
+    _make_events("ip:2.2.2.2", blocked=3)
+    alertable = find_alertable_offenders(threshold=5, days=1)
+    keys = {row["key"] for row in alertable}
+    assert "ip:1.1.1.1" in keys
+    assert "ip:2.2.2.2" not in keys
+
+
+@pytest.mark.django_db
+def test_send_offender_alerts_disabled_without_threshold():
+    _make_events("ip:3.3.3.3", blocked=10)
+    result = send_offender_alerts(threshold=None, days=1)
+    assert result["enabled"] is False
+
+
+@pytest.mark.django_db
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    DEFAULT_FROM_EMAIL="alerts@example.com",
+    RATELIMIT_ALERT_EMAILS=["ops@example.com"],
+)
+def test_send_offender_alerts_email():
+    _make_events("ip:4.4.4.4", blocked=20)
+    result = send_offender_alerts(threshold=5, days=1)
+    assert result["enabled"] is True
+    assert result["channels"]["email"]["sent"] is True
+    assert len(mail.outbox) == 1
+    assert "ip:4.4.4.4" in mail.outbox[0].body
+
+
+@pytest.mark.django_db
+def test_send_offender_alerts_webhook(monkeypatch):
+    _make_events("ip:5.5.5.5", blocked=8)
+    sent = {}
+
+    def fake_urlopen(req, timeout=None):
+        sent["url"] = req.full_url
+        sent["body"] = req.data
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        return _Resp()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    result = send_offender_alerts(
+        threshold=5, days=1, webhook_url="https://hooks.example.com/x"
+    )
+    assert result["channels"]["webhook"]["sent"] is True
+    assert sent["url"] == "https://hooks.example.com/x"
+    assert b"ip:5.5.5.5" in sent["body"]
+
+
+@pytest.mark.django_db
+def test_offender_detail_view_staff_only():
+    _make_events("ip:6.6.6.6", blocked=4)
+    # Authenticated but NOT staff -> 403
+    non_staff = RequestFactory().get("/", {"key": "ip:6.6.6.6"})
+    non_staff.user = User(username="plainuser")  # is_staff defaults to False
+    assert offender_detail_view(non_staff).status_code == 403
+    # Staff -> 200 JSON with the detail
+    resp = offender_detail_view(_staff_req(key="ip:6.6.6.6"))
+    assert resp.status_code == 200
+    import json
+
+    data = json.loads(resp.content)
+    assert data["key"] == "ip:6.6.6.6"
+    assert data["blocked"] == 4
+    # Missing key -> 400
+    assert offender_detail_view(_staff_req()).status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# 5.2.3 native atomic Redis leaky bucket
+# ---------------------------------------------------------------------------
+
+
+def test_redis_native_leaky_bucket_atomic():
+    from django_smart_ratelimit.backends.redis_backend import RedisBackend
+
+    backend = RedisBackend()
+    key = "lbtest:v460"
+    backend.reset(key)
+    # capacity 5, negligible leak during the test -> exactly 5 admitted.
+    decisions = [backend.leaky_bucket_check(key, 5, 0.0001, 1)[0] for _ in range(7)]
+    assert decisions == [True, True, True, True, True, False, False]
+    info = backend.leaky_bucket_info(key, 5, 0.0001)
+    assert info["bucket_level"] > 4.0  # near full, read-only (no mutation)
+    backend.reset(key)

--- a/tests/integration/test_user_tiers_decorator.py
+++ b/tests/integration/test_user_tiers_decorator.py
@@ -1,0 +1,161 @@
+"""Phase 3 completion (v4.6.0): decorator-level tiers/overrides + helpers.
+
+Covers the `@rate_limit` decorator honoring `RATELIMIT_USE_USER_TIERS` (so the
+decorator reaches parity with the middleware), the `tier_key` key function, and
+the `create_user_override` programmatic helper.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
+from django.utils import timezone
+
+from django_smart_ratelimit import rate_limit
+from django_smart_ratelimit.backends import clear_backend_cache
+from django_smart_ratelimit.models import (
+    UserRateLimitOverride,
+    UserTier,
+    UserTierAssignment,
+)
+from django_smart_ratelimit.tiers import (
+    create_user_override,
+    get_user_override,
+    tier_key,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _req(user=None, ip="203.0.113.5", path="/api/x"):
+    request = RequestFactory().get(path)
+    request.META["REMOTE_ADDR"] = ip
+    if user is not None:
+        request.user = user
+    return request
+
+
+class _Anon:
+    is_authenticated = False
+    pk = None
+
+
+# ---------------------------------------------------------------------------
+# 3.3.2 decorator honors tiers/overrides
+# ---------------------------------------------------------------------------
+
+
+@override_settings(RATELIMIT_USE_USER_TIERS=True)
+def test_decorator_premium_user_gets_higher_limit():
+    clear_backend_cache()
+    premium = UserTier.objects.create(name="premium", rate_multiplier=3.0)
+    user = User.objects.create(username="dprem")
+    UserTierAssignment.objects.create(user=user, tier=premium)
+
+    @rate_limit(key="ip", rate="2/m", backend="memory")
+    def view(request):
+        return HttpResponse("ok")
+
+    # Base 2/m * 3 = 6/m for the premium user; the 7th is blocked.
+    codes = [view(_req(user, ip="7.7.7.7")).status_code for _ in range(7)]
+    assert codes.count(200) == 6
+    assert codes[-1] == 429
+    clear_backend_cache()
+
+
+@override_settings(RATELIMIT_USE_USER_TIERS=True)
+def test_decorator_override_applies_and_per_user_bucket():
+    clear_backend_cache()
+    u1 = User.objects.create(username="da")
+    u2 = User.objects.create(username="db")
+    UserRateLimitOverride.objects.create(
+        user=u1, rate="5/m", expires_at=timezone.now() + timedelta(hours=1)
+    )
+
+    @rate_limit(key="ip", rate="2/m", backend="memory")
+    def view(request):
+        return HttpResponse("ok")
+
+    # u1 (override 5/m) and u2 (default 2/m) share an IP but bucket separately.
+    u1_codes = [view(_req(u1, ip="8.8.8.8")).status_code for _ in range(6)]
+    u2_codes = [view(_req(u2, ip="8.8.8.8")).status_code for _ in range(3)]
+    assert u1_codes.count(200) == 5
+    assert u2_codes == [200, 200, 429]
+    clear_backend_cache()
+
+
+@override_settings(RATELIMIT_USE_USER_TIERS=True)
+def test_decorator_anonymous_unaffected_by_tiers():
+    clear_backend_cache()
+
+    @rate_limit(key="ip", rate="2/m", backend="memory")
+    def view(request):
+        return HttpResponse("ok")
+
+    codes = [view(_req(_Anon(), ip="6.6.6.6")).status_code for _ in range(3)]
+    assert codes == [200, 200, 429]  # plain base rate
+    clear_backend_cache()
+
+
+def test_decorator_no_tiers_setting_is_noop():
+    # With the setting off (default), the decorator ignores tiers entirely.
+    clear_backend_cache()
+    premium = UserTier.objects.create(name="premium2", rate_multiplier=5.0)
+    user = User.objects.create(username="dnoop")
+    UserTierAssignment.objects.create(user=user, tier=premium)
+
+    @rate_limit(key="ip", rate="2/m", backend="memory")
+    def view(request):
+        return HttpResponse("ok")
+
+    codes = [view(_req(user, ip="5.5.5.4")).status_code for _ in range(3)]
+    assert codes == [200, 200, 429]  # base 2/m, tier ignored
+    clear_backend_cache()
+
+
+# ---------------------------------------------------------------------------
+# 3.1.4 tier_key key function
+# ---------------------------------------------------------------------------
+
+
+def test_tier_key():
+    assert tier_key(_req(_Anon())) == "tier:anonymous"
+    plain = User.objects.create(username="plain")
+    assert tier_key(_req(plain)) == "tier:default"
+    gold = UserTier.objects.create(name="gold", rate_multiplier=2.0)
+    vip = User.objects.create(username="vip")
+    UserTierAssignment.objects.create(user=vip, tier=gold)
+    assert tier_key(_req(vip)) == "tier:gold"
+
+
+# ---------------------------------------------------------------------------
+# 3.3.4 programmatic override creation
+# ---------------------------------------------------------------------------
+
+
+def test_create_user_override_defaults_and_lookup():
+    user = User.objects.create(username="ovr")
+    override = create_user_override(user, "50/h", reason="support ticket")
+    assert override.rate == "50/h"
+    assert override.reason == "support ticket"
+    # Active immediately, expires ~1h out by default.
+    assert get_user_override(user) == "50/h"
+    delta = override.expires_at - override.starts_at
+    assert abs(delta.total_seconds() - 3600) < 5
+
+
+def test_create_user_override_scope_and_duration():
+    user = User.objects.create(username="ovr2")
+    create_user_override(user, "10/m", scope="upload", duration_seconds=60)
+    assert get_user_override(user, scope="upload") == "10/m"
+    assert get_user_override(user, scope="other") is None  # scoped, no blanket
+
+
+def test_create_user_override_rejects_bad_rate():
+    user = User.objects.create(username="ovr3")
+    with pytest.raises(ValidationError):
+        create_user_override(user, "not-a-rate")

--- a/tests/unit/backends/test_redis_backend.py
+++ b/tests/unit/backends/test_redis_backend.py
@@ -53,7 +53,7 @@ class RedisBackendTests(TestCase):
         self.assertIsInstance(backend, self.RedisBackend)
         self.mock_redis_module.Redis.assert_called_once()
         self.mock_redis_client.ping.assert_called_once()
-        self.assertEqual(self.mock_redis_client.script_load.call_count, 4)
+        self.assertEqual(self.mock_redis_client.script_load.call_count, 6)
 
     def test_redis_backend_initialization_no_redis_module(self):
         """Test Redis backend initialization when redis module is not available."""
@@ -378,9 +378,9 @@ class RedisBackendScriptTests(TestCase):
         """Test that sliding window script is loaded correctly."""
         self.RedisBackend()  # Just test script loading
 
-        # Verify script_load was called 4 times
-        # (sliding + fixed window + token bucket + token bucket info)
-        self.assertEqual(self.mock_redis_client.script_load.call_count, 4)
+        # Verify script_load was called 6 times
+        # (sliding + fixed + token + token info + leaky + leaky info)
+        self.assertEqual(self.mock_redis_client.script_load.call_count, 6)
 
         # Verify sliding window script is not empty
         calls = self.mock_redis_client.script_load.call_args_list
@@ -393,9 +393,9 @@ class RedisBackendScriptTests(TestCase):
         """Test that fixed window script is loaded correctly."""
         self.RedisBackend()  # Just test script loading
 
-        # Verify script_load was called 4 times
-        # (sliding + fixed window + token bucket + token bucket info)
-        self.assertEqual(self.mock_redis_client.script_load.call_count, 4)
+        # Verify script_load was called 6 times
+        # (sliding + fixed + token + token info + leaky + leaky info)
+        self.assertEqual(self.mock_redis_client.script_load.call_count, 6)
 
         # Verify fixed window script is not empty
         calls = self.mock_redis_client.script_load.call_args_list

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -224,7 +224,7 @@ class RedisBackendTestMixin:
         """Assert that Redis ping was called."""
         self.mock_redis_client.ping.assert_called()
 
-    def assert_redis_script_load_called(self, expected_count: int = 4):
+    def assert_redis_script_load_called(self, expected_count: int = 6):
         """Assert that Redis script_load was called expected number of times."""
         self.assertEqual(self.mock_redis_client.script_load.call_count, expected_count)
 


### PR DESCRIPTION
Builds the remaining items from the original v2.0 roadmap that a task-by-task audit found were planned but never implemented. **All additive and opt-in — no existing behavior changes.**

## Phase 3 (user integration)
- **Decorator honors tiers/overrides (3.3.2)** — with `RATELIMIT_USE_USER_TIERS=True`, `@rate_limit` now resolves an authenticated request to its effective rate (override → tier → base) and buckets it per-user, matching the middleware. No-op when off or when `adaptive=` is used.
- **`tiers.tier_key` (3.1.4)** — key function bucketing by the user's tier.
- **`tiers.create_user_override` (3.3.4)** — programmatic temporary per-user override helper (validates rate, 1h default).

## Phase 4 (analytics)
- **`get_offender_detail` + staff JSON `offender-detail` view (4.3.2)** — per-key totals, per-path breakdown, recent events (`dashboard/offender/?key=`).
- **Alerting (4.3.4)** — `find_alertable_offenders` / `send_offender_alerts` (email + webhook), plus a `ratelimit_alerts` management command for cron. Opt-in via `RATELIMIT_ALERT_THRESHOLD` / `RATELIMIT_ALERT_EMAILS` / `RATELIMIT_ALERT_WEBHOOK`.

## Phase 5 (advanced)
- **StatsD exporter (5.1.3)** — dependency-free `StatsDClient` + `StatsDMetrics` mirroring the Prometheus API, via `RATELIMIT_STATSD`.
- **Native atomic Redis leaky bucket (5.2.3)** — `RedisBackend.leaky_bucket_check` / `leaky_bucket_info` via Lua; the `leaky_bucket` algorithm is now atomic on Redis (was a non-atomic fallback).
- **`TimeOfDayIndicator` (5.3.1)** — adaptive load indicator driven by peak hours.

## Testing
- New tests: `tests/integration/test_user_tiers_decorator.py`, `tests/integration/test_roadmap_v460.py`.
- Full suite: **1902 passed, 9 skipped** (live Redis + Mongo).
- Redis leaky-bucket Lua verified on live Redis (atomic admission + leak/refill).
- pre-commit (black/flake8/isort/mypy/bandit) clean.

Closes the v2.0 roadmap code gaps; user-facing docs for the v4.x features follow in a separate docs PR.