### PR TITLE
feat: top-level re-exports + async-native Redis leaky bucket (v4.7.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
         # so the DB concurrency/atomicity tests -- which SQLite cannot reproduce
         # -- actually execute. Other cells run on SQLite.
         if: ${{ matrix.coverage }}
-        run: pytest -m "not benchmark" --cov=django_smart_ratelimit --cov-report=xml --cov-report=term-missing --cov-fail-under=65
+        run: pytest -m "not benchmark" --cov=django_smart_ratelimit --cov-report=xml --cov-report=term-missing --cov-fail-under=68
         env:
           REDIS_URL: redis://localhost:6379/0
           MONGODB_URL: mongodb://localhost:27017/test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.6.0] - 2026-06-04
+## [4.7.0] - 2026-06-04
+
+Polish release: discoverability and async parity. Additive; no breaking changes.
+
+### Added
+
+- **Top-level re-exports for the v4.x feature APIs.** The dynamic-rules, user-tier,
+  group, API-key, analytics, geographic, multi-tenant, GraphQL, and StatsD helpers
+  are now importable directly from `django_smart_ratelimit` (and listed in
+  `__all__`) for autocomplete, e.g. `from django_smart_ratelimit import geo_key,
+  tier_key, get_traffic_summary`. The submodule imports
+  (`from django_smart_ratelimit import geo`) still work. Django **model** classes
+  remain importable from `django_smart_ratelimit.models` (re-exporting them at the
+  top level would touch the app registry too early).
+- **Async-native Redis leaky bucket.** `AsyncRedisBackend` gains
+  `aleaky_bucket_check` / `aleaky_bucket_info` (same atomic Lua as the sync
+  backend), so the dedicated async backend has true atomic leaky-bucket semantics.
+
+### Changed
+
+- Raised the CI coverage floor (`--cov-fail-under`) from 65% to 68%, reflecting
+  the measured coverage.
 
 Completes the original v2.0 feature roadmap: the handful of items that were
 planned but never built. Everything here is additive and opt-in; no existing

--- a/django_smart_ratelimit/__init__.py
+++ b/django_smart_ratelimit/__init__.py
@@ -5,7 +5,7 @@ with support for multiple backends, algorithms (including token bucket),
 and comprehensive rate limiting strategies.
 """
 
-__version__ = "4.6.0"
+__version__ = "4.7.0"
 __author__ = "Yasser Shkeir"
 
 # Optional backend imports (may not be available)
@@ -110,6 +110,27 @@ def ratelimit(
     )
 
 
+# Advanced feature modules (roadmap Phase 2-5). These are safe to import at
+# package load (they import Django models lazily, inside functions), so they can
+# be re-exported here for discoverability/autocomplete. The Django *model*
+# classes are NOT re-exported — import those from django_smart_ratelimit.models
+# (importing them here would touch the app registry before it is ready).
+from .analytics import (
+    find_alertable_offenders,
+    get_offender_detail,
+    get_rule_hit_counts,
+    get_top_offenders,
+    get_traffic_summary,
+    offenders_csv,
+    send_offender_alerts,
+)
+from .api_keys import (
+    api_key_key,
+    extract_api_key,
+    get_api_key_record,
+    get_api_key_tier,
+)
+
 # Exceptions
 from .exceptions import (
     BackendConnectionError,
@@ -122,6 +143,24 @@ from .exceptions import (
     RateLimitExceeded,
     RateLimitException,
 )
+from .geo import (
+    GeoLocation,
+    GeoProvider,
+    MaxMindProvider,
+    NullGeoProvider,
+    geo_key,
+    get_country,
+    get_geo_provider,
+    get_rate_for_country,
+    set_geo_provider,
+)
+from .graphql import (
+    GrapheneRateLimitMiddleware,
+    GraphQLRateLimitExceeded,
+    estimate_query_complexity,
+    make_strawberry_extension,
+)
+from .groups import get_tier_from_groups, group_key
 
 # Common key functions
 from .key_functions import api_key_aware_key, composite_key, geographic_key
@@ -145,6 +184,22 @@ from .pipeline import (
     apply_policy_lists,
     handle_shadow_decision,
     resolve_effective_rate,
+)
+from .rules import RuleEngine, get_rule_engine, rule_engine
+from .statsd import StatsDClient, StatsDMetrics, get_statsd_metrics
+from .tenants import (
+    extract_tenant,
+    get_tenant_quota,
+    resolve_tenant_rate,
+    tenant_key,
+)
+from .tiers import (
+    apply_tier_to_rate,
+    create_user_override,
+    get_user_override,
+    get_user_tier,
+    resolve_effective_user_rate,
+    tier_key,
 )
 
 # Utilities
@@ -317,4 +372,53 @@ __all__ = [
     "is_staff_user",
     "is_superuser",
     "should_bypass_rate_limit",
+    # Dynamic rules (Phase 2)
+    "RuleEngine",
+    "rule_engine",
+    "get_rule_engine",
+    # User tiers / groups / overrides / API keys (Phase 3)
+    "get_user_tier",
+    "apply_tier_to_rate",
+    "get_user_override",
+    "resolve_effective_user_rate",
+    "tier_key",
+    "create_user_override",
+    "get_tier_from_groups",
+    "group_key",
+    "extract_api_key",
+    "get_api_key_record",
+    "api_key_key",
+    "get_api_key_tier",
+    # Analytics (Phase 4)
+    "get_traffic_summary",
+    "get_top_offenders",
+    "get_rule_hit_counts",
+    "offenders_csv",
+    "get_offender_detail",
+    "find_alertable_offenders",
+    "send_offender_alerts",
+    # Geographic (Phase 5.4)
+    "geo_key",
+    "get_country",
+    "get_rate_for_country",
+    "GeoProvider",
+    "MaxMindProvider",
+    "NullGeoProvider",
+    "GeoLocation",
+    "get_geo_provider",
+    "set_geo_provider",
+    # Multi-tenant (Phase 5.5)
+    "extract_tenant",
+    "tenant_key",
+    "get_tenant_quota",
+    "resolve_tenant_rate",
+    # GraphQL (Phase 5.6)
+    "GrapheneRateLimitMiddleware",
+    "make_strawberry_extension",
+    "estimate_query_complexity",
+    "GraphQLRateLimitExceeded",
+    # StatsD exporter (Phase 5.1)
+    "StatsDClient",
+    "StatsDMetrics",
+    "get_statsd_metrics",
 ]

--- a/django_smart_ratelimit/backends/redis_backend.py
+++ b/django_smart_ratelimit/backends/redis_backend.py
@@ -1135,6 +1135,8 @@ class AsyncRedisBackend(BaseBackend):
         # Scripts
         self.sliding_window_sha = ""
         self.fixed_window_sha = ""
+        self.leaky_bucket_sha = ""  # nosec B105 - SHA cache init, lazily loaded
+        self.leaky_bucket_info_sha = ""  # nosec B105 - SHA cache init
 
     @property
     def client(self):
@@ -1281,6 +1283,82 @@ class AsyncRedisBackend(BaseBackend):
             if self.fail_open:
                 return 0  # Allow
             return 999999  # Block
+
+    async def aleaky_bucket_check(
+        self,
+        key: str,
+        bucket_capacity: int,
+        leak_rate: float,
+        request_cost: int,
+    ) -> Tuple[bool, Dict[str, Any]]:
+        """Async-native atomic leaky bucket check (mirrors the sync backend).
+
+        Uses the same Lua script as :class:`RedisBackend`, evaluated on the async
+        client, so the dedicated async backend has true atomic leaky-bucket
+        semantics instead of a non-atomic fallback. Returns
+        ``(is_allowed, metadata)``.
+        """
+        client = await self._get_client()
+        normalized_key = normalize_key(f"{key}:leaky_bucket", self.key_prefix)
+        now = get_current_timestamp()
+        args = (normalized_key, bucket_capacity, leak_rate, request_cost, now)
+
+        sha = self.leaky_bucket_sha or await self._load_script(
+            client, RedisBackend.LEAKY_BUCKET_SCRIPT
+        )
+        self.leaky_bucket_sha = sha
+        try:
+            res = await client.evalsha(sha, 1, *args)
+        except redis.exceptions.NoScriptError:
+            sha = await self._load_script(client, RedisBackend.LEAKY_BUCKET_SCRIPT)
+            self.leaky_bucket_sha = sha
+            res = await client.evalsha(sha, 1, *args)
+
+        is_allowed = bool(res[0])
+        bucket_level = float(res[1]) / 1000.0
+        tus_raw = float(res[2])
+        time_until_space = float("inf") if tus_raw < 0 else tus_raw / 1000.0
+        return is_allowed, {
+            "bucket_level": bucket_level,
+            "bucket_capacity": bucket_capacity,
+            "leak_rate": leak_rate,
+            "request_cost": request_cost,
+            "space_remaining": max(0.0, bucket_capacity - bucket_level),
+            "time_until_space": time_until_space,
+        }
+
+    async def aleaky_bucket_info(
+        self, key: str, bucket_capacity: int, leak_rate: float
+    ) -> Dict[str, Any]:
+        """Inspect async leaky bucket state without adding to it."""
+        client = await self._get_client()
+        normalized_key = normalize_key(f"{key}:leaky_bucket", self.key_prefix)
+        now = get_current_timestamp()
+        args = (normalized_key, leak_rate, now)
+
+        sha = self.leaky_bucket_info_sha or await self._load_script(
+            client, RedisBackend.LEAKY_BUCKET_INFO_SCRIPT
+        )
+        self.leaky_bucket_info_sha = sha
+        try:
+            res = await client.evalsha(sha, 1, *args)
+        except redis.exceptions.NoScriptError:
+            sha = await self._load_script(client, RedisBackend.LEAKY_BUCKET_INFO_SCRIPT)
+            self.leaky_bucket_info_sha = sha
+            res = await client.evalsha(sha, 1, *args)
+
+        bucket_level = float(res[0]) / 1000.0
+        last_leak = float(res[1]) / 1000.0
+        return {
+            "bucket_level": bucket_level,
+            "bucket_capacity": bucket_capacity,
+            "leak_rate": leak_rate,
+            "space_remaining": max(0.0, bucket_capacity - bucket_level),
+            "time_to_empty": (
+                bucket_level / leak_rate if leak_rate > 0 else float("inf")
+            ),
+            "last_leak": last_leak,
+        }
 
     # Implement abstract methods
     def incr(self, key: str, period: int) -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-smart-ratelimit"
-version = "4.6.0"
+version = "4.7.0"
 dynamic = []
 description = "A flexible and efficient rate limiting library for Django applications"
 readme = "README.md"

--- a/tests/integration/test_v470_polish.py
+++ b/tests/integration/test_v470_polish.py
@@ -1,0 +1,111 @@
+"""v4.7.0 polish: top-level re-exports + async-native Redis leaky bucket."""
+
+import time
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Discoverability: v4.x feature symbols are re-exported at the package top level
+# ---------------------------------------------------------------------------
+
+
+def test_v4x_features_are_top_level_exports():
+    import django_smart_ratelimit as d
+
+    expected = [
+        # dynamic rules
+        "RuleEngine",
+        "rule_engine",
+        "get_rule_engine",
+        # tiers / groups / overrides / api keys
+        "get_user_tier",
+        "tier_key",
+        "create_user_override",
+        "get_tier_from_groups",
+        "group_key",
+        "extract_api_key",
+        "api_key_key",
+        "get_api_key_tier",
+        # analytics
+        "get_traffic_summary",
+        "get_top_offenders",
+        "get_offender_detail",
+        "find_alertable_offenders",
+        "send_offender_alerts",
+        # geo / tenant / graphql
+        "geo_key",
+        "get_rate_for_country",
+        "GeoProvider",
+        "extract_tenant",
+        "tenant_key",
+        "resolve_tenant_rate",
+        "GrapheneRateLimitMiddleware",
+        "estimate_query_complexity",
+        # statsd
+        "StatsDClient",
+        "StatsDMetrics",
+        "get_statsd_metrics",
+    ]
+    missing = [s for s in expected if not hasattr(d, s)]
+    assert missing == [], f"not re-exported: {missing}"
+    # every name is also advertised in __all__
+    not_in_all = [s for s in expected if s not in d.__all__]
+    assert not_in_all == [], f"missing from __all__: {not_in_all}"
+
+
+def test_reexports_are_the_same_objects_as_submodules():
+    import django_smart_ratelimit as d
+    from django_smart_ratelimit import analytics, geo, tenants, tiers
+
+    assert d.geo_key is geo.geo_key
+    assert d.tenant_key is tenants.tenant_key
+    assert d.tier_key is tiers.tier_key
+    assert d.get_traffic_summary is analytics.get_traffic_summary
+
+
+def test_no_dangling_all_names():
+    import django_smart_ratelimit as d
+
+    dangling = [n for n in d.__all__ if not hasattr(d, n)]
+    assert dangling == [], f"__all__ lists names that don't resolve: {dangling}"
+
+
+# ---------------------------------------------------------------------------
+# Async-native Redis leaky bucket
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_redis_leaky_bucket_atomic():
+    from django_smart_ratelimit.backends.redis_backend import AsyncRedisBackend
+
+    backend = AsyncRedisBackend()
+    key = "albtest:v470:%d" % int(time.time() * 1000)
+    # capacity 4, negligible leak during the test -> exactly 4 admitted.
+    decisions = []
+    for _ in range(6):
+        allowed, meta = await backend.aleaky_bucket_check(key, 4, 0.0001, 1)
+        decisions.append(allowed)
+    assert decisions == [True, True, True, True, False, False]
+
+    info = await backend.aleaky_bucket_info(key, 4, 0.0001)
+    assert info["bucket_level"] > 3.0  # near full, read-only (no mutation)
+    assert info["space_remaining"] < 1.0
+
+
+@pytest.mark.asyncio
+async def test_async_redis_leaky_bucket_leaks_over_time():
+    import asyncio
+
+    from django_smart_ratelimit.backends.redis_backend import AsyncRedisBackend
+
+    backend = AsyncRedisBackend()
+    key = "albtest2:v470:%d" % int(time.time() * 1000)
+    # Fill to capacity (cost 2 == capacity 2), then it's immediately full.
+    await backend.aleaky_bucket_check(key, 2, 100.0, 2)
+    denied, _ = await backend.aleaky_bucket_check(key, 2, 100.0, 2)
+    assert denied is False
+    # leak_rate 100/s drains the bucket within 0.1s.
+    await asyncio.sleep(0.1)
+    allowed, _ = await backend.aleaky_bucket_check(key, 2, 100.0, 2)
+    assert allowed is True


### PR DESCRIPTION
Polish release from the post-roadmap backlog. **Additive only — no breaking changes.**

## Discoverability — top-level re-exports
The v4.x feature APIs were only reachable as submodules (`from django_smart_ratelimit import geo`), so they didn't surface in autocomplete. They're now re-exported from the package top level and listed in `__all__`:

```python
from django_smart_ratelimit import (
    geo_key, get_rate_for_country,           # geographic
    tenant_key, resolve_tenant_rate,         # multi-tenant
    tier_key, get_user_tier, create_user_override,  # tiers
    get_traffic_summary, get_offender_detail,       # analytics
    GrapheneRateLimitMiddleware, estimate_query_complexity,  # graphql
    StatsDMetrics, rule_engine,              # statsd, dynamic rules
)
```

Submodule imports still work. Django **model** classes intentionally stay in `django_smart_ratelimit.models` (re-exporting them at package load would touch the app registry before it's ready).

## Async-native Redis leaky bucket
`AsyncRedisBackend` gains `aleaky_bucket_check` / `aleaky_bucket_info` — the same atomic Lua as the sync backend (v4.6.0), evaluated on the async client. Verified on live async Redis (atomic admission + leak/refill + read-only info).

## Coverage
Measured the real coverage (~69% locally on redis+sqlite) and raised the CI floor `--cov-fail-under` 65% → 68% (CI runs on Postgres and covers more).

## Testing
- New: `tests/integration/test_v470_polish.py` (re-export resolution + identity, no dangling `__all__`, async leaky bucket atomicity + leak).
- Full suite: **1910 passed, 9 skipped**.
- pre-commit (black/flake8/isort/mypy/bandit) clean.