### PR TITLE
docs: user-facing guides for the v4.x features

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,12 @@ A high-performance rate limiting library for Django. Protects your APIs from abu
 - **Observability** -- Prometheus `/metrics`, OpenTelemetry spans and metrics, and structured JSON logging ([docs](https://django-smart-ratelimit.readthedocs.io/en/latest/installation/))
 - **Type-Safe Enums** -- Optional `Algorithm` and `RateLimitKey` enums for autocomplete and typo-proof config
 - **Configurable Proxy Trust** -- `RATELIMIT_TRUSTED_PROXIES` for spoof-resistant client IP extraction behind load balancers (new in v3.1)
-- **Adaptive Rate Limiting** -- Dynamic limits based on CPU, memory, latency, and custom load indicators
+- **Adaptive Rate Limiting** -- Dynamic limits based on CPU, memory, latency, time-of-day, and custom load indicators
+- **Dynamic Rules** -- Define and change limits at runtime from the Django admin, no redeploy ([docs](https://django-smart-ratelimit.readthedocs.io/en/latest/dynamic_rules/))
+- **User-Aware Limiting** -- Per-user tiers, Django-group mapping, temporary overrides, and API-key tiers ([docs](https://django-smart-ratelimit.readthedocs.io/en/latest/user_tiers/))
+- **Analytics & Alerting** -- Event logging, a staff dashboard, offender reports, and email/webhook alerts ([docs](https://django-smart-ratelimit.readthedocs.io/en/latest/analytics/))
+- **Geographic & Multi-Tenant** -- Per-country rates and per-tenant quotas ([geo](https://django-smart-ratelimit.readthedocs.io/en/latest/geographic/), [tenants](https://django-smart-ratelimit.readthedocs.io/en/latest/multi_tenant/))
+- **GraphQL** -- Graphene middleware and a Strawberry extension with query-complexity weighting ([docs](https://django-smart-ratelimit.readthedocs.io/en/latest/graphql/))
 
 ## Quick Start
 
@@ -120,6 +125,10 @@ Full documentation is hosted on Read the Docs:
 | [Algorithms](https://django-smart-ratelimit.readthedocs.io/en/latest/algorithms/) | Deep dive into token bucket, sliding window, and more |
 | [Backends](https://django-smart-ratelimit.readthedocs.io/en/latest/backends/) | Redis, async Redis, memory, MongoDB, and the Django ORM database backend |
 | [Configuration](https://django-smart-ratelimit.readthedocs.io/en/latest/configuration/) | Advanced settings, CIDR lists, proxy trust, and circuit breakers |
+| [Dynamic Rules](https://django-smart-ratelimit.readthedocs.io/en/latest/dynamic_rules/) | Runtime, admin-editable rate-limit rules |
+| [User Tiers](https://django-smart-ratelimit.readthedocs.io/en/latest/user_tiers/) | Tiers, groups, per-user overrides, and API-key tiers |
+| [Analytics](https://django-smart-ratelimit.readthedocs.io/en/latest/analytics/) | Event logging, dashboard, offender reports, and alerting |
+| [Geographic](https://django-smart-ratelimit.readthedocs.io/en/latest/geographic/) / [Multi-Tenant](https://django-smart-ratelimit.readthedocs.io/en/latest/multi_tenant/) / [GraphQL](https://django-smart-ratelimit.readthedocs.io/en/latest/graphql/) | Per-country, per-tenant, and GraphQL limiting |
 | [Deployment](https://django-smart-ratelimit.readthedocs.io/en/latest/deployment/) | Running in production behind proxies and load balancers |
 | [Design Philosophy](https://django-smart-ratelimit.readthedocs.io/en/latest/design/) | Architecture decisions and comparison with alternatives |
 
@@ -127,8 +136,8 @@ Full documentation is hosted on Read the Docs:
 
 | | Supported Versions |
 | :--- | :--- |
-| Python | 3.9, 3.10, 3.11, 3.12, 3.13 |
-| Django | 3.2, 4.0, 4.1, 4.2, 5.0, 5.1 |
+| Python | 3.9, 3.10, 3.11, 3.12, 3.13, 3.14 |
+| Django | 3.2, 4.2, 5.0, 5.1, 5.2, 6.0 |
 
 ## Contributing
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,315 @@
+# Analytics & Monitoring
+
+`django-smart-ratelimit` can record every rate-limit decision the middleware
+makes and report on it: a traffic summary, the top offenders, per-rule hit
+counts, a staff-only dashboard, a CSV export, an offender drill-down, and
+threshold-based email/webhook alerting.
+
+Everything here is built on a single Django model, `RateLimitEvent`, that the
+middleware writes one row per request to. Logging is **opt-in** and **off by
+default** because it can generate a lot of rows on a busy site.
+
+## Enabling Event Logging
+
+Set `RATELIMIT_LOG_EVENTS = True` and make sure the `RateLimitMiddleware` is
+installed. Each request the middleware checks then produces one `RateLimitEvent`
+row.
+
+```python
+# settings.py
+INSTALLED_APPS = [
+    # ...
+    "django_smart_ratelimit",
+]
+
+MIDDLEWARE = [
+    # ...
+    "django_smart_ratelimit.middleware.RateLimitMiddleware",
+]
+
+RATELIMIT_LOG_EVENTS = True
+```
+
+Because `RateLimitEvent` is a database model, run migrations once before
+enabling it:
+
+```bash
+python manage.py migrate django_smart_ratelimit
+```
+
+Only requests that flow through `RateLimitMiddleware` are logged. Decorator-only
+rate limits do not write events.
+
+### Best-effort by design
+
+Event logging is wrapped so it can **never break a request**. If the write
+fails (database down, migrations missing, etc.) the middleware swallows the
+error and the request proceeds normally — you simply get no event row for that
+request. Treat the event log as best-effort reporting data, not an audit trail.
+
+## The RateLimitEvent model
+
+```python
+from django_smart_ratelimit.models import RateLimitEvent
+```
+
+Each row records the outcome of one rate-limit check:
+
+| Field        | Meaning                                                       |
+| ------------ | ------------------------------------------------------------- |
+| `timestamp`  | When the event was recorded (`auto_now_add`, indexed).        |
+| `key`        | The rate-limit key (e.g. `ip:203.0.113.5`, `user:42`).        |
+| `rule_name`  | Rule name, recovered from a `rule:<name>:...` key (or `""`).  |
+| `path`       | Request path.                                                 |
+| `method`     | HTTP method.                                                  |
+| `allowed`    | `True` if allowed, `False` if blocked.                        |
+| `count`      | Request count in the window at decision time.                 |
+| `limit`      | The configured limit.                                         |
+| `ip_address` | `REMOTE_ADDR`, if available.                                  |
+| `user_id`    | The authenticated user's PK, or `None`.                       |
+
+Rows are ordered newest-first and indexed on `timestamp`, `(key, timestamp)`,
+and `(allowed, timestamp)` for time-range, per-key, and blocked-only reporting.
+The model is registered read-only in the Django admin.
+
+## Wiring up the URLs
+
+The dashboard, CSV export, and offender-detail endpoint ship as a URLconf.
+Include it from your project's `urls.py`:
+
+```python
+# urls.py
+from django.urls import include, path
+
+urlpatterns = [
+    # ...
+    path("ratelimit/", include("django_smart_ratelimit.urls")),
+]
+```
+
+That mounts three views (all gated to authenticated staff users):
+
+| URL                                   | Name             | Returns                          |
+| ------------------------------------- | ---------------- | -------------------------------- |
+| `ratelimit/dashboard/`                | `dashboard`      | HTML dashboard                   |
+| `ratelimit/dashboard/offenders.csv`   | `offenders-csv`  | CSV download of top offenders    |
+| `ratelimit/dashboard/offender/`       | `offender-detail`| JSON drill-down for one `key`    |
+
+All three accept an optional `?days=` query parameter (clamped to `1..365`,
+default `7`).
+
+## The dashboard
+
+`ratelimit/dashboard/` renders a staff-only summary for the requested window.
+Non-staff and anonymous requests get a `403 Forbidden`.
+
+```text
+GET /ratelimit/dashboard/?days=30
+```
+
+The view (`RateLimitDashboardView`) populates its template context with:
+
+- `today` — `get_traffic_summary(days=1)`
+- `window` — `get_traffic_summary(days=days)`
+- `top_offenders` — `get_top_offenders(days=days, limit=20)`
+- `rule_hits` — `get_rule_hit_counts(days=days, limit=20)`
+
+It renders `django_smart_ratelimit/dashboard.html`. Override that template in
+your own templates directory if you want to restyle it.
+
+### CSV export
+
+`ratelimit/dashboard/offenders.csv` streams the top offenders (up to 1000) as a
+CSV attachment for the requested window:
+
+```text
+GET /ratelimit/dashboard/offenders.csv?days=30
+```
+
+```csv
+key,blocked_count
+ip:203.0.113.5,412
+user:42,87
+```
+
+### Offender detail (JSON)
+
+`ratelimit/dashboard/offender/?key=<key>` returns a JSON drill-down for a single
+key. The `key` parameter is required; omitting it returns `400`.
+
+```text
+GET /ratelimit/dashboard/offender/?key=ip:203.0.113.5&days=7
+```
+
+```json
+{
+  "key": "ip:203.0.113.5",
+  "days": 7,
+  "total": 530,
+  "allowed": 118,
+  "blocked": 412,
+  "block_rate": 0.777,
+  "first_seen": "2026-05-01T08:14:02Z",
+  "last_seen": "2026-05-07T22:41:55Z",
+  "by_path": [{"path": "/api/login", "blocked_count": 300}],
+  "recent_events": [
+    {
+      "timestamp": "2026-05-07T22:41:55Z",
+      "path": "/api/login",
+      "method": "POST",
+      "allowed": false,
+      "count": 11,
+      "limit": 10,
+      "rule_name": "login"
+    }
+  ]
+}
+```
+
+## Aggregation functions
+
+The dashboard and exports are thin wrappers over functions in
+`django_smart_ratelimit.analytics`. You can call them directly from your own
+code, shell, or reporting jobs:
+
+```python
+from django_smart_ratelimit.analytics import (
+    get_traffic_summary,
+    get_top_offenders,
+    get_rule_hit_counts,
+    offenders_csv,
+    get_offender_detail,
+)
+
+# Total / allowed / blocked counts and block rate over the last N days.
+get_traffic_summary(days=1)
+# {"days": 1, "total": 5, "allowed": 2, "blocked": 3, "block_rate": 0.6}
+
+# Keys with the most BLOCKED requests, descending.
+get_top_offenders(days=7, limit=100)
+# [{"key": "ip:203.0.113.5", "blocked_count": 412}, ...]
+
+# Per-rule total hits and blocked counts (rows with a rule_name only).
+get_rule_hit_counts(days=7, limit=50)
+# [{"rule_name": "login", "hits": 900, "blocked": 412}, ...]
+
+# Top offenders rendered as a CSV string.
+offenders_csv(days=7, limit=1000)
+
+# Full drill-down for one key (the JSON the offender-detail view returns).
+get_offender_detail("ip:203.0.113.5", days=7, recent=50)
+```
+
+All windows are relative to "now": `days=7` means events with a `timestamp`
+within the last 7 days. Events outside the window are ignored.
+
+## Threshold alerting
+
+The library can find offenders whose blocked-request count over a window crosses
+a threshold and dispatch alerts by email and/or webhook.
+
+### Settings
+
+```python
+# settings.py
+RATELIMIT_ALERT_THRESHOLD = 100          # min blocked requests to alert on
+RATELIMIT_ALERT_EMAILS = ["ops@example.com"]
+RATELIMIT_ALERT_WEBHOOK = "https://hooks.example.com/ratelimit"
+```
+
+`RATELIMIT_ALERT_THRESHOLD` gates everything: with no threshold set (and no
+`--threshold` passed) alerting is disabled and nothing is sent. Email uses
+Django's configured mail backend (and `DEFAULT_FROM_EMAIL`); the webhook
+receives a `POST` with a JSON body.
+
+Alert dispatch is **best-effort**: a failing channel is logged and reported in
+the result, never raised.
+
+### The `ratelimit_alerts` command (cron)
+
+Run the check on a schedule (cron or Celery beat). It defaults to the
+look-back window of 1 day and reads the threshold/channels from settings when
+the flags are omitted:
+
+```bash
+# Use RATELIMIT_ALERT_THRESHOLD and the configured channels, last 1 day.
+python manage.py ratelimit_alerts
+
+# Explicit threshold and window.
+python manage.py ratelimit_alerts --threshold 100 --days 1
+
+# Preview matching offenders without sending anything.
+python manage.py ratelimit_alerts --threshold 100 --dry-run
+```
+
+Example crontab entry (every 5 minutes):
+
+```cron
+*/5 * * * * /path/to/venv/bin/python /path/to/manage.py ratelimit_alerts >> /var/log/ratelimit_alerts.log 2>&1
+```
+
+### Programmatic API
+
+The same logic is available as functions:
+
+```python
+from django_smart_ratelimit.analytics import (
+    find_alertable_offenders,
+    send_offender_alerts,
+)
+
+# Offenders whose blocked count over the window is >= threshold.
+find_alertable_offenders(threshold=100, days=1, limit=100)
+# [{"key": "ip:203.0.113.5", "blocked_count": 412}]
+
+# Find offenders over the threshold and dispatch alerts. Arguments fall back
+# to RATELIMIT_ALERT_THRESHOLD / RATELIMIT_ALERT_EMAILS / RATELIMIT_ALERT_WEBHOOK.
+result = send_offender_alerts(threshold=100, days=1)
+# {
+#   "enabled": True,
+#   "threshold": 100,
+#   "days": 1,
+#   "offenders": [...],
+#   "channels": {"email": {"sent": True, "to": ["ops@example.com"]}},
+# }
+```
+
+When alerting is disabled (no threshold), `send_offender_alerts()` returns
+`{"enabled": False, "offenders": [], "channels": {}}` without doing any work.
+You can also override the channels per call with the `email_to` and
+`webhook_url` keyword arguments.
+
+## Retention / cleanup
+
+One row per request adds up fast, so prune old events on a schedule.
+`RateLimitEvent.cleanup_old()` deletes events older than a cutoff (in batches)
+and returns the number deleted:
+
+```python
+from django_smart_ratelimit.models import RateLimitEvent
+
+# Delete events older than 30 days (the default).
+deleted = RateLimitEvent.cleanup_old(older_than_days=30)
+
+# Shorter retention, smaller delete batches.
+RateLimitEvent.cleanup_old(older_than_days=7, batch_size=500)
+```
+
+Schedule it from cron or Celery beat, for example via a tiny management command
+or a `manage.py shell -c` invocation:
+
+```cron
+0 3 * * * /path/to/venv/bin/python /path/to/manage.py shell -c "from django_smart_ratelimit.models import RateLimitEvent; RateLimitEvent.cleanup_old(older_than_days=30)"
+```
+
+> **Note:** the `ratelimit_cleanup` management command prunes the rate-limit
+> *state* tables (counters, sliding-window entries, token/leaky buckets) — it
+> does **not** touch `RateLimitEvent`. Use `RateLimitEvent.cleanup_old()` to
+> prune the analytics log.
+
+## See Also
+
+- [Observability](observability.md) — OpenTelemetry and Prometheus integrations
+  for real-time metrics (complementary to this historical event log).
+- [Configuration](configuration.md) — all `RATELIMIT_*` settings.
+- [Deployment](deployment.md) — running scheduled jobs in production.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -253,6 +253,41 @@ RATELIMIT_ENABLE = True
 > The middleware reads `SKIP_PATHS` (not `excluded_paths`) and the top-level
 > `RATELIMIT_ENABLE` setting (not a `'enabled'` key inside `RATELIMIT_MIDDLEWARE`).
 
+## Advanced feature settings (v4.x)
+
+These are all opt-in and default to off. Each links to a dedicated guide.
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `RATELIMIT_USE_DYNAMIC_RULES` | `False` | Enable database-backed [dynamic rules](dynamic_rules.md). |
+| `RATELIMIT_RULE_CACHE_TIMEOUT` | `60` | Seconds to cache dynamic rules before reloading. |
+| `RATELIMIT_USE_USER_TIERS` | `False` | Enable [user tiers / overrides](user_tiers.md) in the middleware and decorator. |
+| `RATELIMIT_LOG_EVENTS` | `False` | Record a `RateLimitEvent` per decision for [analytics](analytics.md). |
+| `RATELIMIT_GEOIP_PATH` | `None` | Path to a GeoLite2/GeoIP2 `.mmdb` for [geographic limiting](geographic.md). |
+| `RATELIMIT_ALERT_THRESHOLD` | unset | Min blocked requests before an [offender alert](analytics.md) fires. |
+| `RATELIMIT_ALERT_EMAILS` | unset | Recipient list for offender email alerts. |
+| `RATELIMIT_ALERT_WEBHOOK` | unset | Webhook URL for offender alerts (POSTed JSON). |
+| `RATELIMIT_STATSD` | `{}` | StatsD exporter config (`ENABLED`/`HOST`/`PORT`/`PREFIX`); see [Observability](observability.md). |
+
+```python
+# settings.py — example: dynamic rules + user tiers + event logging
+RATELIMIT_USE_DYNAMIC_RULES = True
+RATELIMIT_RULE_CACHE_TIMEOUT = 60
+RATELIMIT_USE_USER_TIERS = True
+RATELIMIT_LOG_EVENTS = True
+
+# Geographic limiting
+RATELIMIT_GEOIP_PATH = "/var/lib/GeoIP/GeoLite2-City.mmdb"
+
+# Offender alerting (run `manage.py ratelimit_alerts` from cron)
+RATELIMIT_ALERT_THRESHOLD = 500
+RATELIMIT_ALERT_EMAILS = ["secops@example.com"]
+RATELIMIT_ALERT_WEBHOOK = "https://hooks.example.com/ratelimit"
+
+# StatsD / DogStatsD metrics
+RATELIMIT_STATSD = {"ENABLED": True, "HOST": "127.0.0.1", "PORT": 8125}
+```
+
 ## Custom Configuration
 
 You can add custom configuration values using the `RATELIMIT_CONFIG_` prefix:

--- a/docs/database_backend.md
+++ b/docs/database_backend.md
@@ -1,0 +1,225 @@
+# Database Backend
+
+The database backend stores rate-limit state in your SQL database using
+Django's ORM, so you can rate limit without running Redis. It works on
+PostgreSQL, MySQL, and SQLite, and uses database-level locking to keep the
+sliding-window algorithm correct under concurrency.
+
+It is implemented by `django_smart_ratelimit.backends.database.DatabaseBackend`
+and registered under the short name `database`.
+
+## When to Use It
+
+Prefer the database backend when:
+
+- You do not want to operate a separate Redis/memcached service, and your
+  database already has spare capacity.
+- Your traffic is low-to-moderate and you value operational simplicity over
+  raw throughput.
+- You want rate-limit state to live in the same transactional store as the
+  rest of your data.
+
+Prefer Redis (`RATELIMIT_BACKEND = "redis"`) when:
+
+- You have high request volume. The sliding-window algorithm writes one row
+  per request (`RateLimitEntry`), which is expensive on a SQL database.
+- Latency matters and you want to keep this load off your primary database.
+
+For high-throughput sliding-window limiting, Redis is the recommended backend.
+
+## Setup
+
+### 1. Add the app and run migrations
+
+The backend's tables ship as migrations in the `django_smart_ratelimit` app,
+so it must be in `INSTALLED_APPS`:
+
+```python
+# settings.py
+INSTALLED_APPS = [
+    # ...
+    "django_smart_ratelimit",
+]
+```
+
+```bash
+python manage.py migrate
+```
+
+This creates four tables:
+
+- `ratelimit_counter` (`RateLimitCounter`) — fixed-window counters.
+- `ratelimit_entry` (`RateLimitEntry`) — one row per request, for sliding window.
+- `ratelimit_token_bucket` (`RateLimitTokenBucket`) — token-bucket state.
+- `ratelimit_leaky_bucket` (`RateLimitLeakyBucket`) — leaky-bucket state.
+
+### 2. Select the backend
+
+```python
+# settings.py
+RATELIMIT_BACKEND = "database"
+```
+
+The decorator and middleware now use the database backend automatically. No
+other code changes are required.
+
+## Choosing an Algorithm
+
+The backend supports four algorithms:
+
+- `fixed_window` — counts requests in a clock-aligned window
+  (`RateLimitCounter`).
+- `sliding_window` — counts requests in a rolling window by storing a row per
+  request (`RateLimitEntry`).
+- `token_bucket` — token-bucket limiting (`RateLimitTokenBucket`), via
+  `token_bucket_check()`.
+- `leaky_bucket` — leaky-bucket limiting (`RateLimitLeakyBucket`), via
+  `leaky_bucket_check()`.
+
+The algorithm used for `incr()` / `check_rate_limit()` (what the decorator and
+middleware call) is `fixed_window` or `sliding_window`. Pass the algorithm to
+the backend through `RATELIMIT_BACKEND_CONFIG`:
+
+```python
+# settings.py
+RATELIMIT_BACKEND = "database"
+RATELIMIT_BACKEND_CONFIG = {
+    "algorithm": "sliding_window",  # or "fixed_window"
+}
+```
+
+Other keys accepted by `RATELIMIT_BACKEND_CONFIG` (forwarded to
+`DatabaseBackend.__init__`):
+
+```python
+RATELIMIT_BACKEND_CONFIG = {
+    "algorithm": "fixed_window",
+    "fail_open": False,             # allow requests if the DB errors
+    "cleanup_interval": 300,        # seconds between background cleanup runs
+    "batch_cleanup_size": 1000,     # rows deleted per cleanup batch
+    "enable_background_cleanup": True,
+}
+```
+
+## Concurrency and Atomicity
+
+Fixed-window counters and the token/leaky buckets use
+`select_for_update()` inside a transaction, so concurrent increments for the
+same key are serialized by row locks.
+
+The sliding-window algorithm needs extra care: its "insert a row, then count
+the rows in the window" sequence is not atomic under `READ COMMITTED` (the
+PostgreSQL and MySQL/InnoDB default), where two in-flight transactions can each
+miss the other's not-yet-committed insert and both be admitted. To make it
+atomic, the backend takes a per-key lock before the insert-and-count:
+
+- **PostgreSQL** — a transaction-scoped advisory lock
+  (`pg_advisory_xact_lock`), released automatically on commit or rollback.
+- **MySQL** — a session-scoped named lock (`GET_LOCK` / `RELEASE_LOCK`),
+  acquired around the transaction and released explicitly.
+- **SQLite** — already serializes writers, so no extra lock is needed.
+
+This matters for security-sensitive limits (for example, login throttling),
+where a bypass would let the limit be exceeded by the number of concurrent
+requests.
+
+## Cleaning Up Expired Rows
+
+Expired counters and entries (and stale buckets) accumulate over time. There
+are two ways to remove them.
+
+### Background cleanup (automatic)
+
+By default the backend starts a daemon thread that calls `cleanup_expired()`
+every `cleanup_interval` seconds (300 by default). This is convenient for
+single-process deployments but is per-process and best-effort. For anything
+beyond development, run the management command on a schedule instead and turn
+the thread off:
+
+```python
+RATELIMIT_BACKEND_CONFIG = {
+    "algorithm": "sliding_window",
+    "enable_background_cleanup": False,
+}
+```
+
+### `ratelimit_cleanup` management command
+
+The `ratelimit_cleanup` command deletes, in batches: expired counters
+(by `window_end`), expired sliding-window entries (by `expires_at`), and stale
+token/leaky buckets (not updated within `--stale-days`).
+
+```bash
+# Delete all expired/stale records
+python manage.py ratelimit_cleanup
+
+# Preview without deleting anything
+python manage.py ratelimit_cleanup --dry-run
+
+# Smaller batches to reduce lock contention on a large table
+python manage.py ratelimit_cleanup --batch-size=500
+
+# Treat buckets unused for 14 days as stale (default: 7)
+python manage.py ratelimit_cleanup --stale-days=14
+
+# Machine-readable output for monitoring
+python manage.py ratelimit_cleanup --json
+
+# Detailed per-batch progress
+python manage.py ratelimit_cleanup --verbose
+```
+
+`--batch-size` must be a positive integer; the command errors otherwise.
+
+#### Scheduling it
+
+Run it periodically. With cron, for example every five minutes:
+
+```cron
+*/5 * * * * cd /path/to/project && /path/to/venv/bin/python manage.py ratelimit_cleanup >> /var/log/ratelimit_cleanup.log 2>&1
+```
+
+With Celery beat:
+
+```python
+# settings.py
+from celery.schedules import crontab
+
+CELERY_BEAT_SCHEDULE = {
+    "ratelimit-cleanup": {
+        "task": "myapp.tasks.ratelimit_cleanup",
+        "schedule": crontab(minute="*/5"),
+    },
+}
+```
+
+```python
+# myapp/tasks.py
+from celery import shared_task
+from django.core.management import call_command
+
+
+@shared_task
+def ratelimit_cleanup():
+    call_command("ratelimit_cleanup", batch_size=1000)
+```
+
+## Inspecting State
+
+`DatabaseBackend` exposes helpers for monitoring and health checks:
+
+```python
+from django_smart_ratelimit.backends.factory import BackendFactory
+
+backend = BackendFactory.create_backend("database")
+
+backend.get_stats()      # active record counts, algorithm, database vendor, last cleanup
+backend.health_check()   # {"status": "healthy"|"unhealthy", "response_time": ..., ...}
+```
+
+You can also query the models directly, for example to read the current count
+for a key:
+
+```python
+from django_smart_ratelimit.models import RateLimitCounter, RateLimitEntry
+```

--- a/docs/dynamic_rules.md
+++ b/docs/dynamic_rules.md
@@ -1,0 +1,206 @@
+# Dynamic Rate-Limit Rules
+
+Dynamic rules let you define and change rate limits at runtime, from the Django
+admin or the ORM, without editing settings or redeploying. Rules are stored in
+the database as `RateLimitRule` rows. When the rate-limit middleware handles a
+request, it matches the request against the active rules and, if one matches,
+uses that rule's `rate`, `key`, and `block` instead of the static
+`RATELIMIT_MIDDLEWARE` configuration.
+
+This is a middleware feature: it applies to requests flowing through
+`RateLimitMiddleware`. It does not change the behavior of the `@rate_limit`
+decorator.
+
+## Setup
+
+### 1. Add the app and run migrations
+
+`RateLimitRule` is a Django model, so the app must be installed and its
+migrations applied.
+
+```python
+# settings.py
+INSTALLED_APPS = [
+    # ...
+    "django_smart_ratelimit",
+]
+
+MIDDLEWARE = [
+    # ...
+    "django_smart_ratelimit.middleware.RateLimitMiddleware",
+]
+```
+
+```bash
+python manage.py migrate
+```
+
+### 2. Enable dynamic rules
+
+Dynamic rules are off by default. Turn them on with a single setting:
+
+```python
+# settings.py
+RATELIMIT_USE_DYNAMIC_RULES = True
+
+# Optional: how long (seconds) the active rule set is cached. Default 60.
+RATELIMIT_RULE_CACHE_TIMEOUT = 60
+
+# The middleware still needs its normal config; matching rules override it.
+RATELIMIT_MIDDLEWARE = {
+    "BACKEND": "redis",
+    "DEFAULT_RATE": "1000/m",
+}
+```
+
+With `RATELIMIT_USE_DYNAMIC_RULES = False` (the default), the middleware never
+queries the rule table and behaves exactly as before.
+
+## Defining a rule
+
+You can create rules in the Django admin (the `RateLimitRule` admin is
+registered automatically when the app is installed) or directly via the ORM.
+
+```python
+from django_smart_ratelimit.models import RateLimitRule
+
+RateLimitRule.objects.create(
+    name="api-strict",
+    path_pattern=r"^/api/",   # regex matched against request.path
+    method="ALL",             # or "GET,POST"
+    rate="2/m",               # 2 requests per minute
+    key="ip",                 # ip | user | header:X-API-Key
+    algorithm="fixed_window",
+    block=True,
+    priority=10,
+    is_active=True,
+)
+```
+
+### Fields
+
+| Field          | Type   | Default          | Description                                                                                                                |
+| :------------- | :----- | :--------------- | :------------------------------------------------------------------------------------------------------------------------- |
+| `name`         | str    | required, unique | Identifier for the rule. Also used in the rate-limit key (`rule:<name>:...`) and in recorded events.                       |
+| `description`  | str    | `""`             | Free-text note for operators.                                                                                              |
+| `path_pattern` | str    | required         | A regular expression matched against `request.path` with `re.search`, e.g. `^/api/`. Validated at save time.               |
+| `method`       | str    | `"ALL"`          | `ALL`, or a comma-separated list of HTTP methods such as `GET,POST`. Case-insensitive.                                     |
+| `rate`         | str    | required         | Rate string such as `100/m`, `1000/h`, or `10/30s`. Validated at save time.                                                |
+| `key`          | str    | `"ip"`           | Per-client key: `ip`, `user` (falls back to IP for anonymous users), or `header:<Header-Name>` such as `header:X-API-Key`. |
+| `algorithm`    | str    | `"fixed_window"` | One of `fixed_window`, `sliding_window`, `token_bucket`, `leaky_bucket`.                                                    |
+| `block`        | bool   | `True`           | When `True`, requests over the limit get a `429`. When `False`, the limit is counted but not enforced.                     |
+| `is_active`    | bool   | `True`           | Only active rules are loaded and matched. Inactive rules are ignored.                                                      |
+| `priority`     | int    | `0`              | Higher priority wins when several rules match the same request.                                                            |
+
+Both the admin save and `RateLimitRule.save()` run `full_clean()`, so an invalid
+`rate` string or an invalid `path_pattern` regex raises a `ValidationError`
+before the row is written.
+
+## How matching and priority work
+
+For each request, the middleware asks the rule engine for the single
+highest-priority active rule that matches. A rule matches when:
+
+1. `re.search(rule.path_pattern, request.path)` finds a match, and
+2. the request's HTTP method is in `rule.method` (or the rule's method is `ALL`).
+
+Active rules are ordered by `-priority` then `name`, so when several rules match
+the same request, the one with the highest `priority` is applied. If no rule
+matches, the request falls back to the static middleware configuration.
+
+```python
+RateLimitRule.objects.create(name="lo", path_pattern="^/api/", rate="9/m", priority=1)
+RateLimitRule.objects.create(name="hi", path_pattern="^/api/", rate="1/m", priority=9)
+# A GET /api/x request matches both; "hi" (priority 9) is applied -> 1/m.
+```
+
+## Overriding static config
+
+When dynamic rules are enabled and a rule matches, that rule fully determines
+the limit for the request: its `rate`, its `block` flag, and a key derived from
+its `key` field. This overrides whatever the static `RATE_LIMITS` /
+`DEFAULT_RATE` settings would have produced.
+
+```python
+# settings.py
+RATELIMIT_USE_DYNAMIC_RULES = True
+RATELIMIT_MIDDLEWARE = {"BACKEND": "memory", "DEFAULT_RATE": "1000/m"}
+```
+
+```python
+# A rule scoped to /api/ at 2/m.
+RateLimitRule.objects.create(
+    name="api-strict", path_pattern=r"^/api/", rate="2/m", key="ip", priority=10
+)
+```
+
+With the rule above, requests to `/api/...` are limited to `2/m` (the rule
+wins), while requests to any other path still use the static `DEFAULT_RATE` of
+`1000/m` (no rule matches, so the fallback applies).
+
+Each rule gets its own counter namespace: the key the middleware uses is
+`rule:<name>:<client>`, where `<client>` is the IP, `user:<pk>`, or the header
+value, according to the rule's `key`. So two rules with overlapping path
+patterns count independently.
+
+## Caching and invalidation
+
+Loading every active rule from the database on every request would be expensive,
+so the rule engine caches the active rule set in process memory. The cache TTL
+is `RATELIMIT_RULE_CACHE_TIMEOUT` seconds (default `60`).
+
+Edits made through the ORM or the admin take effect immediately: the app wires
+Django `post_save` and `post_delete` signals on `RateLimitRule` (from
+`AppConfig.ready()`) so that saving or deleting a rule invalidates the cache.
+The TTL is the upper bound on staleness for changes that bypass those signals
+(for example a bulk `UPDATE` run directly against the database, or an edit made
+in a different process/worker).
+
+```python
+# Editing a rule at runtime takes effect on the next request in this process.
+rule = RateLimitRule.objects.get(name="api-strict")
+rule.rate = "10/m"
+rule.save()   # post_save signal invalidates the cache
+```
+
+If you need to drop the cache by hand:
+
+```python
+from django_smart_ratelimit.rules import rule_engine
+
+rule_engine.invalidate_cache()
+```
+
+## Reloading rules manually
+
+After a change that bypasses the model signals (a bulk DB import, a raw SQL
+update, or an edit applied in another worker), invalidate the cache in this
+process with the management command:
+
+```bash
+python manage.py ratelimit_reload_rules
+```
+
+It invalidates the rule cache so the next request reloads from the database, and
+reports how many active rules there are:
+
+```
+Rate-limit rule cache reloaded (3 active rule(s)).
+```
+
+Note that, like the in-process cache itself, this affects only the process it
+runs in. With multiple workers, rely on the per-process signal invalidation and
+the `RATELIMIT_RULE_CACHE_TIMEOUT` TTL for changes to propagate everywhere, or
+run the command (or restart) per worker.
+
+## Managing rules in the admin
+
+The `RateLimitRule` admin is registered automatically. It lists `name`,
+`path_pattern`, `method`, `rate`, `key`, `algorithm`, `is_active`, and
+`priority`, with `is_active` and `priority` editable inline. It also provides
+two bulk actions, **Enable selected rules** and **Disable selected rules**,
+which save each rule individually so the cache is invalidated.
+
+The admin also exposes a read-only **Rate Limit Counter** view
+(`RateLimitCounter`) for inspecting live fixed-window counters; these rows are
+created by the limiter and cannot be added or edited by hand.

--- a/docs/geographic.md
+++ b/docs/geographic.md
@@ -1,0 +1,187 @@
+# Geographic Rate Limiting
+
+`django-smart-ratelimit` can bucket and limit requests by the client's
+country, resolved from the request IP. This is useful for applying different
+quotas per region, or for keying a single shared limit by country.
+
+Geolocation is a thin provider abstraction over MaxMind's GeoIP2/GeoLite2
+databases. It is entirely optional: without the `geoip2` package and a
+configured database, country resolution returns `None` (`"unknown"`) and the
+API still imports and runs, so you can leave the calls in your code
+unconditionally.
+
+The public API lives in `django_smart_ratelimit.geo`.
+
+## Installation
+
+Install the optional `geoip` extra, which pulls in `geoip2`:
+
+```bash
+pip install "django-smart-ratelimit[geoip]"
+```
+
+You also need a country (or city) database in MaxMind's `.mmdb` format.
+Download a free **GeoLite2-City** or **GeoLite2-Country** database from MaxMind
+(a free account is required), or use a commercial GeoIP2 database. Both are
+read with the same `geoip2.database.Reader`.
+
+## Configuration
+
+Point the library at your `.mmdb` file with the `RATELIMIT_GEOIP_PATH`
+setting:
+
+```python
+# settings.py
+RATELIMIT_GEOIP_PATH = "/var/lib/GeoIP/GeoLite2-City.mmdb"
+```
+
+When this setting is present and loadable, the library uses a
+`MaxMindProvider`. When it is unset (or the file/package is missing), it falls
+back to a `NullGeoProvider` that resolves nothing. The provider is resolved
+once and cached, so the database is opened a single time per process.
+
+## Keying requests by country
+
+`geo_key` is a key function suitable for the decorator's `key` argument. It
+returns `geo:<CC>` using the ISO 3166-1 alpha-2 country code (e.g. `geo:US`),
+or `geo:unknown` when the country cannot be resolved.
+
+```python
+from django_smart_ratelimit import rate_limit
+from django_smart_ratelimit.geo import geo_key
+
+
+@rate_limit(key=geo_key, rate="1000/h")
+def public_api(request):
+    ...
+```
+
+All requests from the same country share one bucket. Note that this is a
+single global limit per country, not a per-user limit; combine it with a
+narrower key if you want per-client limits within a region.
+
+## Resolving the country directly
+
+If you only need the country code, call `get_country`. It accepts either a
+request object or a raw IP string and returns the ISO code or `None`:
+
+```python
+from django_smart_ratelimit.geo import get_country
+
+get_country(request)       # -> "US" (or None)
+get_country("8.8.8.8")     # -> "US" (or None)
+```
+
+## Per-country rate selection
+
+`get_rate_for_country` picks a rate string for a country from a mapping,
+falling back to a default. The mapping is keyed by ISO code and maps to rate
+strings like `"1000/h"`:
+
+```python
+from django_smart_ratelimit.geo import get_country, get_rate_for_country
+
+COUNTRY_RATES = {
+    "US": "1000/h",
+    "CN": "100/h",
+    "*": "500/h",   # wildcard: any country not listed above
+}
+
+
+def country_rate(request):
+    country = get_country(request)
+    return get_rate_for_country(country, COUNTRY_RATES, default_rate="200/h")
+```
+
+The lookup rules are:
+
+- If `country` is set and present in the mapping, its rate is returned.
+- Otherwise, if the mapping contains a `"*"` entry, that wildcard rate is used.
+- Otherwise, `default_rate` is returned.
+
+So with the mapping above, `"DE"` resolves to the wildcard `"500/h"`, while an
+unknown country (`None`) with a mapping that has no `"*"` falls through to
+`default_rate`.
+
+You can feed this into the decorator by computing the rate at request time —
+for example by composing `geo_key` for the key and a small wrapper that selects
+the rate, or by enforcing the limit yourself in a view using your preferred
+backend.
+
+## The provider abstraction
+
+Country resolution goes through a `GeoProvider`:
+
+```python
+from django_smart_ratelimit.geo import GeoProvider, GeoLocation
+
+
+class GeoProvider:
+    def lookup(self, ip: str) -> GeoLocation: ...
+```
+
+`GeoLocation` is a dataclass with `country`, `region`, and `city` fields, any
+of which may be `None`:
+
+```python
+GeoLocation(country="US", region="CA", city="Mountain View")
+```
+
+Two implementations ship with the library:
+
+- **`MaxMindProvider(db_path)`** — opens the `.mmdb` at `db_path` and looks up
+  city/country data via `geoip2`. Constructing it raises
+  `django.core.exceptions.ImproperlyConfigured` if `geoip2` is not installed.
+  Any failed or invalid lookup returns an empty `GeoLocation()` rather than
+  raising.
+- **`NullGeoProvider`** — always returns an empty `GeoLocation()`. This is the
+  fallback when `RATELIMIT_GEOIP_PATH` is unset, the database cannot be loaded,
+  or `geoip2` is missing. With it, `get_country` returns `None` and `geo_key`
+  returns `geo:unknown`.
+
+`get_geo_provider()` returns the active, cached provider:
+
+```python
+from django_smart_ratelimit.geo import get_geo_provider
+
+provider = get_geo_provider()   # MaxMindProvider or NullGeoProvider
+```
+
+## Overriding the provider (tests)
+
+Use `set_geo_provider` to swap in your own provider, which is handy for tests
+that should not depend on a real database. Pass `None` to reset back to the
+cached default.
+
+```python
+from django_smart_ratelimit.geo import (
+    GeoLocation,
+    GeoProvider,
+    geo_key,
+    set_geo_provider,
+)
+
+
+class FakeGeo(GeoProvider):
+    def lookup(self, ip):
+        return GeoLocation(country="CN" if ip.startswith("1.") else "US")
+
+
+def test_geo_key():
+    set_geo_provider(FakeGeo())
+    try:
+        assert geo_key(make_request(ip="8.8.8.8")) == "geo:US"
+        assert geo_key(make_request(ip="1.2.3.4")) == "geo:CN"
+    finally:
+        set_geo_provider(None)   # reset the cached provider
+```
+
+## Notes
+
+- Country resolution depends on the client IP. The IP is taken from the same
+  trusted-proxy / forwarded-header logic as the rest of the library, so make
+  sure `RATELIMIT_TRUSTED_PROXIES` / `RATELIMIT_TRUST_FORWARDED_HEADERS` are
+  configured correctly behind a proxy or CDN. See
+  [Configuration](configuration.md).
+- GeoIP lookups are best-effort: private, reserved, or unrecognized addresses
+  resolve to `unknown`, and your limits should treat that bucket sensibly.

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -1,0 +1,184 @@
+# GraphQL Rate Limiting
+
+`django-smart-ratelimit` can rate-limit GraphQL operations for both
+[Graphene](https://graphene-python.org/) and
+[Strawberry](https://strawberry.rocks/). It plugs in as a Graphene *middleware*
+or a Strawberry *schema extension*, reuses your configured backend, and can
+optionally weight the limit by query complexity so that expensive queries
+consume more of the allowance.
+
+Everything lives in `django_smart_ratelimit.graphql`. Graphene and Strawberry
+are optional: the module imports nothing from either at load time, so it is safe
+to import without them installed. The Strawberry extension imports Strawberry
+lazily, only when you build it.
+
+## Installation
+
+The Graphene middleware needs Graphene:
+
+```bash
+pip install "django-smart-ratelimit[graphql]"
+```
+
+This pulls in `graphene>=3.0`. For Strawberry, install
+[`strawberry-graphql`](https://strawberry.rocks/) yourself — it is not part of
+the `graphql` extra. If you call `make_strawberry_extension()` without
+Strawberry installed, it raises `django.core.exceptions.ImproperlyConfigured`.
+
+## Graphene
+
+Add `GrapheneRateLimitMiddleware` to the `middleware` list you pass to
+`schema.execute()`:
+
+```python
+from django_smart_ratelimit.graphql import GrapheneRateLimitMiddleware
+
+result = schema.execute(
+    query,
+    context=request,
+    middleware=[GrapheneRateLimitMiddleware(rate="100/m")],
+)
+```
+
+`GrapheneRateLimitMiddleware` accepts:
+
+- `rate` — the limit string in `count/period` form (default `"60/m"`), e.g.
+  `"100/m"`, `"1000/h"`. Periods are the same ones used everywhere else in the
+  library (`s`, `m`, `h`, `d`).
+- `key` — an optional callable `request -> str` that produces the limiter key.
+  If omitted, the client IP is used (`django_smart_ratelimit.key_functions.get_ip_key`,
+  which respects your proxy-trust settings).
+- `complexity_cost` — `bool`, default `False`. When `True`, each operation is
+  charged `estimate_query_complexity(query)` instead of `1`. See below.
+
+### Only top-level operations are limited
+
+The middleware checks the limit once per operation, on the top-level resolver
+(`root is None`). Nested field resolvers are passed straight through and never
+counted, so a query that selects many fields still costs a single increment (or
+a single complexity-weighted increment). This keeps the count proportional to
+the number of operations a client sends, not the number of resolvers Graphene
+happens to invoke.
+
+### Per-user keys
+
+```python
+from django_smart_ratelimit.graphql import GrapheneRateLimitMiddleware
+
+
+def user_or_ip(request):
+    user = getattr(request, "user", None)
+    if user is not None and user.is_authenticated:
+        return f"user:{user.pk}"
+    from django_smart_ratelimit.key_functions import get_ip_key
+
+    return get_ip_key(request)
+
+
+middleware = [GrapheneRateLimitMiddleware(rate="200/m", key=user_or_ip)]
+```
+
+The `request` handed to your `key` function is taken from the execution
+context: Graphene's `info.context` is the Django request itself.
+
+### Handling the limit
+
+When an operation is denied, the middleware raises
+`GraphQLRateLimitExceeded`:
+
+```python
+from django_smart_ratelimit.graphql import GraphQLRateLimitExceeded
+
+try:
+    result = schema.execute(query, context=request, middleware=[...])
+except GraphQLRateLimitExceeded:
+    ...  # return a 429 or a GraphQL error to the client
+```
+
+Graphene surfaces resolver exceptions in `result.errors`, so depending on how
+you run the schema you may also find the message
+`"GraphQL rate limit exceeded. Try again later."` there.
+
+## Strawberry
+
+Build a schema extension with `make_strawberry_extension(rate, key)` and pass it
+to your `strawberry.Schema`:
+
+```python
+import strawberry
+
+from django_smart_ratelimit.graphql import make_strawberry_extension
+
+schema = strawberry.Schema(
+    query=Query,
+    extensions=[make_strawberry_extension("100/m")],
+)
+```
+
+`make_strawberry_extension` takes the same `rate` (default `"60/m"`) and
+optional `key` callable as the Graphene middleware, and returns a Strawberry
+`SchemaExtension` subclass. The extension runs `on_operation`, checking the
+limit once per operation and raising `GraphQLRateLimitExceeded` when it is
+exceeded.
+
+Strawberry exposes the Django request on the context, so the `key` callable
+receives the request whether your context is the request directly or an object
+with a `.request` attribute.
+
+```python
+def by_tenant(request):
+    return f"tenant:{request.headers.get('X-Tenant-ID', 'default')}"
+
+
+schema = strawberry.Schema(
+    query=Query,
+    extensions=[make_strawberry_extension("500/m", key=by_tenant)],
+)
+```
+
+> Note: the Strawberry extension applies a flat per-operation cost. Complexity
+> weighting is currently available through the Graphene middleware only.
+
+## Complexity-weighted limiting
+
+`estimate_query_complexity(query)` returns a cheap, dependency-free estimate of
+how expensive a query is. It counts the field-like identifiers in the query
+(ignoring keywords such as `query`, `mutation`, `fragment`, `on`, `true`,
+`false`, `null`) and adds a surcharge for nesting depth. The result is always at
+least `1`; an empty string returns `1`.
+
+```python
+from django_smart_ratelimit.graphql import estimate_query_complexity
+
+estimate_query_complexity("{ user { id } }")                 # small
+estimate_query_complexity("query { a { b { c d } } posts { t } }")  # larger
+```
+
+Enable complexity weighting on the Graphene middleware so deep or wide queries
+draw down the limit faster than trivial ones:
+
+```python
+from django_smart_ratelimit.graphql import GrapheneRateLimitMiddleware
+
+middleware = [
+    GrapheneRateLimitMiddleware(rate="1000/m", complexity_cost=True),
+]
+```
+
+With `complexity_cost=True`, the cost charged for an operation is the estimated
+complexity of its query rather than `1`. A `rate` of `"1000/m"` therefore means
+"up to 1000 units of query complexity per minute" — a client can run many cheap
+queries or fewer expensive ones, but not an unbounded number of large nested
+queries.
+
+You can also use `estimate_query_complexity` on its own to reject queries that
+exceed a hard ceiling before they ever execute.
+
+## Backend and keys
+
+GraphQL limiting uses the same backend as the rest of the library (configured
+via `RATELIMIT_BACKEND`); no extra configuration is required. Keys are stored
+under a `graphql:` prefix, so they share a namespace with neither the decorator
+nor the DRF integration. The default IP-based key honors
+`RATELIMIT_TRUSTED_PROXIES` / `RATELIMIT_TRUST_FORWARDED_HEADERS` just like the
+rest of the project.

--- a/docs/multi_tenant.md
+++ b/docs/multi_tenant.md
@@ -1,0 +1,175 @@
+# Multi-Tenant Rate Limiting
+
+In a multi-tenant (SaaS) application every request belongs to a tenant, and you
+usually want to give each tenant its own rate budget rather than a single global
+one. The `django_smart_ratelimit.tenants` module resolves a tenant id from the
+request, exposes a `tenant_key` key function so all of a tenant's traffic shares
+one bucket, and resolves a per-tenant rate from the optional `TenantQuota` model.
+
+It is designed to compose with [django-tenants](https://django-tenants.readthedocs.io/)
+(which sets `request.tenant`) but does not require it — the resolver also reads a
+header, the authenticated user, or the Host subdomain.
+
+```python
+from django_smart_ratelimit import tenants
+```
+
+## Tenant resolution
+
+`extract_tenant(request)` returns the tenant id as a string, or `None` when no
+source matches. Sources are tried in this fixed order, and the first match wins:
+
+1. **`request.tenant`** — the model instance django-tenants attaches to the
+   request. Its `schema_name` is used, falling back to its `pk`, then its
+   `str()`.
+2. **`X-Tenant-ID` header** — read from `request.headers`.
+3. **`request.user.tenant_id`** — only for authenticated users, when the user
+   model carries a `tenant_id` attribute.
+4. **Host subdomain** — the first label of the Host header when it has at least
+   three labels (`acme.example.com` -> `acme`). The port is stripped first.
+
+```python
+from django_smart_ratelimit import tenants
+
+tenants.extract_tenant(request)   # -> "acme", or None if nothing matches
+```
+
+A bare domain with no subdomain (`example.com`) and an unauthenticated request
+with no header both resolve to `None`.
+
+## tenant_key as a key function
+
+`tenant_key` is a key function with the standard `(request, *args, **kwargs)`
+signature, so you can pass it directly to the `@rate_limit` decorator or to a
+backend call. It buckets every request by its tenant as `tenant:<id>`, and falls
+back to `tenant:default` when no tenant can be resolved.
+
+```python
+from django_smart_ratelimit import rate_limit, tenants
+
+@rate_limit(key=tenants.tenant_key, rate="1000/h")
+def api_view(request):
+    ...
+```
+
+```python
+tenants.tenant_key(request)   # "tenant:acme"  (or "tenant:default")
+```
+
+This gives every tenant the same limit. To give tenants *different* limits, see
+per-tenant quotas below.
+
+## Per-tenant quotas
+
+`TenantQuota` stores a rate string per tenant in the database, so you can change
+a tenant's budget at runtime without a redeploy.
+
+```python
+from django_smart_ratelimit.models import TenantQuota
+
+TenantQuota.objects.create(tenant_id="acme", rate="500/h")
+```
+
+Fields:
+
+| Field        | Type      | Notes                                                     |
+| :----------- | :-------- | :-------------------------------------------------------- |
+| `tenant_id`  | `str`     | Unique, indexed. Matches the value from `extract_tenant`. |
+| `rate`       | `str`     | Rate string, e.g. `"1000/h"`, `"100/m"`, `"10/30s"`.      |
+| `is_active`  | `bool`    | Defaults to `True`. Inactive quotas are ignored.          |
+| `created_at` | datetime  | Auto-set on creation.                                     |
+| `updated_at` | datetime  | Auto-updated on save.                                     |
+
+The `rate` string is validated on `save()` (via `full_clean()`), so an invalid
+value like `"nope"` raises `django.core.exceptions.ValidationError` before it
+ever reaches the database.
+
+### Resolving a tenant's rate
+
+`resolve_tenant_rate(request, default_rate)` extracts the tenant from the request,
+looks up its active quota, and returns that rate — or `default_rate` when the
+tenant has no active quota (or no tenant could be resolved).
+
+```python
+from django_smart_ratelimit import tenants
+
+# With TenantQuota(tenant_id="acme", rate="500/h") active:
+tenants.resolve_tenant_rate(request_for_acme, "100/m")   # -> "500/h"
+tenants.resolve_tenant_rate(request_no_tenant, "100/m")  # -> "100/m"
+```
+
+`get_tenant_quota(tenant_id)` is the lower-level lookup if you already have the
+id. It returns the active quota's rate string, or `None`:
+
+```python
+tenants.get_tenant_quota("acme")    # -> "500/h"
+tenants.get_tenant_quota("ghost")   # -> None  (no active quota)
+tenants.get_tenant_quota(None)      # -> None
+```
+
+### Applying per-tenant rates
+
+Because `resolve_tenant_rate` needs the request to pick the rate, combine it with
+`tenant_key` inside your own view or wrapper rather than as a static decorator
+argument. A simple pattern:
+
+```python
+from django.http import HttpResponse
+
+from django_smart_ratelimit import rate_limit, tenants
+
+
+def api_view(request):
+    rate = tenants.resolve_tenant_rate(request, "100/m")
+
+    @rate_limit(key=tenants.tenant_key, rate=rate)
+    def _limited(request):
+        return HttpResponse("ok")
+
+    return _limited(request)
+```
+
+`tenant_key` keeps each tenant in its own `tenant:<id>` bucket while
+`resolve_tenant_rate` decides how large that bucket is for the current tenant.
+
+## Composing with django-tenants
+
+When django-tenants is installed and its middleware runs, it attaches the active
+tenant model to `request.tenant`. Because that is the first source `extract_tenant`
+checks, no extra configuration is needed — `tenant_key` and `resolve_tenant_rate`
+pick up the django-tenants tenant automatically.
+
+Make sure the django-tenants middleware runs **before** any rate-limit middleware
+or view so that `request.tenant` is already set when the tenant is resolved. The
+`schema_name` of the tenant model is used as the id, so a `TenantQuota.tenant_id`
+should match the tenant's schema name:
+
+```python
+from django_smart_ratelimit.models import TenantQuota
+
+# tenant whose django-tenants schema_name is "acme"
+TenantQuota.objects.create(tenant_id="acme", rate="2000/h")
+```
+
+If django-tenants is not installed, nothing changes — resolution simply falls
+through to the header, user, and subdomain sources.
+
+## Admin
+
+`TenantQuota` is registered in the Django admin (via
+`django_smart_ratelimit.admin`), so operators can create and adjust quotas
+without code. The list view shows `tenant_id`, `rate`, `is_active`, and
+`updated_at`; `rate` and `is_active` are editable inline; and you can filter by
+`is_active` and search by `tenant_id`.
+
+Edits validate the `rate` string on save (the same `full_clean()` check as the
+ORM), so an invalid rate is rejected in the admin form.
+
+## See also
+
+- [Decorator](decorator.md) — passing a callable as the `key` argument.
+- [Utilities](utilities.md) — `get_tenant_key`, a separate key function that
+  reads a configurable user/header/query field and prefixes the per-user bucket
+  with the tenant id (distinct from this module's `tenant_key`).
+- [Observability](observability.md) — exporting check outcomes to your monitoring
+  stack.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -195,6 +195,50 @@ metrics.set_backend_health("redis", healthy=True)
 metrics.set_active_keys("redis", count=1_234)
 ```
 
+## StatsD
+
+For push-based monitoring (StatsD / DogStatsD / Datadog agent), a dependency-free
+UDP exporter mirrors the Prometheus API. It is fire-and-forget: network failures
+are swallowed and never affect request handling.
+
+### Configuration: RATELIMIT_STATSD
+
+```python
+# settings.py
+RATELIMIT_STATSD = {
+    "ENABLED": True,
+    "HOST": "127.0.0.1",
+    "PORT": 8125,
+    "PREFIX": "django_ratelimit",  # metric name prefix
+}
+```
+
+With `ENABLED` off (the default), the exporter is a no-op.
+
+### Emitted metrics
+
+`record_request()` emits a `requests` counter (tagged `backend` and
+`result=allowed|denied`), a `requests_denied` counter on denials, and a
+`request_duration` timer (milliseconds). Gauges are available for backend
+health, circuit-breaker state, and active key counts. DogStatsD-style
+`|#tag:value` tags are included.
+
+### Programmatic access
+
+```python
+from django_smart_ratelimit.statsd import get_statsd_metrics
+
+metrics = get_statsd_metrics()
+metrics.record_request("ip:1.2.3.4", backend="redis", allowed=False,
+                       duration_seconds=0.004)
+metrics.set_backend_health("redis", healthy=True)
+```
+
+> **Grafana:** scrape the Prometheus `/metrics` endpoint with a Prometheus data
+> source, or send StatsD metrics to a Datadog/Graphite source. The metric names
+> above (`*_requests`, `*_requests_denied`, `*_request_duration`) are what you
+> graph.
+
 ## See Also
 
 - [Decorator](decorator.md) — `shadow=True` for safe rollouts.

--- a/docs/user_tiers.md
+++ b/docs/user_tiers.md
@@ -1,0 +1,294 @@
+# User-Aware Rate Limiting
+
+`django-smart-ratelimit` can adjust a request's limit to the authenticated user
+behind it: a named **tier** (e.g. free / premium), the user's **Django groups**,
+a temporary **per-user override**, or the tier attached to an **API key**.
+
+When enabled, an authenticated user is limited at *their* effective rate and in
+their *own* bucket, so two users sharing a key (such as an IP) never compete for
+the same budget. Anonymous requests are unaffected and fall through to the base
+rate.
+
+This is the roadmap Phase 3 / v4.3.0 feature set; the `@rate_limit` decorator
+reached parity with the middleware in v4.6.0, which also added the `tier_key`
+key function and the `create_user_override` helper.
+
+## Enabling
+
+The feature is off by default. Turn it on with a single Django setting:
+
+```python
+# settings.py
+RATELIMIT_USE_USER_TIERS = True
+```
+
+This is read by both the middleware and the decorator. With it off, every
+symbol on this page still imports and runs, but limiting behaves exactly as it
+did before (no tier, override, or per-user bucketing is applied).
+
+The models live in the app, so make sure migrations are applied:
+
+```bash
+python manage.py migrate django_smart_ratelimit
+```
+
+All five models (`UserTier`, `UserTierAssignment`, `GroupRateLimit`,
+`UserRateLimitOverride`, `APIKey`) are registered in the Django admin, so most
+day-to-day management can happen there.
+
+## Precedence
+
+For an authenticated request, the effective rate is resolved in this order
+(`resolve_effective_user_rate`):
+
+1. **An active per-user override** (`UserRateLimitOverride`) — highest priority.
+2. **The user's tier** (`UserTier`) — from an explicit `UserTierAssignment` if
+   present and not expired, otherwise from the highest-priority tier mapped to
+   one of the user's Django groups. The tier is applied to the base rate.
+3. **The base rate**, unchanged — if neither of the above applies.
+
+## Tiers
+
+A `UserTier` either scales the base rate by `rate_multiplier` or replaces it
+outright per scope via `explicit_limits`. An explicit limit for the active scope
+always wins; otherwise the base limit is scaled (rounded, minimum 1).
+
+```python
+from django_smart_ratelimit.models import UserTier, UserTierAssignment
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+# A multiplier tier: 3x the base limit everywhere.
+premium = UserTier.objects.create(name="premium", rate_multiplier=3.0)
+
+# An explicit-limits tier: fixed per-scope limits, 2x elsewhere.
+enterprise = UserTier.objects.create(
+    name="enterprise",
+    rate_multiplier=2.0,
+    explicit_limits={"api": "5000/h", "upload": "100/d"},
+)
+
+# Assign a user to a tier (optionally with an expiry).
+user = User.objects.get(username="alice")
+UserTierAssignment.objects.create(user=user, tier=premium)
+```
+
+`apply_tier_to_rate` shows the resolution rules directly:
+
+```python
+from django_smart_ratelimit.tiers import apply_tier_to_rate
+
+apply_tier_to_rate("10/m", premium)            # "30/60s"  (multiplier)
+apply_tier_to_rate("10/m", enterprise, "api")  # "5000/h"  (explicit scope wins)
+apply_tier_to_rate("10/m", None)               # "10/m"    (no tier -> unchanged)
+```
+
+A `UserTierAssignment` is a one-to-one link (`user.ratelimit_tier`). If it has an
+`expires_at` in the past, it is ignored and resolution falls back to the user's
+groups.
+
+`UserTier.priority` breaks ties: when a user resolves to several tiers (e.g.
+through multiple groups), the highest-priority tier wins.
+
+`get_user_tier(user)` returns the effective tier (explicit assignment first,
+then groups), or `None` for anonymous users and users with no tier.
+
+## Group-based tiers
+
+Map a Django `auth.Group` to a tier with `GroupRateLimit`. Any user in that
+group inherits the tier (unless they have an explicit assignment, which takes
+priority). When a user belongs to several mapped groups, the tier with the
+highest `priority` is chosen.
+
+```python
+from django.contrib.auth.models import Group
+from django_smart_ratelimit.models import GroupRateLimit, UserTier
+
+vip = UserTier.objects.create(name="vip", rate_multiplier=5.0, priority=10)
+group = Group.objects.create(name="vips")
+GroupRateLimit.objects.create(group=group, tier=vip)
+
+# Now every member of "vips" resolves to the vip tier.
+user.groups.add(group)
+```
+
+`GroupRateLimit.tier` is optional (it may be `None`); only group configs that
+point at a tier participate in resolution.
+
+## Per-user overrides
+
+A `UserRateLimitOverride` grants a specific user a custom rate for a bounded
+window. It outranks any tier. A scope-specific override (matching `rule_name`)
+beats a blank one (`rule_name=""`, which applies to all scopes).
+
+Create one programmatically with `create_user_override` — a convenience wrapper
+around the model that validates the rate and computes the expiry for you:
+
+```python
+from django_smart_ratelimit.tiers import create_user_override
+
+# Applies to everything for ~1 hour by default.
+create_user_override(user, "50/h", reason="support ticket")
+
+# Scoped to a single rule/endpoint, for a fixed duration.
+create_user_override(user, "10/m", scope="upload", duration_seconds=60)
+
+# Or pin an absolute expiry instead of a duration.
+from django.utils import timezone
+from datetime import timedelta
+create_user_override(
+    user, "1000/h", expires_at=timezone.now() + timedelta(days=7)
+)
+```
+
+Signature:
+
+```python
+create_user_override(
+    user,
+    rate,
+    *,
+    scope="",              # maps to the override's rule_name; "" = all scopes
+    duration_seconds=None, # relative to now; defaults to 3600 if neither given
+    expires_at=None,       # absolute expiry; provide this OR duration_seconds
+    reason="",
+    created_by=None,
+)
+```
+
+`scope` maps to the model's `rule_name`. Provide at most one of
+`duration_seconds` or `expires_at`; if neither is given the override lasts one
+hour. An invalid `rate` raises `django.core.exceptions.ValidationError` before
+any row is written.
+
+You can also create the row directly via the ORM or the admin:
+
+```python
+from django_smart_ratelimit.models import UserRateLimitOverride
+from django.utils import timezone
+from datetime import timedelta
+
+UserRateLimitOverride.objects.create(
+    user=user,
+    rate="999/m",
+    rule_name="",  # blank = all scopes
+    expires_at=timezone.now() + timedelta(hours=1),
+)
+```
+
+`get_user_override(user, scope="")` returns the active override's rate string (or
+`None`), applying the scope-then-blank fallback.
+
+## How it applies (middleware and decorator)
+
+When `RATELIMIT_USE_USER_TIERS` is on, both entry points run the same
+resolution and bucketing for an authenticated user:
+
+- the rate becomes the user's effective rate (override → tier → base), and
+- the key becomes per-user (`user:<pk>:<scope-or-key>`), so users at different
+  tiers behind a shared key are limited independently.
+
+Nothing changes for your call sites — you write your usual rules and the
+adjustment happens underneath.
+
+**Middleware** (handled by `_maybe_apply_tiers`):
+
+```python
+# settings.py
+RATELIMIT_USE_USER_TIERS = True
+RATELIMIT_MIDDLEWARE = {"BACKEND": "redis", "DEFAULT_RATE": "100/m"}
+```
+
+A premium user (`rate_multiplier=3.0`) against a `100/m` rule is allowed `300/m`,
+in their own bucket.
+
+**Decorator** (v4.6.0, handled by `_apply_user_tiers`):
+
+```python
+from django.http import HttpResponse
+from django_smart_ratelimit import rate_limit
+
+@rate_limit(key="ip", rate="2/m")
+def my_view(request):
+    return HttpResponse("ok")
+```
+
+With the setting on, an authenticated premium user hitting this view gets `6/m`
+even though the rule says `2/m`, and is bucketed by user rather than by IP. An
+anonymous request still gets the plain `2/m` base rate.
+
+## Bucketing by tier with `tier_key`
+
+The above gives each user their own bucket. If instead you want everyone in the
+same tier to *share* one budget, use the `tier_key` key function:
+
+```python
+from django_smart_ratelimit import rate_limit
+from django_smart_ratelimit.tiers import tier_key
+
+@rate_limit(key=tier_key, rate="1000/m")
+def shared_pool(request):
+    ...
+```
+
+`tier_key` returns:
+
+- `tier:anonymous` for unauthenticated requests,
+- `tier:default` for authenticated users with no resolved tier,
+- `tier:<name>` otherwise (e.g. `tier:premium`).
+
+There is a matching `group_key` in `django_smart_ratelimit.groups` that buckets
+by the user's sorted group names (`group:<a,b>`, or `group:anonymous`).
+
+## API-key tiers
+
+Attach a tier to an `APIKey` to give keyed clients a limit independent of any
+logged-in user.
+
+```python
+from django_smart_ratelimit.models import APIKey, UserTier
+
+api_tier = UserTier.objects.create(name="api-gold", rate_multiplier=4.0)
+APIKey.objects.create(key="live_abc123", name="Acme prod", tier=api_tier)
+```
+
+`extract_api_key(request)` pulls a key from the request, checking in order:
+
+1. the `X-API-Key` header,
+2. an `api_key` query parameter,
+3. a `Bearer` token in the `Authorization` header.
+
+Bucket requests by their API key with the `api_key_key` key function (it falls
+back to the client IP when no key is present):
+
+```python
+from django_smart_ratelimit import rate_limit
+from django_smart_ratelimit.api_keys import api_key_key
+
+@rate_limit(key=api_key_key, rate="1000/h")
+def api_view(request):
+    ...
+```
+
+`api_key_key` returns `api_key:<key>` when a key is found, otherwise the IP key.
+
+Supporting helpers in `django_smart_ratelimit.api_keys`:
+
+- `get_api_key_record(key, touch=False)` — the active `APIKey` row for a key (or
+  `None`); pass `touch=True` to update `last_used_at`.
+- `get_api_key_tier(request)` — the `UserTier` attached to the request's API key,
+  or `None`.
+
+```python
+from django_smart_ratelimit.api_keys import get_api_key_tier
+from django_smart_ratelimit.tiers import apply_tier_to_rate
+
+tier = get_api_key_tier(request)          # UserTier or None
+rate = apply_tier_to_rate("100/h", tier)  # scaled by the key's tier
+```
+
+> Note: the middleware/decorator integration described above resolves tiers from
+> the authenticated **user**. API-key tiers are exposed through the key function
+> and helpers, so combine `api_key_key` with `get_api_key_tier` /
+> `apply_tier_to_rate` when you want a key's tier to also change its rate.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
       - Configuration: configuration.md
       - Migration: migration.md
       - Backends: backends.md
+      - Database Backend: database_backend.md
       - Algorithms: algorithms.md
       - Decorator: decorator.md
       - DRF: drf.md
@@ -25,6 +26,13 @@ nav:
       - Error Handling: error_handling.md
       - Observability: observability.md
       - Deployment: deployment.md
+  - Features:
+      - Dynamic Rules: dynamic_rules.md
+      - User Tiers: user_tiers.md
+      - Analytics: analytics.md
+      - Geographic: geographic.md
+      - Multi-Tenant: multi_tenant.md
+      - GraphQL: graphql.md
   - Design: design.md
 
 markdown_extensions:


### PR DESCRIPTION
Adds the documentation the original roadmap's Documentation Plan called for. The features shipped across v4.2.0–v4.6.0 previously had **no user-facing docs** (a gap the roadmap audit and an earlier coverage survey both flagged).

## New pages
- `dynamic_rules.md` — database-backed `RateLimitRule` + admin + `RuleEngine` + hot reload
- `user_tiers.md` — tiers, groups, per-user overrides, API-key tiers; middleware **and** decorator integration; `tier_key`, `create_user_override`
- `analytics.md` — event logging, dashboard, offender CSV + detail endpoint, alerting (`ratelimit_alerts`), `cleanup_old`
- `geographic.md` — `geo_key`, per-country rates, GeoIP provider, `RATELIMIT_GEOIP_PATH`
- `multi_tenant.md` — tenant resolution, `tenant_key`, `TenantQuota`, django-tenants
- `graphql.md` — Graphene middleware, Strawberry extension, complexity weighting
- `database_backend.md` — `RATELIMIT_BACKEND="database"`, models, `ratelimit_cleanup`

## Updated
- `configuration.md` — a settings reference for the new `RATELIMIT_*` flags
- `observability.md` — a StatsD exporter section
- `README.md` — v4.x feature bullets + doc links; **fixed the stale compatibility table** (was Python ≤3.13 / Django 4.0,4.1; now Python 3.9–3.14, Django 3.2/4.2/5.0/5.1/5.2/6.0)
- `mkdocs.yml` — a Features nav section + the database backend page

## Verification
- `mkdocs build --strict` passes (no broken nav or internal links).
- Drafted by reading the actual modules + tests; symbol/setting names verified against source.

Docs-only; no package/runtime change. ReadTheDocs rebuilds from `main` on merge.