### PR TITLE
feat: Memcached backend (v4.8.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,11 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      memcached:
+        image: memcached:alpine
+        ports:
+          - 11211:11211
+
       postgres:
         image: postgres:16-alpine
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.8.0] - 2026-06-04
+
+Adds a **Memcached backend** — the last open item on the backends roadmap and a
+direct answer to a user request. Additive and opt-in.
+
+### Added
+
+- **`MemcachedBackend`** (`RATELIMIT_BACKEND = "memcached"`) — clock-aligned
+  fixed-window rate limiting on Memcached's atomic `add`/`incr`, for deployments
+  that already run Memcached and want distributed limiting without Redis.
+  Supports a single server or several nodes (consistent-hashed via
+  `pymemcache.HashClient`), honors `fail_open` and the circuit breaker, and
+  sanitizes oversized/whitespace keys. Requires the optional `pymemcache`
+  dependency (`pip install django-smart-ratelimit[memcached]`); registered as the
+  `memcached` alias.
+- New optional extra `memcached` (`pymemcache`).
+- Docs: a Memcached backend section (`docs/backends.md`) and installation extra.
+
+### Notes
+
+- Memcached has no server-side scripting, so `sliding_window`, `token_bucket`,
+  and `leaky_bucket` degrade to fixed-window counting on this backend; use Redis
+  or the database backend when you need sliding windows or bucket algorithms.
+
+### Testing
+
+- Unit tests (`tests/unit/backends/test_memcached_backend.py`), real-backend e2e
+  + real-life scenario tests (`tests/e2e/test_memcached_e2e.py`: login throttle,
+  per-API-key quota, burst, window rollover, fail-open), and a manual
+  verification script (`tests/test_project/scripts/verify_memcached.py`). CI
+  gains a `memcached` service so the live tests run.
+
 ## [4.7.0] - 2026-06-04
 
 Polish release: discoverability and async parity. Additive; no breaking changes.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A high-performance rate limiting library for Django. Protects your APIs from abu
 - **Sync and Async** -- Dual-mode support with native `@ratelimit` and `@aratelimit` decorators
 - **Enterprise Reliability** -- Built-in circuit breaker, automatic failover, and fail-open strategies
 - **Multiple Algorithms** -- Token bucket, sliding window, fixed window, and leaky bucket
-- **Flexible Backends** -- Redis (recommended), async Redis, in-memory, MongoDB, Django ORM (database), or custom backends
+- **Flexible Backends** -- Redis (recommended), async Redis, in-memory, MongoDB, Memcached, Django ORM (database), or custom backends
 - **Precise Control** -- Rate limit by IP, user, header, or any custom callable
 - **Shadow Mode** -- Evaluate and log decisions without enforcing them for safe, zero-risk rollouts ([docs](https://django-smart-ratelimit.readthedocs.io/en/latest/decorator/))
 - **Cost-Based (Weighted) Limiting** -- Charge expensive requests more of the budget via a per-request `cost` ([docs](https://django-smart-ratelimit.readthedocs.io/en/latest/decorator/))

--- a/django_smart_ratelimit/__init__.py
+++ b/django_smart_ratelimit/__init__.py
@@ -5,7 +5,7 @@ with support for multiple backends, algorithms (including token bucket),
 and comprehensive rate limiting strategies.
 """
 
-__version__ = "4.7.0"
+__version__ = "4.8.0"
 __author__ = "Yasser Shkeir"
 
 # Optional backend imports (may not be available)

--- a/django_smart_ratelimit/backends/factory.py
+++ b/django_smart_ratelimit/backends/factory.py
@@ -16,6 +16,7 @@ BUILTIN_BACKENDS: Dict[str, str] = {
     "mongodb": "django_smart_ratelimit.backends.mongodb.MongoDBBackend",
     "multi": "django_smart_ratelimit.backends.multi.MultiBackend",
     "database": "django_smart_ratelimit.backends.database.DatabaseBackend",
+    "memcached": "django_smart_ratelimit.backends.memcached.MemcachedBackend",
 }
 
 # Custom backend registry

--- a/django_smart_ratelimit/backends/memcached.py
+++ b/django_smart_ratelimit/backends/memcached.py
@@ -1,0 +1,246 @@
+"""Memcached backend for rate limiting.
+
+A lightweight, dependency-light backend built on Memcached's atomic ``incr`` and
+``add`` operations. It implements clock-aligned **fixed-window** counting, which
+is Memcached's natural fit (there is no server-side scripting, so sliding-window
+and bucket algorithms fall back to window counting via ``incr``).
+
+Enable it with::
+
+    RATELIMIT_BACKEND = "memcached"   # or the dotted path to MemcachedBackend
+    RATELIMIT_MEMCACHED = {
+        "HOST": "127.0.0.1",
+        "PORT": 11211,
+        # ...or several nodes (consistent-hashed via pymemcache.HashClient):
+        # "SERVERS": ["10.0.0.1:11211", "10.0.0.2:11211"],
+        "CONNECT_TIMEOUT": 1,
+        "TIMEOUT": 1,
+    }
+
+Requires the optional ``pymemcache`` dependency
+(``pip install django-smart-ratelimit[memcached]``).
+"""
+
+import hashlib
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from .base import BaseBackend
+from .utils import (
+    get_current_timestamp,
+    get_time_bucket_key_suffix,
+    log_backend_operation,
+    normalize_key,
+)
+
+try:
+    from pymemcache.client.base import Client as _MemcacheClient
+    from pymemcache.client.hash import HashClient as _MemcacheHashClient
+except ImportError:  # pragma: no cover - optional dependency
+    _MemcacheClient = None
+    _MemcacheHashClient = None
+
+
+def _safe_memcached_key(key: str) -> str:
+    """Return a Memcached-safe key (no spaces/control chars, <=250 bytes).
+
+    Rate-limit keys are normally short and safe; this guards the rare long or
+    whitespace-containing key by replacing spaces and hashing anything that
+    would exceed Memcached's 250-byte key limit.
+    """
+    key = key.replace(" ", "_")
+    if len(key.encode("utf-8")) > 250 or any(ord(c) < 33 for c in key):
+        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        return f"rl:{digest}"
+    return key
+
+
+class MemcachedBackend(BaseBackend):
+    """Memcached fixed-window rate-limit backend (optional ``pymemcache``)."""
+
+    name = "memcached"
+
+    def __init__(
+        self,
+        algorithm: str = "fixed_window",
+        fail_open: bool = False,
+        enable_circuit_breaker: bool = True,
+        circuit_breaker_config: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Build the Memcached client from ``RATELIMIT_MEMCACHED`` settings."""
+        if _MemcacheClient is None:
+            from django.core.exceptions import ImproperlyConfigured
+
+            raise ImproperlyConfigured(
+                "The Memcached backend requires the 'pymemcache' package "
+                "(pip install django-smart-ratelimit[memcached])."
+            )
+
+        from django_smart_ratelimit.config import get_settings
+
+        settings = get_settings()
+        super().__init__(
+            enable_circuit_breaker=enable_circuit_breaker,
+            circuit_breaker_config=circuit_breaker_config,
+            fail_open=fail_open if fail_open else settings.fail_open,
+            **kwargs,
+        )
+
+        self._algorithm = algorithm or settings.default_algorithm
+        self._key_prefix = settings.key_prefix
+
+        from django.conf import settings as django_settings
+
+        config = getattr(django_settings, "RATELIMIT_MEMCACHED", {})
+        self._client = self._build_client(config)
+
+    @staticmethod
+    def _parse_server(server: Any) -> Any:
+        """Normalize a ``"host:port"`` string to a ``(host, port)`` tuple."""
+        if isinstance(server, (tuple, list)):
+            return (server[0], int(server[1]))
+        if isinstance(server, str) and ":" in server:
+            host, port = server.rsplit(":", 1)
+            return (host, int(port))
+        return server
+
+    def _build_client(self, config: Dict[str, Any]) -> Any:
+        """Create a single-server ``Client`` or a multi-node ``HashClient``."""
+        connect_timeout = config.get("CONNECT_TIMEOUT", 1)
+        timeout = config.get("TIMEOUT", 1)
+        servers = config.get("SERVERS")
+        # default_noreply=False is REQUIRED: rate limiting relies on add()
+        # returning whether the key was actually created (with the pymemcache
+        # default of True, storage commands are fire-and-forget and add() always
+        # reports success, which would pin every window's counter at 1).
+        if servers:
+            return _MemcacheHashClient(
+                [self._parse_server(s) for s in servers],
+                connect_timeout=connect_timeout,
+                timeout=timeout,
+                ignore_exc=False,
+                default_noreply=False,
+            )
+        host = config.get("HOST", "127.0.0.1")
+        port = int(config.get("PORT", 11211))
+        return _MemcacheClient(
+            (host, port),
+            connect_timeout=connect_timeout,
+            timeout=timeout,
+            default_noreply=False,
+        )
+
+    def _window_key(self, key: str, period: int) -> str:
+        """Build the clock-aligned, Memcached-safe key for ``key``'s window."""
+        normalized = normalize_key(key, self._key_prefix)
+        normalized += get_time_bucket_key_suffix(period)
+        return _safe_memcached_key(normalized)
+
+    def incr(self, key: str, period: int) -> int:
+        """Increment and return the counter for ``key`` within ``period``."""
+        mkey = self._window_key(key, period)
+        try:
+            # add() is atomic and only succeeds when the key does not yet exist,
+            # which makes the first request in a window deterministically 1; all
+            # others go through the atomic incr().
+            if self._client.add(mkey, b"1", expire=period):
+                return 1
+            result = self._client.incr(mkey, 1)
+            if result is None:
+                # The key expired between add() and incr() (rare). Re-seed it.
+                self._client.add(mkey, b"1", expire=period)
+                return 1
+            return int(result)
+        except Exception as e:
+            log_backend_operation(
+                "incr",
+                f"memcached backend increment failed for key {key}: {e}",
+                level="error",
+            )
+            allowed, _ = self._handle_backend_error("incr", key, e)
+            return 0 if allowed else 9999
+
+    def get_count(self, key: str, period: int = 60) -> int:
+        """Return the current counter for ``key`` (0 if absent)."""
+        mkey = self._window_key(key, period)
+        try:
+            raw = self._client.get(mkey)
+            return int(raw) if raw is not None else 0
+        except Exception as e:
+            log_backend_operation(
+                "get_count",
+                f"memcached backend get_count failed for key {key}: {e}",
+                level="error",
+            )
+            return 0
+
+    def reset(self, key: str) -> None:
+        """Clear ``key``'s counter for the current window."""
+        # Reset both the clock-aligned current window and the unaligned key, so a
+        # reset works regardless of the align-window-to-clock setting.
+        normalized = normalize_key(key, self._key_prefix)
+        candidates = {
+            _safe_memcached_key(normalized),
+            self._window_key(key, 60),
+        }
+        try:
+            for mkey in candidates:
+                self._client.delete(mkey)
+        except Exception as e:
+            log_backend_operation(
+                "reset",
+                f"memcached backend reset failed for key {key}: {e}",
+                level="error",
+            )
+
+    def get_reset_time(self, key: str) -> Optional[int]:
+        """Return ``None``: Memcached does not expose a queryable TTL.
+
+        The decorator/middleware compute ``Retry-After`` / ``X-RateLimit-Reset``
+        from the configured rate when this is ``None``.
+        """
+        return None
+
+    def health_check(self) -> Dict[str, Any]:
+        """Ping Memcached and report reachability."""
+        info: Dict[str, Any] = {"backend": "memcached", "algorithm": self._algorithm}
+        try:
+            probe = _safe_memcached_key(
+                normalize_key("__healthcheck__", self._key_prefix)
+            )
+            self._client.set(probe, b"1", expire=5)
+            ok = self._client.get(probe) == b"1"
+            self._client.delete(probe)
+            info["healthy"] = bool(ok)
+            info["timestamp"] = time.time()
+        except Exception as e:  # pragma: no cover - depends on a live server
+            info["healthy"] = False
+            info["error"] = str(e)
+        return info
+
+    def check_batch(
+        self, checks: List[Dict[str, Any]]
+    ) -> List[Tuple[bool, Dict[str, Any]]]:
+        """Evaluate several limits sequentially (no server-side batching)."""
+        results: List[Tuple[bool, Dict[str, Any]]] = []
+        for check in checks:
+            key = check["key"]
+            limit = int(check["limit"])
+            period = int(check.get("period", 60))
+            count = self.incr(key, period)
+            results.append(
+                (
+                    count <= limit,
+                    {
+                        "count": count,
+                        "limit": limit,
+                        "remaining": max(0, limit - count),
+                    },
+                )
+            )
+        return results
+
+    def get_current_timestamp(self) -> float:
+        """Expose the shared timestamp helper (used by some algorithms)."""
+        return get_current_timestamp()

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -25,6 +25,7 @@ The recognized short aliases (from `backends/factory.py`, `BUILTIN_BACKENDS`) ar
 | `mongodb`     | `django_smart_ratelimit.backends.mongodb.MongoDBBackend`         |
 | `multi`       | `django_smart_ratelimit.backends.multi.MultiBackend`             |
 | `database`    | `django_smart_ratelimit.backends.database.DatabaseBackend`       |
+| `memcached`   | `django_smart_ratelimit.backends.memcached.MemcachedBackend`     |
 
 You can register your own backend under a custom alias with
 `django_smart_ratelimit.backends.factory.register_backend(name, backend_class)`.
@@ -98,6 +99,35 @@ backend with native leaky-bucket support.
 
 - Pros: no extra infrastructure, works with your existing database.
 - Cons: higher per-request overhead than Redis.
+
+### Memcached Backend
+
+**Alias**: `memcached` &nbsp; **Class**: `django_smart_ratelimit.backends.memcached.MemcachedBackend`
+
+Uses Memcached's atomic `add`/`incr` for **clock-aligned fixed-window** counting.
+A good fit if you already run Memcached and want distributed limiting without
+adding Redis. Requires the optional `pymemcache` dependency
+(`pip install django-smart-ratelimit[memcached]`).
+
+```python
+# settings.py
+RATELIMIT_BACKEND = "memcached"
+RATELIMIT_MEMCACHED = {
+    "HOST": "127.0.0.1",
+    "PORT": 11211,
+    # ...or several nodes (consistent-hashed via pymemcache.HashClient):
+    # "SERVERS": ["10.0.0.1:11211", "10.0.0.2:11211"],
+    "CONNECT_TIMEOUT": 1,
+    "TIMEOUT": 1,
+}
+```
+
+- Pros: simple, fast, distributed; reuses an existing Memcached.
+- Cons: **fixed-window only** — Memcached has no server-side scripting, so
+  `sliding_window`, `token_bucket`, and `leaky_bucket` degrade to fixed-window
+  counting. Memcached can also evict keys under memory pressure (a limit may
+  reset early). Use Redis or the database backend if you need sliding windows or
+  bucket algorithms.
 
 ### Memory Backend
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,6 +32,7 @@ Install only the backends and integrations you need:
 | --- | --- | --- |
 | `redis` | `redis`, `hiredis` | Redis backend (recommended for production) |
 | `mongodb` | `pymongo` | MongoDB backend |
+| `memcached` | `pymemcache` | Memcached backend (fixed-window) |
 | `jwt` | `PyJWT` | JWT-based rate limit keys |
 | `drf` | `djangorestframework` | DRF throttle adapter (new in v3.0.0) |
 | `prometheus` | `prometheus-client` | Prometheus metrics |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-smart-ratelimit"
-version = "4.7.0"
+version = "4.8.0"
 dynamic = []
 description = "A flexible and efficient rate limiting library for Django applications"
 readme = "README.md"
@@ -52,6 +52,9 @@ redis = [
 mongodb = [
     "pymongo>=4.0",
 ]
+memcached = [
+    "pymemcache>=4.0",
+]
 jwt = [
     "PyJWT>=2.0",
 ]
@@ -75,6 +78,7 @@ all = [
     "redis>=4.0",
     "hiredis>=2.0",
     "pymongo>=4.0",
+    "pymemcache>=4.0",
     "PyJWT>=2.0",
     "djangorestframework>=3.12",
     "prometheus-client>=0.14.0",
@@ -104,6 +108,7 @@ dev = [
     "redis>=4.0",
     "hiredis>=2.0",
     "pymongo>=4.0",
+    "pymemcache>=4.0",
     "prometheus-client>=0.14.0",
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -34,6 +34,7 @@ REDIS = "django_smart_ratelimit.backends.redis_backend.RedisBackend"
 ASYNC_REDIS = "django_smart_ratelimit.backends.redis_backend.AsyncRedisBackend"
 MONGODB = "django_smart_ratelimit.backends.mongodb.MongoDBBackend"
 DATABASE = "django_smart_ratelimit.backends.database.DatabaseBackend"
+MEMCACHED = "django_smart_ratelimit.backends.memcached.MemcachedBackend"
 
 
 def _host_port(env_var, default_host, default_port):
@@ -55,6 +56,19 @@ def _host_port(env_var, default_host, default_port):
 
 REDIS_HOST, REDIS_PORT = _host_port("REDIS_URL", "localhost", 6379)
 MONGO_HOST, MONGO_PORT = _host_port("MONGODB_URL", "localhost", 27017)
+MEMCACHED_HOST = os.environ.get("MEMCACHED_HOST", "localhost")
+MEMCACHED_PORT = int(os.environ.get("MEMCACHED_PORT", "11211"))
+
+
+def memcached_available():
+    try:
+        from pymemcache.client.base import Client
+
+        c = Client((MEMCACHED_HOST, MEMCACHED_PORT), connect_timeout=1, timeout=1)
+        c.set(b"__e2e_probe__", b"1", expire=2)
+        return c.get(b"__e2e_probe__") == b"1"
+    except Exception:
+        return False
 
 
 def redis_available():
@@ -81,13 +95,22 @@ def mongo_available():
 
 REDIS_UP = redis_available()
 MONGO_UP = mongo_available()
+MEMCACHED_UP = memcached_available()
 
 # CI safety valve: a green run that silently skipped every Redis/Mongo scenario
 # looks identical to a run that exercised them. Set RATELIMIT_E2E_REQUIRE_SERVICES=1
 # (in CI, where the service containers must be present) to turn those skips into a
 # hard collection error instead. Default unset -> skip gracefully, as before.
 if os.environ.get("RATELIMIT_E2E_REQUIRE_SERVICES", "").lower() in ("1", "true", "yes"):
-    _missing = [n for n, up in (("Redis", REDIS_UP), ("MongoDB", MONGO_UP)) if not up]
+    _missing = [
+        n
+        for n, up in (
+            ("Redis", REDIS_UP),
+            ("MongoDB", MONGO_UP),
+            ("Memcached", MEMCACHED_UP),
+        )
+        if not up
+    ]
     if _missing:
         raise RuntimeError(
             "RATELIMIT_E2E_REQUIRE_SERVICES is set but these services are "
@@ -98,6 +121,9 @@ if os.environ.get("RATELIMIT_E2E_REQUIRE_SERVICES", "").lower() in ("1", "true",
 # Mark factories so tests/files can build their own parametrizations.
 skip_without_redis = pytest.mark.skipif(not REDIS_UP, reason="live Redis unavailable")
 skip_without_mongo = pytest.mark.skipif(not MONGO_UP, reason="live MongoDB unavailable")
+skip_without_memcached = pytest.mark.skipif(
+    not MEMCACHED_UP, reason="live Memcached unavailable"
+)
 
 
 def _db_is_postgres():
@@ -143,6 +169,12 @@ def flush_store(name):
             from pymongo import MongoClient
 
             MongoClient(host=MONGO_HOST, port=MONGO_PORT).drop_database("ratelimit")
+        elif name == "memcached":
+            from pymemcache.client.base import Client
+
+            Client(
+                (MEMCACHED_HOST, MEMCACHED_PORT), connect_timeout=1, timeout=1
+            ).flush_all()
         elif name == "memory":
             backend = get_backend()
             if hasattr(backend, "clear_all"):
@@ -212,6 +244,15 @@ def use_backend(name):
             },
         ),
         "database": (DATABASE, {}),
+        "memcached": (
+            MEMCACHED,
+            {
+                "RATELIMIT_MEMCACHED": {
+                    "HOST": MEMCACHED_HOST,
+                    "PORT": MEMCACHED_PORT,
+                }
+            },
+        ),
     }
     path, extra = paths[name]
     ov = override_settings(RATELIMIT_BACKEND=path, **extra)

--- a/tests/e2e/test_memcached_e2e.py
+++ b/tests/e2e/test_memcached_e2e.py
@@ -1,0 +1,181 @@
+"""End-to-end tests for the Memcached backend against a live server.
+
+No mocks: these drive the real `@rate_limit` decorator and `RateLimitMiddleware`
+through a real Memcached instance. They skip when Memcached is unreachable. The
+backend implements clock-aligned fixed-window counting, so the assertions here
+are written for fixed-window semantics (a burst up to the limit, then blocking
+until the window rolls over).
+"""
+
+import time
+
+from django.http import HttpResponse
+from django.test import override_settings
+
+from django_smart_ratelimit import rate_limit
+from django_smart_ratelimit.backends import get_backend
+from django_smart_ratelimit.middleware import RateLimitMiddleware
+
+from .conftest import exhaust, make_request, skip_without_memcached, use_backend
+
+pytestmark = skip_without_memcached
+
+
+def _uid():
+    return time.time_ns()
+
+
+# ---------------------------------------------------------------------------
+# Backend through the public get_backend() path
+# ---------------------------------------------------------------------------
+
+
+def test_get_backend_returns_memcached_and_counts():
+    with use_backend("memcached"):
+        backend = get_backend()
+        assert backend.name == "memcached"
+        key = f"e2e:{_uid()}"
+        assert [backend.incr(key, 60) for _ in range(3)] == [1, 2, 3]
+        assert backend.get_count(key, 60) == 3
+
+
+# ---------------------------------------------------------------------------
+# Decorator over a real Memcached
+# ---------------------------------------------------------------------------
+
+
+def test_decorator_allows_then_blocks_fixed_window():
+    with use_backend("memcached"):
+
+        @rate_limit(key="ip", rate="5/m", algorithm="fixed_window")
+        def view(_request):
+            return HttpResponse("ok")
+
+        codes = exhaust(view, 7, ip=f"198.51.100.{_uid() % 200}")
+        assert codes[:5] == [200] * 5
+        assert codes[5:] == [429, 429]
+
+
+def test_decorator_isolates_distinct_clients():
+    with use_backend("memcached"):
+
+        @rate_limit(key="ip", rate="2/m", algorithm="fixed_window")
+        def view(_request):
+            return HttpResponse("ok")
+
+        a = exhaust(view, 3, ip="203.0.113.41")
+        b = exhaust(view, 3, ip="203.0.113.42")
+        assert a == [200, 200, 429]
+        assert b == [200, 200, 429]  # independent bucket per IP
+
+
+def test_window_rolls_over_and_allows_again():
+    with use_backend("memcached"):
+
+        @rate_limit(key="ip", rate="2/s", algorithm="fixed_window")
+        def view(_request):
+            return HttpResponse("ok")
+
+        ip = "203.0.113.77"
+        first = exhaust(view, 3, ip=ip)
+        assert first == [200, 200, 429]
+        time.sleep(1.2)  # next clock-aligned 1s window
+        assert exhaust(view, 1, ip=ip) == [200]
+
+
+# ---------------------------------------------------------------------------
+# Middleware over a real Memcached
+# ---------------------------------------------------------------------------
+
+
+@override_settings(
+    RATELIMIT_MIDDLEWARE={"DEFAULT_RATE": "3/m", "BACKEND": "memcached"},
+    RATELIMIT_ALGORITHM="fixed_window",
+)
+def test_middleware_enforces_default_rate():
+    with use_backend("memcached"):
+        mw = RateLimitMiddleware(lambda req: HttpResponse("ok"))
+        codes = [
+            mw(make_request(ip="203.0.113.90", path="/api/x")).status_code
+            for _ in range(5)
+        ]
+        assert codes.count(200) == 3
+        assert codes[-1] == 429
+
+
+# ---------------------------------------------------------------------------
+# Real-life scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_login_brute_force_throttle():
+    """A login endpoint capped at 5 attempts/min per IP blocks the 6th try."""
+    with use_backend("memcached"):
+
+        @rate_limit(key="ip", rate="5/m", algorithm="fixed_window", block=True)
+        def login(_request):
+            return HttpResponse("login form")
+
+        attacker = "203.0.113.6"
+        codes = exhaust(login, 8, ip=attacker)
+        assert codes[:5] == [200] * 5
+        assert all(c == 429 for c in codes[5:])
+        # A different user from another IP is unaffected.
+        assert exhaust(login, 1, ip="203.0.113.7") == [200]
+
+
+def test_scenario_api_quota_per_api_key():
+    """Per-API-key quota: each key gets its own budget via a header key."""
+    with use_backend("memcached"):
+
+        @rate_limit(
+            key=lambda r, *a, **k: f"apikey:{r.headers.get('X-API-Key', 'anon')}",
+            rate="4/m",
+            algorithm="fixed_window",
+        )
+        def api(_request):
+            return HttpResponse("data")
+
+        def call(api_key):
+            return api(make_request(headers={"X-API-Key": api_key})).status_code
+
+        gold = [call("gold") for _ in range(5)]
+        silver = [call("silver") for _ in range(2)]
+        assert gold == [200, 200, 200, 200, 429]
+        assert silver == [200, 200]  # separate key, separate quota
+
+
+def test_scenario_burst_traffic_under_limit_all_allowed():
+    """A burst that stays under the limit is fully served."""
+    with use_backend("memcached"):
+
+        @rate_limit(key="ip", rate="50/m", algorithm="fixed_window")
+        def page(_request):
+            return HttpResponse("ok")
+
+        codes = exhaust(page, 40, ip="203.0.113.123")
+        assert codes == [200] * 40
+
+
+def test_scenario_fail_open_when_memcached_unreachable():
+    """With fail_open, a dead Memcached lets traffic through (availability)."""
+    with use_backend("memcached"):
+
+        @rate_limit(
+            key="ip",
+            rate="1/m",
+            algorithm="fixed_window",
+            backend="django_smart_ratelimit.backends.memcached.MemcachedBackend",
+        )
+        def view(_request):
+            return HttpResponse("ok")
+
+        # Point the live backend instance at a dead port and enable fail_open.
+        backend = get_backend()
+        from pymemcache.client.base import Client
+
+        backend._client = Client(("127.0.0.1", 1), connect_timeout=1, timeout=1)
+        backend.fail_open = True
+        # Both requests are allowed despite the backend being unreachable.
+        codes = exhaust(view, 2, ip="203.0.113.200")
+        assert codes == [200, 200]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -82,6 +82,13 @@ RATELIMIT_REDIS = {
     "db": int(os.environ.get("REDIS_DB", "0")),
 }
 
+# Memcached connection for the memcached backend tests (defaults to localhost;
+# CI sets MEMCACHED_HOST/PORT when a service container is available).
+RATELIMIT_MEMCACHED = {
+    "HOST": os.environ.get("MEMCACHED_HOST", "localhost"),
+    "PORT": int(os.environ.get("MEMCACHED_PORT", "11211")),
+}
+
 RATELIMIT_ALGORITHM = "sliding_window"
 RATELIMIT_KEY_PREFIX = "test:ratelimit:"
 

--- a/tests/test_project/scripts/verify_memcached.py
+++ b/tests/test_project/scripts/verify_memcached.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+"""Manual verification for the Memcached backend.
+
+Run it against a real Memcached to sanity-check the backend by hand, e.g.::
+
+    # start one: docker run -d -p 11211:11211 memcached:alpine
+    python tests/test_project/scripts/verify_memcached.py --host 127.0.0.1 --port 11211
+
+Exits non-zero if any check fails. This is a manual tool (excluded from the
+pytest run via ``norecursedirs``); the automated coverage lives in
+``tests/unit/backends/test_memcached_backend.py`` and
+``tests/e2e/test_memcached_e2e.py``.
+"""
+
+import argparse
+import sys
+import time
+
+
+def _configure_django(host, port):
+    import django
+    from django.conf import settings
+
+    if not settings.configured:
+        settings.configure(
+            DEBUG=True,
+            DATABASES={},
+            INSTALLED_APPS=["django_smart_ratelimit"],
+            RATELIMIT_BACKEND="memcached",
+            RATELIMIT_ALGORITHM="fixed_window",
+            RATELIMIT_KEY_PREFIX="manual:memcached:",
+            RATELIMIT_MEMCACHED={"HOST": host, "PORT": port},
+            DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+        )
+    django.setup()
+
+
+class _Checker:
+    def __init__(self):
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, name, condition, detail=""):
+        if condition:
+            print(f"  [PASS] {name}")
+            self.passed += 1
+        else:
+            print(f"  [FAIL] {name} {detail}")
+            self.failed += 1
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Manual Memcached backend check")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=11211)
+    args = parser.parse_args()
+
+    _configure_django(args.host, args.port)
+
+    from django.http import HttpResponse
+
+    from django_smart_ratelimit import rate_limit
+    from django_smart_ratelimit.backends.memcached import MemcachedBackend
+
+    try:
+        from django.test import RequestFactory
+    except Exception:  # pragma: no cover
+        RequestFactory = None
+
+    c = _Checker()
+    backend = MemcachedBackend(algorithm="fixed_window")
+    suffix = str(time.time_ns())
+
+    print(f"Memcached backend @ {args.host}:{args.port}")
+
+    # 1. Health
+    health = backend.health_check()
+    c.check("health_check reports healthy", health.get("healthy") is True, str(health))
+
+    # 2. Counter increments
+    k = f"counter:{suffix}"
+    seq = [backend.incr(k, 60) for _ in range(5)]
+    c.check("incr counts 1..5 within window", seq == [1, 2, 3, 4, 5], str(seq))
+    c.check("get_count reflects the counter", backend.get_count(k, 60) == 5)
+
+    # 3. Reset
+    backend.reset(k)
+    c.check("reset clears the counter", backend.get_count(k, 60) == 0)
+
+    # 4. Key isolation
+    k1, k2 = f"iso1:{suffix}", f"iso2:{suffix}"
+    backend.incr(k1, 60)
+    backend.incr(k1, 60)
+    backend.incr(k2, 60)
+    c.check(
+        "distinct keys are isolated",
+        backend.get_count(k1, 60) == 2 and backend.get_count(k2, 60) == 1,
+    )
+
+    # 5. Window rollover
+    wk = f"win:{suffix}"
+    backend.incr(wk, 1)
+    backend.incr(wk, 1)
+    before = backend.get_count(wk, 1)
+    time.sleep(1.2)
+    after = backend.incr(wk, 1)
+    c.check(
+        "window rolls over (count resets)",
+        before == 2 and after == 1,
+        f"before={before} after={after}",
+    )
+
+    # 6. Decorator burst-then-block
+    if RequestFactory is not None:
+
+        @rate_limit(key="ip", rate="5/m", algorithm="fixed_window")
+        def view(_request):
+            return HttpResponse("ok")
+
+        def call(ip):
+            req = RequestFactory().get("/")
+            req.META["REMOTE_ADDR"] = ip
+            return view(req).status_code
+
+        ip = f"203.0.113.{int(suffix) % 200}"
+        codes = [call(ip) for _ in range(7)]
+        c.check(
+            "decorator allows 5 then blocks",
+            codes == [200] * 5 + [429, 429],
+            str(codes),
+        )
+
+    print(f"\n=== {c.passed} passed, {c.failed} failed ===")
+    return 1 if c.failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/backends/test_memcached_backend.py
+++ b/tests/unit/backends/test_memcached_backend.py
@@ -1,0 +1,204 @@
+"""Unit tests for the Memcached backend.
+
+Live tests run against a real Memcached when one is reachable (localhost:11211
+by default, or MEMCACHED_HOST/PORT); they skip cleanly otherwise. Error / fail
+behavior is exercised with a mocked client so it always runs.
+"""
+
+import os
+import time
+from unittest import mock
+
+import pytest
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
+
+from django_smart_ratelimit.backends import memcached as mc_module
+from django_smart_ratelimit.backends.factory import BackendFactory
+from django_smart_ratelimit.backends.memcached import (
+    MemcachedBackend,
+    _safe_memcached_key,
+)
+
+MEMCACHED_HOST = os.environ.get("MEMCACHED_HOST", "localhost")
+MEMCACHED_PORT = int(os.environ.get("MEMCACHED_PORT", "11211"))
+
+
+def _memcached_available():
+    if mc_module._MemcacheClient is None:
+        return False
+    try:
+        c = mc_module._MemcacheClient(
+            (MEMCACHED_HOST, MEMCACHED_PORT), connect_timeout=1, timeout=1
+        )
+        c.set(b"__probe__", b"1", expire=2)
+        return c.get(b"__probe__") == b"1"
+    except Exception:
+        return False
+
+
+MEMCACHED_UP = _memcached_available()
+skip_without_memcached = pytest.mark.skipif(
+    not MEMCACHED_UP, reason="live Memcached unavailable"
+)
+
+
+def _backend(**kwargs):
+    return MemcachedBackend(**kwargs)
+
+
+def _unique(prefix="mc"):
+    return f"{prefix}:{time.time_ns()}"
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no server needed)
+# ---------------------------------------------------------------------------
+
+
+def test_safe_key_passthrough_for_normal_keys():
+    assert _safe_memcached_key("ip:203.0.113.7") == "ip:203.0.113.7"
+
+
+def test_safe_key_replaces_spaces():
+    assert " " not in _safe_memcached_key("user name:bob")
+
+
+def test_safe_key_hashes_long_or_control_keys():
+    long_key = "x" * 300
+    safe = _safe_memcached_key(long_key)
+    assert safe.startswith("rl:") and len(safe.encode()) <= 250
+    assert _safe_memcached_key("a\nb").startswith("rl:")
+
+
+def test_parse_server_forms():
+    assert MemcachedBackend._parse_server("10.0.0.1:11211") == ("10.0.0.1", 11211)
+    assert MemcachedBackend._parse_server(["h", 5]) == ("h", 5)
+
+
+def test_missing_pymemcache_raises_improperly_configured():
+    with mock.patch.object(mc_module, "_MemcacheClient", None):
+        with pytest.raises(ImproperlyConfigured):
+            MemcachedBackend()
+
+
+# ---------------------------------------------------------------------------
+# Error / fail-open behavior (mocked client)
+# ---------------------------------------------------------------------------
+
+
+@skip_without_memcached
+def test_incr_fail_open_returns_zero_on_client_error():
+    backend = _backend(fail_open=True)
+    backend._client = mock.Mock()
+    backend._client.add.side_effect = OSError("down")
+    # fail_open -> treated as allowed -> count 0 (under any limit)
+    assert backend.incr("k", 60) == 0
+
+
+@skip_without_memcached
+def test_incr_fail_closed_raises_on_client_error():
+    from django_smart_ratelimit.exceptions import BackendError
+
+    backend = _backend(fail_open=False)
+    backend._client = mock.Mock()
+    backend._client.add.side_effect = OSError("down")
+    # fail_closed -> the shared error handler raises BackendError, which the
+    # decorator/middleware translate into a blocked (429) response.
+    with pytest.raises(BackendError):
+        backend.incr("k", 60)
+
+
+@skip_without_memcached
+def test_get_count_and_reset_swallow_client_errors():
+    backend = _backend()
+    backend._client = mock.Mock()
+    backend._client.get.side_effect = OSError("down")
+    backend._client.delete.side_effect = OSError("down")
+    assert backend.get_count("k", 60) == 0
+    backend.reset("k")  # must not raise
+
+
+@skip_without_memcached
+def test_incr_reseeds_when_key_expires_between_add_and_incr():
+    backend = _backend()
+    backend._client = mock.Mock()
+    backend._client.add.return_value = False  # key "exists"
+    backend._client.incr.return_value = None  # ...but expired before incr
+    assert backend.incr("k", 60) == 1  # re-seeded to 1
+    backend._client.add.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Live behavior
+# ---------------------------------------------------------------------------
+
+
+@skip_without_memcached
+def test_incr_counts_up_within_window():
+    backend = _backend(algorithm="fixed_window")
+    key = _unique()
+    assert [backend.incr(key, 60) for _ in range(5)] == [1, 2, 3, 4, 5]
+    assert backend.get_count(key, 60) == 5
+    backend.reset(key)
+    assert backend.get_count(key, 60) == 0
+
+
+@skip_without_memcached
+def test_distinct_keys_are_isolated():
+    backend = _backend()
+    k1, k2 = _unique("a"), _unique("b")
+    backend.incr(k1, 60)
+    backend.incr(k1, 60)
+    backend.incr(k2, 60)
+    assert backend.get_count(k1, 60) == 2
+    assert backend.get_count(k2, 60) == 1
+
+
+@skip_without_memcached
+def test_window_expiry_resets_count():
+    backend = _backend()
+    key = _unique()
+    # A 1-second window; after it lapses the counter is gone.
+    backend.incr(key, 1)
+    backend.incr(key, 1)
+    assert backend.get_count(key, 1) == 2
+    time.sleep(1.2)
+    # New window (clock-aligned bucket rolled over) starts fresh.
+    assert backend.incr(key, 1) == 1
+
+
+@skip_without_memcached
+def test_health_check_reports_healthy():
+    backend = _backend()
+    health = backend.health_check()
+    assert health["backend"] == "memcached"
+    assert health["healthy"] is True
+
+
+@skip_without_memcached
+def test_check_batch():
+    backend = _backend()
+    key = _unique()
+    backend.incr(key, 60)
+    results = backend.check_batch(
+        [{"key": key, "limit": 3, "period": 60}, {"key": _unique(), "limit": 1}]
+    )
+    assert results[0][0] is True and results[0][1]["count"] == 2
+    assert results[1][0] is True and results[1][1]["count"] == 1
+
+
+@skip_without_memcached
+def test_factory_resolves_memcached_alias():
+    backend = BackendFactory.create_backend("memcached")
+    assert backend.name == "memcached"
+    assert isinstance(backend, MemcachedBackend)
+
+
+@skip_without_memcached
+@override_settings(RATELIMIT_MEMCACHED={"HOST": MEMCACHED_HOST, "PORT": MEMCACHED_PORT})
+def test_respects_ratelimit_memcached_setting():
+    backend = _backend()
+    key = _unique()
+    assert backend.incr(key, 60) == 1


### PR DESCRIPTION
Adds a **Memcached backend** — the last open item on the backends roadmap and a direct answer to discussion #39 (a user wanting a no-Redis option). Additive and opt-in.

## What's new
- **`MemcachedBackend`** (`RATELIMIT_BACKEND = "memcached"`) — clock-aligned **fixed-window** limiting on Memcached's atomic `add`/`incr`. Single server or several nodes (consistent-hashed via `pymemcache.HashClient`); honors `fail_open` + circuit breaker; sanitizes oversized/whitespace keys. Registered as the `memcached` alias.
- Optional `memcached` extra (`pymemcache`), added to `[all]`/`[dev]`.
- Docs: a Memcached section in `docs/backends.md`, the installation extra, README backends list.

## Limitation (documented)
Memcached has no server-side scripting, so `sliding_window`, `token_bucket`, and `leaky_bucket` degrade to fixed-window counting on this backend. Use Redis or the database backend for sliding windows / bucket algorithms.

## Tests (as requested: unit + manual + e2e + real-life scenarios)
- **Unit** (`tests/unit/backends/test_memcached_backend.py`, 16): methods, key safety, `_parse_server`, fail-open/fail-closed + error paths (mocked), pymemcache-missing, factory resolution, window expiry — live tests skip cleanly when Memcached is down.
- **E2E + real-life scenarios** (`tests/e2e/test_memcached_e2e.py`, 9): decorator + middleware over a **real** Memcached — login brute-force throttle, per-API-key quota, burst under limit, window rollover, per-IP isolation, and fail-open on a dead server.
- **Manual** (`tests/test_project/scripts/verify_memcached.py`): standalone, human-runnable, exits non-zero on failure.
- CI gains a `memcached` service so the live tests run; `pymemcache` is in `[all]`.

Full suite: **1935 passed, 9 skipped**. pre-commit clean.