### PR TITLE
feat: Redis Cluster backend (v4.9.0, closes #68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.9.0] - 2026-06-05
+
+Adds **Redis Cluster** support (issue #68), built on a contributor refactor that
+makes the Redis client construction overridable.
+
+### Added
+
+- **`RedisClusterBackend`** (`RATELIMIT_BACKEND = "redis_cluster"`) — rate
+  limiting against a Redis Cluster. The Lua scripts are each single-key, so they
+  hash to one slot and run correctly on a cluster; only the client construction
+  differs. Configure via `RATELIMIT_REDIS` with a seed `host`/`port`, a list of
+  `startup_nodes`, or a `url`. Verified against a real 6-node cluster (sliding
+  window, fixed window, token bucket, decorator enforcement). Registered as the
+  `redis_cluster` alias and exported as `RedisClusterBackend`.
+- **`init_client()` seam** on `RedisBackend` and `AsyncRedisBackend` — client
+  creation is now an overridable method, so a custom/cluster client only needs to
+  override `init_client()` instead of `__init__`/`_reconnect`/`_get_client`.
+  Thanks to @zbohm (CZ-NIC) for this refactor (#92). The async `init_client()`
+  now covers both the URL and host/port paths.
+
+### Testing
+
+- Unit tests (mocked `RedisCluster`, run everywhere) plus integration tests
+  against a real cluster (skipped when none is reachable) in
+  `tests/integration/test_redis_cluster.py`, and a manual
+  `tests/test_project/scripts/verify_redis_cluster.py`.
+
 ## [4.8.0] - 2026-06-04
 
 Adds a **Memcached backend** — the last open item on the backends roadmap and a

--- a/django_smart_ratelimit/__init__.py
+++ b/django_smart_ratelimit/__init__.py
@@ -5,7 +5,7 @@ with support for multiple backends, algorithms (including token bucket),
 and comprehensive rate limiting strategies.
 """
 
-__version__ = "4.8.0"
+__version__ = "4.9.0"
 __author__ = "Yasser Shkeir"
 
 # Optional backend imports (may not be available)
@@ -234,10 +234,11 @@ else:
     MongoDBBackendType = None
 
 RedisBackend: Optional[type] = None
+RedisClusterBackend: Optional[type] = None
 MongoDBBackend: Optional[type] = None
 
 try:
-    from .backends.redis_backend import RedisBackend
+    from .backends.redis_backend import RedisBackend, RedisClusterBackend
 except ImportError:
     pass
 
@@ -309,6 +310,7 @@ __all__ = [
     "MemoryBackend",
     "MultiBackend",
     "RedisBackend",
+    "RedisClusterBackend",
     "MongoDBBackend",
     # Circuit Breaker
     "CircuitBreakerConfig",

--- a/django_smart_ratelimit/backends/factory.py
+++ b/django_smart_ratelimit/backends/factory.py
@@ -13,6 +13,7 @@ BUILTIN_BACKENDS: Dict[str, str] = {
     "memory": "django_smart_ratelimit.backends.memory.MemoryBackend",
     "redis": "django_smart_ratelimit.backends.redis_backend.RedisBackend",
     "async_redis": "django_smart_ratelimit.backends.redis_backend.AsyncRedisBackend",
+    "redis_cluster": "django_smart_ratelimit.backends.redis_backend.RedisClusterBackend",
     "mongodb": "django_smart_ratelimit.backends.mongodb.MongoDBBackend",
     "multi": "django_smart_ratelimit.backends.multi.MultiBackend",
     "database": "django_smart_ratelimit.backends.database.DatabaseBackend",

--- a/django_smart_ratelimit/backends/redis_backend.py
+++ b/django_smart_ratelimit/backends/redis_backend.py
@@ -1154,8 +1154,6 @@ class AsyncRedisBackend(BaseBackend):
         """Get or create async redis client."""
         import asyncio
 
-        from redis import asyncio as aioredis
-
         # Check if client needs to be reset due to closed event loop
         if self.client:
             try:
@@ -1193,11 +1191,10 @@ class AsyncRedisBackend(BaseBackend):
                 if k not in ["algorithm", "key_prefix"]
             }
 
-            if self.url:
-                self.client = aioredis.from_url(self.url, **clean_config)
-            else:
-                self._clean_config = clean_config
-                self.init_client()
+            # Route BOTH the url and host/port paths through init_client so a
+            # subclass (e.g. an async cluster client) can override one method.
+            self._clean_config = clean_config
+            self.init_client()
 
             # Load scripts
             try:
@@ -1214,10 +1211,13 @@ class AsyncRedisBackend(BaseBackend):
         return self.client
 
     def init_client(self) -> None:
-        """Initialize Redis client."""
+        """Initialize the async Redis client (url or host/port)."""
         from redis import asyncio
 
-        self.client = asyncio.Redis(**self._clean_config)
+        if self.url:
+            self.client = asyncio.from_url(self.url, **self._clean_config)
+        else:
+            self.client = asyncio.Redis(**self._clean_config)
 
     async def _load_script(self, client, script_content: str) -> str:
         """Load Lua script into Redis."""
@@ -1388,3 +1388,72 @@ class AsyncRedisBackend(BaseBackend):
 
     def get_reset_time(self, key: str) -> Optional[int]:
         raise NotImplementedError("Use aget_reset_time for AsyncRedisBackend")
+
+
+class RedisClusterBackend(RedisBackend):
+    """Redis backend for a Redis Cluster (roadmap / issue #68).
+
+    Builds on the :meth:`RedisBackend.init_client` seam: the rate-limiting Lua
+    scripts are each single-key, so they hash to one slot and run correctly on a
+    cluster -- only the client construction differs. Configure it via
+    ``RATELIMIT_REDIS`` with either a seed ``host``/``port``, a list of
+    ``startup_nodes``, or a ``url``::
+
+        RATELIMIT_BACKEND = "redis_cluster"
+        RATELIMIT_REDIS = {
+            "startup_nodes": [
+                {"host": "10.0.0.1", "port": 7000},
+                {"host": "10.0.0.2", "port": 7000},
+            ],
+            # ...or a single seed node the cluster is discovered from:
+            # "host": "10.0.0.1", "port": 7000,
+            # ...or a URL:
+            # "url": "redis://10.0.0.1:7000/0",
+        }
+
+    Requires ``redis>=4.1`` (which bundles ``redis.cluster.RedisCluster``).
+    """
+
+    name = "redis_cluster"
+
+    @classmethod
+    def _get_or_create_pool(cls, *args: Any, **kwargs: Any) -> Any:
+        """No shared pool: a Redis Cluster client owns a pool per node.
+
+        Accepts (and ignores) any args so a ``url`` present in both the
+        positional slot and ``RATELIMIT_REDIS`` does not collide.
+        """
+        return None
+
+    @staticmethod
+    def _to_cluster_node(node: Any) -> Any:
+        """Coerce a ``{'host','port'}`` dict or ``'host:port'`` string to a node."""
+        from redis.cluster import ClusterNode
+
+        if isinstance(node, dict):
+            return ClusterNode(node["host"], int(node.get("port", 6379)))
+        if isinstance(node, str) and ":" in node:
+            host, port = node.rsplit(":", 1)
+            return ClusterNode(host, int(port))
+        return node
+
+    def init_client(self) -> None:
+        """Build a ``RedisCluster`` client from ``RATELIMIT_REDIS``."""
+        from redis.cluster import RedisCluster
+
+        cfg = dict(self.config)
+        # Cluster mode has no logical DBs and manages its own pools.
+        cfg.pop("db", None)
+        cfg.pop("connection_pool", None)
+        url = cfg.pop("url", None)
+        startup_nodes = cfg.pop("startup_nodes", None) or cfg.pop("nodes", None)
+        host = cfg.pop("host", "127.0.0.1")
+        port = int(cfg.pop("port", 6379))
+
+        if url:
+            self.redis = RedisCluster.from_url(url, **cfg)
+        elif startup_nodes:
+            nodes = [self._to_cluster_node(n) for n in startup_nodes]
+            self.redis = RedisCluster(startup_nodes=nodes, **cfg)
+        else:
+            self.redis = RedisCluster(host=host, port=port, **cfg)

--- a/django_smart_ratelimit/backends/redis_backend.py
+++ b/django_smart_ratelimit/backends/redis_backend.py
@@ -308,7 +308,7 @@ class RedisBackend(BaseBackend):
         try:
             # Get or create connection pool
             self._pool = self._get_or_create_pool(url, **self.config)
-            self.redis = redis.Redis(connection_pool=self._pool)
+            self.init_client()
 
             # Initial verification
             self._check_connection(raise_exception=True)
@@ -359,6 +359,10 @@ class RedisBackend(BaseBackend):
             level="info",
         )
 
+    def init_client(self) -> None:
+        """Initialize Redis client."""
+        self.redis = redis.Redis(connection_pool=self._pool)
+
     @classmethod
     def _get_or_create_pool(cls, url: Optional[str], **kwargs: Any) -> Any:
         """Get or create a connection pool."""
@@ -402,7 +406,7 @@ class RedisBackend(BaseBackend):
                 self._pool.disconnect()  # Reset connections
             # Redis client automatically uses the pool, so resetting pool is enough?
             # Or create new client?
-            self.redis = redis.Redis(connection_pool=self._pool)
+            self.init_client()
         except Exception:
             # log but don't crash
             pass  # nosec B110 - intentional resilient error handling
@@ -1192,7 +1196,8 @@ class AsyncRedisBackend(BaseBackend):
             if self.url:
                 self.client = aioredis.from_url(self.url, **clean_config)
             else:
-                self.client = aioredis.Redis(**clean_config)
+                self._clean_config = clean_config
+                self.init_client()
 
             # Load scripts
             try:
@@ -1207,6 +1212,11 @@ class AsyncRedisBackend(BaseBackend):
                 pass  # nosec B110 - intentional resilient error handling
 
         return self.client
+
+    def init_client(self) -> None:
+        """Initialize Redis client."""
+        from redis import asyncio
+        self.client = asyncio.Redis(**self._clean_config)
 
     async def _load_script(self, client, script_content: str) -> str:
         """Load Lua script into Redis."""

--- a/django_smart_ratelimit/backends/redis_backend.py
+++ b/django_smart_ratelimit/backends/redis_backend.py
@@ -1216,6 +1216,7 @@ class AsyncRedisBackend(BaseBackend):
     def init_client(self) -> None:
         """Initialize Redis client."""
         from redis import asyncio
+
         self.client = asyncio.Redis(**self._clean_config)
 
     async def _load_script(self, client, script_content: str) -> str:

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -22,6 +22,7 @@ The recognized short aliases (from `backends/factory.py`, `BUILTIN_BACKENDS`) ar
 | `memory`      | `django_smart_ratelimit.backends.memory.MemoryBackend`           |
 | `redis`       | `django_smart_ratelimit.backends.redis_backend.RedisBackend`     |
 | `async_redis` | `django_smart_ratelimit.backends.redis_backend.AsyncRedisBackend`|
+| `redis_cluster` | `django_smart_ratelimit.backends.redis_backend.RedisClusterBackend` |
 | `mongodb`     | `django_smart_ratelimit.backends.mongodb.MongoDBBackend`         |
 | `multi`       | `django_smart_ratelimit.backends.multi.MultiBackend`             |
 | `database`    | `django_smart_ratelimit.backends.database.DatabaseBackend`       |
@@ -67,6 +68,36 @@ When `RATELIMIT_BACKEND = "redis"`, async views automatically use `AsyncRedisBac
 
 - Requirements: `redis-py` >= 4.2.0.
 - Pros: non-blocking IO, high performance for async apps.
+
+### Redis Cluster Backend
+
+**Alias**: `redis_cluster` &nbsp; **Class**: `django_smart_ratelimit.backends.redis_backend.RedisClusterBackend`
+
+Targets a [Redis Cluster](https://redis.io/docs/management/scaling/). The
+rate-limiting Lua scripts are each single-key, so every operation hashes to one
+slot and runs correctly on a cluster — only the client construction differs.
+Configure it with a seed node, a list of `startup_nodes`, or a URL:
+
+```python
+# settings.py
+RATELIMIT_BACKEND = "redis_cluster"
+RATELIMIT_REDIS = {
+    "startup_nodes": [
+        {"host": "10.0.0.1", "port": 7000},
+        {"host": "10.0.0.2", "port": 7000},
+    ],
+    # ...or a single seed node the cluster is discovered from:
+    # "host": "10.0.0.1", "port": 7000,
+    # ...or a URL:
+    # "url": "redis://10.0.0.1:7000/0",
+}
+```
+
+- Requirements: `redis-py` >= 4.1 (bundles `redis.cluster.RedisCluster`).
+- Pros: horizontal scale and high availability across many nodes.
+- Note: cluster mode has no logical databases, so a `db` in `RATELIMIT_REDIS` is
+  ignored. Custom clients can be supplied by subclassing and overriding
+  `init_client()`.
 
 ### MongoDB Backend
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-smart-ratelimit"
-version = "4.8.0"
+version = "4.9.0"
 dynamic = []
 description = "A flexible and efficient rate limiting library for Django applications"
 readme = "README.md"

--- a/tests/integration/test_redis_cluster.py
+++ b/tests/integration/test_redis_cluster.py
@@ -1,0 +1,194 @@
+"""Tests for the Redis Cluster backend (issue #68).
+
+Unit tests use a mocked ``RedisCluster`` and always run. Integration tests run
+against a real cluster when one is reachable (127.0.0.1:7100 by default, or
+REDIS_CLUSTER_HOST/PORT) and skip cleanly otherwise. A 6-node cluster can be
+started for local testing with::
+
+    docker run -d -p 7100-7105:7100-7105 -e IP=127.0.0.1 -e INITIAL_PORT=7100 \
+        grokzen/redis-cluster:7.0.10
+"""
+
+import os
+import time
+from unittest import mock
+
+import pytest
+
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
+
+from django_smart_ratelimit import rate_limit
+from django_smart_ratelimit.backends.factory import BackendFactory
+from django_smart_ratelimit.backends.redis_backend import RedisClusterBackend
+from django_smart_ratelimit.config import reset_settings
+
+CLUSTER_HOST = os.environ.get("REDIS_CLUSTER_HOST", "127.0.0.1")
+CLUSTER_PORT = int(os.environ.get("REDIS_CLUSTER_PORT", "7100"))
+
+
+def _cluster_available():
+    try:
+        from redis.cluster import RedisCluster
+
+        rc = RedisCluster(
+            host=CLUSTER_HOST, port=CLUSTER_PORT, socket_connect_timeout=1
+        )
+        return bool(rc.ping())
+    except Exception:
+        return False
+
+
+CLUSTER_UP = _cluster_available()
+skip_without_cluster = pytest.mark.skipif(
+    not CLUSTER_UP, reason="live Redis Cluster unavailable"
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit (mocked RedisCluster) -- always run, including in CI
+# ---------------------------------------------------------------------------
+
+
+def test_get_or_create_pool_is_none_for_cluster():
+    # The cluster client owns its per-node pools; no shared pool is built.
+    assert RedisClusterBackend._get_or_create_pool("redis://x") is None
+
+
+def test_to_cluster_node_forms():
+    from redis.cluster import ClusterNode
+
+    n1 = RedisClusterBackend._to_cluster_node({"host": "h", "port": 7000})
+    n2 = RedisClusterBackend._to_cluster_node("h2:7001")
+    assert isinstance(n1, ClusterNode) and (n1.host, n1.port) == ("h", 7000)
+    assert isinstance(n2, ClusterNode) and (n2.host, n2.port) == ("h2", 7001)
+
+
+def _mock_cluster():
+    """A RedisCluster stand-in whose ping() passes the init health check."""
+    client = mock.MagicMock()
+    client.ping.return_value = True
+    return client
+
+
+@override_settings(RATELIMIT_REDIS={"host": "10.0.0.1", "port": 7000})
+def test_init_client_builds_rediscluster_from_seed():
+    reset_settings()
+    with mock.patch("redis.cluster.RedisCluster") as RC:
+        RC.return_value = _mock_cluster()
+        backend = RedisClusterBackend()
+        # Built from a seed host/port; db is dropped (cluster has no DBs).
+        _, kwargs = RC.call_args
+        assert kwargs.get("host") == "10.0.0.1" and kwargs.get("port") == 7000
+        assert "db" not in kwargs
+        assert backend._pool is None
+    reset_settings()
+
+
+@override_settings(
+    RATELIMIT_REDIS={
+        "startup_nodes": [{"host": "10.0.0.1", "port": 7000}, "10.0.0.2:7000"]
+    }
+)
+def test_init_client_builds_from_startup_nodes():
+    reset_settings()
+    with mock.patch("redis.cluster.RedisCluster") as RC:
+        RC.return_value = _mock_cluster()
+        RedisClusterBackend()
+        _, kwargs = RC.call_args
+        nodes = kwargs.get("startup_nodes")
+        assert nodes is not None and len(nodes) == 2
+    reset_settings()
+
+
+@override_settings(RATELIMIT_REDIS={"url": "redis://10.0.0.1:7000/0"})
+def test_init_client_builds_from_url():
+    reset_settings()
+    with mock.patch("redis.cluster.RedisCluster") as RC:
+        RC.from_url.return_value = _mock_cluster()
+        RedisClusterBackend()
+        RC.from_url.assert_called_once()
+    reset_settings()
+
+
+def test_init_client_is_an_overridable_seam():
+    # Demonstrates the extension point (the point of PR #92): a subclass can
+    # supply any client by overriding only init_client.
+    sentinel = _mock_cluster()
+
+    class CustomClusterBackend(RedisClusterBackend):
+        def init_client(self) -> None:
+            self.redis = sentinel
+
+    with override_settings(RATELIMIT_REDIS={"host": "x", "port": 1}):
+        reset_settings()
+        backend = CustomClusterBackend()
+        assert backend.redis is sentinel
+        reset_settings()
+
+
+# ---------------------------------------------------------------------------
+# Integration (real cluster) -- skipped when no cluster is reachable
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cluster_backend():
+    with override_settings(
+        RATELIMIT_REDIS={"host": CLUSTER_HOST, "port": CLUSTER_PORT}
+    ):
+        reset_settings()
+        yield RedisClusterBackend
+        reset_settings()
+
+
+@skip_without_cluster
+def test_cluster_incr_count_reset(cluster_backend):
+    backend = cluster_backend(algorithm="fixed_window")
+    key = "cluster:it:%d" % time.time_ns()
+    assert [backend.incr(key, 60) for _ in range(4)] == [1, 2, 3, 4]
+    assert backend.get_count(key, 60) == 4
+    backend.reset(key)
+    assert backend.get_count(key, 60) == 0
+
+
+@skip_without_cluster
+def test_cluster_token_bucket(cluster_backend):
+    backend = cluster_backend()
+    key = "cluster:tb:%d" % time.time_ns()
+    flags = [backend.token_bucket_check(key, 2, 0.0001, 2, 1)[0] for _ in range(4)]
+    assert flags == [True, True, False, False]
+
+
+@skip_without_cluster
+def test_cluster_factory_and_decorator():
+    with override_settings(
+        RATELIMIT_BACKEND="redis_cluster",
+        RATELIMIT_REDIS={"host": CLUSTER_HOST, "port": CLUSTER_PORT},
+    ):
+        reset_settings()
+        from django_smart_ratelimit.backends import clear_backend_cache
+
+        clear_backend_cache()
+        backend = BackendFactory.create_backend("redis_cluster")
+        assert backend.name == "redis_cluster"
+        # Clean slate across the cluster so leftover fixed-window counts from a
+        # prior run in the same minute don't skew the assertion.
+        backend.redis.flushall()
+
+        @rate_limit(
+            key="ip", rate="3/m", algorithm="fixed_window", backend="redis_cluster"
+        )
+        def view(_request):
+            return HttpResponse("ok")
+
+        def call(ip):
+            req = RequestFactory().get("/")
+            req.META["REMOTE_ADDR"] = ip
+            return view(req).status_code
+
+        ip = "203.0.113.%d" % (time.time_ns() % 200)
+        codes = [call(ip) for _ in range(5)]
+        assert codes.count(200) == 3 and codes[-1] == 429
+        clear_backend_cache()
+        reset_settings()

--- a/tests/test_project/scripts/verify_redis_cluster.py
+++ b/tests/test_project/scripts/verify_redis_cluster.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+"""Manual verification for the Redis Cluster backend (issue #68).
+
+Run it against a real Redis Cluster, e.g.::
+
+    # start a 6-node cluster for testing:
+    docker run -d -p 7100-7105:7100-7105 -e IP=127.0.0.1 -e INITIAL_PORT=7100 \
+        grokzen/redis-cluster:7.0.10
+    python tests/test_project/scripts/verify_redis_cluster.py --host 127.0.0.1 --port 7100
+
+Exits non-zero if any check fails. Manual tool (excluded from pytest via
+``norecursedirs``); the automated coverage is in
+``tests/integration/test_redis_cluster.py``.
+"""
+
+import argparse
+import sys
+import time
+
+
+def _configure_django(host, port):
+    import django
+    from django.conf import settings
+
+    if not settings.configured:
+        settings.configure(
+            DEBUG=True,
+            DATABASES={},
+            INSTALLED_APPS=["django_smart_ratelimit"],
+            RATELIMIT_BACKEND="redis_cluster",
+            RATELIMIT_ALGORITHM="sliding_window",
+            RATELIMIT_KEY_PREFIX="manual:cluster:",
+            RATELIMIT_REDIS={"host": host, "port": port},
+            DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+        )
+    django.setup()
+
+
+class _Checker:
+    def __init__(self):
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, name, condition, detail=""):
+        if condition:
+            print(f"  [PASS] {name}")
+            self.passed += 1
+        else:
+            print(f"  [FAIL] {name} {detail}")
+            self.failed += 1
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Manual Redis Cluster backend check")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=7100)
+    args = parser.parse_args()
+
+    _configure_django(args.host, args.port)
+
+    from django.http import HttpResponse
+    from django.test import RequestFactory
+
+    from django_smart_ratelimit import rate_limit
+    from django_smart_ratelimit.backends.redis_backend import RedisClusterBackend
+
+    c = _Checker()
+    suffix = str(time.time_ns())
+    print(f"Redis Cluster backend @ {args.host}:{args.port}")
+
+    backend = RedisClusterBackend(algorithm="fixed_window")
+    c.check("client is RedisCluster", type(backend.redis).__name__ == "RedisCluster")
+    c.check("health_check healthy", backend.health_check().get("status") == "healthy")
+
+    # Counter
+    k = f"counter:{suffix}"
+    seq = [backend.incr(k, 60) for _ in range(5)]
+    c.check("incr counts 1..5", seq == [1, 2, 3, 4, 5], str(seq))
+    c.check("get_count == 5", backend.get_count(k, 60) == 5)
+    backend.reset(k)
+    c.check("reset clears counter", backend.get_count(k, 60) == 0)
+
+    # Token bucket (single-key Lua across the cluster)
+    tk = f"tb:{suffix}"
+    flags = [backend.token_bucket_check(tk, 2, 0.0001, 2, 1)[0] for _ in range(4)]
+    c.check(
+        "token bucket size 2 -> T,T,F,F",
+        flags == [True, True, False, False],
+        str(flags),
+    )
+
+    # Decorator burst-then-block
+    @rate_limit(key="ip", rate="5/m", algorithm="fixed_window")
+    def view(_request):
+        return HttpResponse("ok")
+
+    def call(ip):
+        req = RequestFactory().get("/")
+        req.META["REMOTE_ADDR"] = ip
+        return view(req).status_code
+
+    ip = f"203.0.113.{int(suffix) % 200}"
+    backend.redis.flushall()
+    codes = [call(ip) for _ in range(7)]
+    c.check(
+        "decorator allows 5 then blocks", codes == [200] * 5 + [429, 429], str(codes)
+    )
+
+    print(f"\n=== {c.passed} passed, {c.failed} failed ===")
+    return 1 if c.failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds **Redis Cluster** support — the one remaining user-requested feature (#68) — built on top of @zbohm's `init_client` refactor (#92).

## Foundation: #92 (thanks @zbohm / CZ-NIC)
This PR carries forward @zbohm's commit (authorship preserved) which extracts Redis client creation into an overridable `init_client()` on both the sync and async backends. Since their fork has "allow maintainer edits" off, I rebased their commit onto `main`, applied the one-line `black` fix CI wanted, and built the cluster backend on top. The async `init_client()` now also covers the URL path (a review follow-up).

## RedisClusterBackend
`RATELIMIT_BACKEND = "redis_cluster"` — overrides `init_client()` to build a `redis.cluster.RedisCluster`. The rate-limiting Lua scripts are each **single-key**, so they hash to one slot and run correctly on a cluster; only the client construction differs.

```python
RATELIMIT_BACKEND = "redis_cluster"
RATELIMIT_REDIS = {
    "startup_nodes": [{"host": "10.0.0.1", "port": 7000}, {"host": "10.0.0.2", "port": 7000}],
    # or "host"/"port" seed, or "url"
}
```

## Verification (against a real 6-node cluster)
I stood up a `grokzen/redis-cluster` cluster and confirmed sliding window, fixed window, token bucket, reset, factory resolution, and decorator enforcement all work — `script_load` distributes and `evalsha` routes by key correctly.

## Tests
- **Unit** (mocked `RedisCluster`, run in CI): client construction from seed/startup_nodes/url, node parsing, the no-shared-pool override, and the `init_client` extension point.
- **Integration** (real cluster, skipped when none reachable): incr/count/reset, token bucket, factory + decorator.
- **Manual**: `tests/test_project/scripts/verify_redis_cluster.py`.
- Docs: a Redis Cluster section in `docs/backends.md`.

Full suite: **1924 passed**. pre-commit clean.

Closes #68. Supersedes #92 (carried forward with credit).