### PR TITLE
feat: concurrency (in-flight) limiting (v4.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.10.0] - 2026-06-05
+
+First of the high-leverage additive features from the post-4.x roadmap (#76):
+**concurrency limiting**. Additive and opt-in.
+
+### Added
+
+- **`@concurrency_limit(key=..., max_concurrent=N)`** — cap the number of
+  requests in flight *at the same time* for a key (e.g. "5 simultaneous exports
+  per user"), as opposed to requests per time window. Backed by an atomic
+  semaphore: a Redis sorted set (`concurrency_acquire`/`concurrency_release` via
+  Lua) or the in-memory backend. A slot whose request crashed before releasing is
+  reclaimed after `ttl` seconds, so the limiter self-heals. Supports sync and
+  async views, the same `key` forms as `@rate_limit`, and `block=False` for
+  observe-only mode. Exported as `concurrency_limit`.
+- Backend semaphore primitives `concurrency_acquire` / `concurrency_release` on
+  the Redis and memory backends (the Redis script is lazy-loaded, leaving the
+  init-time `script_load` count unchanged).
+- Docs: a Concurrency Limiting guide.
+
+### Notes
+
+- Requires the Redis or memory backend; other backends raise
+  `ImproperlyConfigured` when a concurrency-limited view is called. Use Redis for
+  any multi-process / multi-host deployment (the memory semaphore is per-process).
+
 ## [4.9.0] - 2026-06-05
 
 Adds **Redis Cluster** support (issue #68), built on a contributor refactor that

--- a/django_smart_ratelimit/__init__.py
+++ b/django_smart_ratelimit/__init__.py
@@ -5,7 +5,7 @@ with support for multiple backends, algorithms (including token bucket),
 and comprehensive rate limiting strategies.
 """
 
-__version__ = "4.9.0"
+__version__ = "4.10.0"
 __author__ = "Yasser Shkeir"
 
 # Optional backend imports (may not be available)
@@ -61,10 +61,11 @@ from .circuit_breaker import (
     circuit_breaker_registry,
 )
 
+# Core functionality
+from .concurrency import concurrency_limit
+
 # Configuration
 from .configuration import RateLimitConfigManager
-
-# Core functionality
 from .decorator import aratelimit, rate_limit
 
 # Enums for type-safe configuration
@@ -267,6 +268,7 @@ __all__ = [
     "rate_limit",
     "ratelimit",  # Alias for rate_limit
     "aratelimit",  # Async decorator
+    "concurrency_limit",
     "RateLimitMiddleware",
     # Logging
     "RATELIMIT_LOG_FORMAT",

--- a/django_smart_ratelimit/backends/memory.py
+++ b/django_smart_ratelimit/backends/memory.py
@@ -138,6 +138,9 @@ class MemoryBackend(BaseBackend):
         # Generic storage for algorithm implementations
         self._storage: Dict[str, Any] = {}
 
+        # Concurrency (in-flight) semaphores: {key: {member: acquire_ts}}
+        self._concurrency: Dict[str, Dict[str, float]] = {}
+
         # Lock for thread safety
         self._lock = threading.RLock()
 
@@ -446,6 +449,33 @@ class MemoryBackend(BaseBackend):
                 return int(oldest_ts + period)
 
             return int(expiry_time)
+
+    # Concurrency (in-flight) Semaphore
+
+    def concurrency_acquire(
+        self, key: str, max_concurrent: int, ttl: int, member: str
+    ) -> bool:
+        """Take one of ``max_concurrent`` in-flight slots; reclaim leaked ones."""
+        now = get_current_timestamp()
+        with self._lock:
+            holders = self._concurrency.setdefault(key, {})
+            # Drop holders older than ttl (a request that crashed before release).
+            stale = [m for m, ts in holders.items() if ts <= now - ttl]
+            for m in stale:
+                holders.pop(m, None)
+            if len(holders) < max_concurrent:
+                holders[member] = now
+                return True
+            return False
+
+    def concurrency_release(self, key: str, member: str) -> None:
+        """Release a previously acquired concurrency slot (best-effort)."""
+        with self._lock:
+            holders = self._concurrency.get(key)
+            if holders is not None:
+                holders.pop(member, None)
+                if not holders:
+                    self._concurrency.pop(key, None)
 
     # Token Bucket Algorithm Implementation
 

--- a/django_smart_ratelimit/backends/redis_backend.py
+++ b/django_smart_ratelimit/backends/redis_backend.py
@@ -255,6 +255,29 @@ class RedisBackend(BaseBackend):
         return {math.floor(level * 1000), math.floor(last_leak * 1000)}
     """  # nosec B105
 
+    # Atomic concurrency (in-flight) semaphore. Each in-flight request is a ZSET
+    # member scored by its acquire time; holders older than the ttl are assumed
+    # leaked (crashed before release) and reclaimed. Returns 1 if the slot was
+    # acquired, else 0. Loaded lazily on first use so it does not change the
+    # init-time script_load count.
+    CONCURRENCY_ACQUIRE_SCRIPT = """
+        local key = KEYS[1]
+        local max_concurrent = tonumber(ARGV[1])
+        local now = tonumber(ARGV[2])
+        local ttl = tonumber(ARGV[3])
+        local member = ARGV[4]
+
+        redis.call('ZREMRANGEBYSCORE', key, 0, now - ttl)
+        local count = redis.call('ZCARD', key)
+        if count < max_concurrent then
+            redis.call('ZADD', key, now, member)
+            redis.call('EXPIRE', key, ttl + 1)
+            return 1
+        else
+            return 0
+        end
+    """  # nosec B105
+
     def __init__(
         self,
         enable_circuit_breaker: bool = True,
@@ -336,6 +359,8 @@ class RedisBackend(BaseBackend):
             self.leaky_bucket_info_sha = self._load_script(
                 self.LEAKY_BUCKET_INFO_SCRIPT
             )
+            # Lazily loaded on first use (keeps the init script_load count stable).
+            self.concurrency_acquire_sha = ""  # nosec B105 - SHA cache init
         else:
             self.sliding_window_sha = ""
             self.fixed_window_sha = ""
@@ -347,6 +372,7 @@ class RedisBackend(BaseBackend):
             self.leaky_bucket_info_sha = (
                 ""  # nosec B105 - not a password, SHA cache init
             )
+            self.concurrency_acquire_sha = ""  # nosec B105 - SHA cache init
 
         # Configuration
         self.algorithm = settings.default_algorithm
@@ -910,6 +936,56 @@ class RedisBackend(BaseBackend):
                 "time_to_empty": 0.0,
                 "last_leak": current_time,
             }
+
+    def concurrency_acquire(
+        self, key: str, max_concurrent: int, ttl: int, member: str
+    ) -> bool:
+        """Atomically try to take one of ``max_concurrent`` in-flight slots.
+
+        Args:
+            key: Concurrency key (e.g. ``user:42``).
+            max_concurrent: Maximum simultaneous holders.
+            ttl: Seconds after which a holder is assumed leaked and reclaimed.
+            member: Unique id for this holder (released with the same id).
+
+        Returns:
+            ``True`` if a slot was acquired, ``False`` if at capacity.
+        """
+        normalized_key = normalize_key(f"{key}:concurrency", self.key_prefix)
+        now = get_current_timestamp()
+        try:
+            result = self._eval_lua(
+                "concurrency_acquire_sha",
+                self.CONCURRENCY_ACQUIRE_SCRIPT,
+                1,
+                normalized_key,
+                max_concurrent,
+                now,
+                ttl,
+                member,
+            )
+            return bool(result)
+        except Exception as e:
+            log_backend_operation(
+                "redis_concurrency_acquire_error",
+                f"Concurrency acquire failed for key {key}: {e}",
+                level="error",
+            )
+            if self.fail_open:
+                return True
+            raise BackendError(ERROR_BACKEND_UNAVAILABLE) from e
+
+    def concurrency_release(self, key: str, member: str) -> None:
+        """Release a previously acquired concurrency slot (best-effort)."""
+        normalized_key = normalize_key(f"{key}:concurrency", self.key_prefix)
+        try:
+            self.redis.zrem(normalized_key, member)
+        except Exception as e:  # pragma: no cover - a missed release is reclaimed
+            log_backend_operation(
+                "redis_concurrency_release_error",
+                f"Concurrency release failed for key {key}: {e}",
+                level="warning",
+            )
 
     def check_batch(
         self,

--- a/django_smart_ratelimit/concurrency.py
+++ b/django_smart_ratelimit/concurrency.py
@@ -1,0 +1,140 @@
+"""Concurrency (in-flight) limiting (roadmap #76, Tier 1).
+
+Caps the number of requests being processed *at the same time* for a key, rather
+than the number of requests per time window. For example, "at most 5 simultaneous
+exports per user". Backed by an atomic semaphore (a Redis sorted set, or the
+in-memory backend); a slot whose request crashed before releasing is reclaimed
+after ``ttl`` seconds, so the limiter self-heals.
+
+Usage::
+
+    from django_smart_ratelimit import concurrency_limit
+
+    @concurrency_limit(key="user", max_concurrent=5)
+    def export_view(request):
+        ...
+
+The key resolves exactly like ``@rate_limit``'s ``key`` (``"ip"``, ``"user"``,
+a template such as ``"user:{user.id}"``, or a callable). Requires a backend with
+semaphore support (Redis or memory); other backends raise at call time.
+"""
+
+import functools
+import logging
+import uuid
+from typing import Any, Callable, Optional, Union
+
+from asgiref.sync import iscoroutinefunction, sync_to_async
+
+from django.core.exceptions import ImproperlyConfigured
+
+from .backends import get_backend
+from .decorator import _create_rate_limit_response, _get_request_from_args
+from .key_functions import generate_key
+
+logger = logging.getLogger(__name__)
+
+_OVER_CAPACITY_MESSAGE = "Too many concurrent requests. Please retry shortly."
+
+
+def _resolve_concurrency_key(
+    key: Union[str, Callable], request: Any, args: Any, kwargs: Any
+) -> str:
+    """Resolve the concurrency key the same way the rate-limit decorator does."""
+    generated = generate_key(key, request, *args, **kwargs)
+    return f"concurrency:{generated}"
+
+
+def _require_semaphore_backend(backend_instance: Any) -> None:
+    if not hasattr(backend_instance, "concurrency_acquire"):
+        raise ImproperlyConfigured(
+            "concurrency_limit requires a backend with semaphore support "
+            "(the redis or memory backend); "
+            f"{type(backend_instance).__name__} does not provide it."
+        )
+
+
+def concurrency_limit(
+    key: Union[str, Callable],
+    max_concurrent: int,
+    *,
+    ttl: int = 60,
+    backend: Optional[str] = None,
+    block: bool = True,
+    response_callback: Optional[Callable] = None,
+) -> Callable:
+    """Limit the number of simultaneous in-flight requests for ``key``.
+
+    Args:
+        key: Concurrency key or callable (resolved like ``@rate_limit``'s key).
+        max_concurrent: Maximum requests allowed in flight at once.
+        ttl: Seconds after which a held slot is assumed leaked and reclaimed
+            (set it above your longest expected request duration).
+        backend: Optional backend name override.
+        block: When True (default), an over-capacity request gets a 429; when
+            False, it is allowed through without holding a slot.
+        response_callback: Optional ``(request) -> HttpResponse`` for the 429.
+    """
+
+    def decorator(func: Callable) -> Callable:
+        if iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def awrapper(*args: Any, **kwargs: Any) -> Any:
+                request = _get_request_from_args(*args, **kwargs)
+                if request is None:
+                    return await func(*args, **kwargs)
+
+                limit_key = _resolve_concurrency_key(key, request, args, kwargs)
+                backend_instance: Any = get_backend(backend)
+                _require_semaphore_backend(backend_instance)
+                member = uuid.uuid4().hex
+
+                acquired = await sync_to_async(backend_instance.concurrency_acquire)(
+                    limit_key, max_concurrent, ttl, member
+                )
+                if not acquired and block:
+                    return _create_rate_limit_response(
+                        _OVER_CAPACITY_MESSAGE,
+                        request=request,
+                        response_callback=response_callback,
+                    )
+                try:
+                    return await func(*args, **kwargs)
+                finally:
+                    if acquired:
+                        await sync_to_async(backend_instance.concurrency_release)(
+                            limit_key, member
+                        )
+
+            return awrapper
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            request = _get_request_from_args(*args, **kwargs)
+            if request is None:
+                return func(*args, **kwargs)
+
+            limit_key = _resolve_concurrency_key(key, request, args, kwargs)
+            backend_instance: Any = get_backend(backend)
+            _require_semaphore_backend(backend_instance)
+            member = uuid.uuid4().hex
+
+            acquired = backend_instance.concurrency_acquire(
+                limit_key, max_concurrent, ttl, member
+            )
+            if not acquired and block:
+                return _create_rate_limit_response(
+                    _OVER_CAPACITY_MESSAGE,
+                    request=request,
+                    response_callback=response_callback,
+                )
+            try:
+                return func(*args, **kwargs)
+            finally:
+                if acquired:
+                    backend_instance.concurrency_release(limit_key, member)
+
+        return wrapper
+
+    return decorator

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -1,0 +1,68 @@
+# Concurrency Limiting
+
+Rate limiting caps requests *per time window*. **Concurrency limiting** caps how
+many requests are being processed **at the same time** for a key — for example,
+"at most 5 simultaneous exports per user". It's the right tool for protecting
+expensive, long-running endpoints from pile-ups.
+
+```python
+from django_smart_ratelimit import concurrency_limit
+
+@concurrency_limit(key="user", max_concurrent=5)
+def export_view(request):
+    ...  # at most 5 of these run concurrently per user
+```
+
+When the limit is reached, additional requests get a `429` until an in-flight
+request finishes and frees a slot.
+
+## How it works
+
+Each in-flight request takes a slot from an **atomic semaphore** (a Redis sorted
+set, or the in-memory backend) on entry and releases it on exit. If a request
+crashes before releasing, its slot is reclaimed after `ttl` seconds, so the
+limiter self-heals rather than deadlocking.
+
+## Arguments
+
+| Argument | Default | Description |
+| --- | --- | --- |
+| `key` | — | Concurrency key. Resolves exactly like `@rate_limit`'s `key`: `"ip"`, `"user"`, a template such as `"user:{user.id}"`, or a callable. |
+| `max_concurrent` | — | Maximum requests allowed in flight at once. |
+| `ttl` | `60` | Seconds after which a held slot is assumed leaked and reclaimed. Set it above your longest expected request duration. |
+| `backend` | `None` | Backend name override (defaults to the configured backend). |
+| `block` | `True` | When `True`, an over-capacity request gets a `429`. When `False`, it runs anyway without holding a slot. |
+| `response_callback` | `None` | Optional `(request) -> HttpResponse` for the over-capacity response. |
+
+## Examples
+
+```python
+# Per-IP cap on a heavy report endpoint, with a generous hold time.
+@concurrency_limit(key="ip", max_concurrent=3, ttl=300)
+def report(request):
+    ...
+
+# A callable key, and observe-only mode (never blocks, just frees slots).
+@concurrency_limit(key=lambda r: f"team:{r.user.team_id}", max_concurrent=10, block=False)
+def bulk_import(request):
+    ...
+
+# Async views are supported too.
+@concurrency_limit(key="user", max_concurrent=2)
+async def async_export(request):
+    ...
+```
+
+## Backends
+
+Concurrency limiting needs a backend with semaphore support:
+
+- **Redis** (recommended for production) — atomic and shared across processes and
+  hosts. Use this for any multi-process / multi-host deployment.
+- **Memory** — works in a single process; fine for development. (It is not shared
+  across processes, so it does not enforce a global limit in a multi-worker
+  deployment.)
+
+Other backends raise `ImproperlyConfigured` when a concurrency-limited view is
+called. This is independent of `RATELIMIT_BACKEND` for rate limiting — you can
+pass `backend="redis"` to `@concurrency_limit` specifically.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
       - Observability: observability.md
       - Deployment: deployment.md
   - Features:
+      - Concurrency Limiting: concurrency.md
       - Dynamic Rules: dynamic_rules.md
       - User Tiers: user_tiers.md
       - Analytics: analytics.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-smart-ratelimit"
-version = "4.9.0"
+version = "4.10.0"
 dynamic = []
 description = "A flexible and efficient rate limiting library for Django applications"
 readme = "README.md"

--- a/tests/e2e/test_memcached_e2e.py
+++ b/tests/e2e/test_memcached_e2e.py
@@ -77,6 +77,10 @@ def test_window_rolls_over_and_allows_again():
             return HttpResponse("ok")
 
         ip = "203.0.113.77"
+        # Align to just after a 1s clock boundary so the burst lands entirely in
+        # one window (clock-aligned fixed windows otherwise let a burst straddle
+        # a boundary and admit more than the limit -- a timing flake on CI).
+        time.sleep(1.0 - (time.time() % 1.0) + 0.05)
         first = exhaust(view, 3, ip=ip)
         assert first == [200, 200, 429]
         time.sleep(1.2)  # next clock-aligned 1s window

--- a/tests/integration/test_concurrency_limit.py
+++ b/tests/integration/test_concurrency_limit.py
@@ -1,0 +1,191 @@
+"""Tests for concurrency (in-flight) limiting (roadmap #76).
+
+Backend semaphore tests run on memory always and on Redis when reachable. The
+decorator tests use the in-process memory backend with real threads so several
+requests are genuinely in flight at once.
+"""
+
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpResponse
+from django.test import RequestFactory
+
+from django_smart_ratelimit import concurrency_limit
+from django_smart_ratelimit.backends import clear_backend_cache, get_backend
+from django_smart_ratelimit.backends.memory import MemoryBackend
+
+
+def _redis_backend():
+    try:
+        from django_smart_ratelimit.backends.redis_backend import RedisBackend
+
+        b = RedisBackend()
+        b.redis.ping()
+        return b
+    except Exception:
+        return None
+
+
+REDIS = _redis_backend()
+skip_without_redis = pytest.mark.skipif(REDIS is None, reason="live Redis unavailable")
+
+
+def _req(ip="203.0.113.5"):
+    request = RequestFactory().get("/")
+    request.META["REMOTE_ADDR"] = ip
+    return request
+
+
+# ---------------------------------------------------------------------------
+# Backend semaphore primitive
+# ---------------------------------------------------------------------------
+
+
+def _semaphore_contract(backend):
+    key = "sem:%s" % uuid.uuid4().hex
+    members = [uuid.uuid4().hex for _ in range(4)]
+    # max 2 concurrent -> first two acquire, next two are refused.
+    assert [backend.concurrency_acquire(key, 2, 60, m) for m in members] == [
+        True,
+        True,
+        False,
+        False,
+    ]
+    # Releasing one frees exactly one slot.
+    backend.concurrency_release(key, members[0])
+    assert backend.concurrency_acquire(key, 2, 60, members[3]) is True
+    for m in members:
+        backend.concurrency_release(key, m)
+    # All released -> full capacity available again.
+    assert backend.concurrency_acquire(key, 2, 60, uuid.uuid4().hex) is True
+
+
+def test_memory_semaphore_contract():
+    _semaphore_contract(MemoryBackend())
+
+
+@skip_without_redis
+def test_redis_semaphore_contract():
+    _semaphore_contract(REDIS)
+
+
+def test_memory_semaphore_reclaims_leaked_slot():
+    backend = MemoryBackend()
+    key = "sem:%s" % uuid.uuid4().hex
+    # Fill capacity, then age the holders past the ttl as if they crashed.
+    backend.concurrency_acquire(key, 1, 60, "leaked")
+    assert backend.concurrency_acquire(key, 1, 60, "blocked") is False
+    for member in backend._concurrency[key]:
+        backend._concurrency[key][member] -= 120  # 120s ago, ttl is 60
+    # The leaked holder is reclaimed, so a new request can proceed.
+    assert backend.concurrency_acquire(key, 1, 60, "fresh") is True
+
+
+# ---------------------------------------------------------------------------
+# Decorator under real concurrency
+# ---------------------------------------------------------------------------
+
+
+def test_decorator_blocks_over_capacity_request():
+    clear_backend_cache()
+    get_backend("memory")  # pre-warm so all threads share one in-process backend
+    release = threading.Event()
+
+    @concurrency_limit(key="ip", max_concurrent=2, backend="memory")
+    def view(_request):
+        release.wait(timeout=5)
+        return HttpResponse("ok")
+
+    def call():
+        return view(_req(ip="9.9.9.9")).status_code
+
+    try:
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            futures = [pool.submit(call) for _ in range(3)]
+            time.sleep(0.5)  # let all three attempt to acquire
+            release.set()
+            codes = sorted(f.result(timeout=5) for f in futures)
+        # Two ran concurrently (200); the third was over capacity (429).
+        assert codes == [200, 200, 429]
+    finally:
+        release.set()
+        clear_backend_cache()
+
+
+def test_decorator_releases_slot_after_each_request():
+    clear_backend_cache()
+
+    @concurrency_limit(key="ip", max_concurrent=1, backend="memory")
+    def view(_request):
+        return HttpResponse("ok")
+
+    # Sequential requests each release their slot, so all are allowed.
+    assert [view(_req()).status_code for _ in range(5)] == [200] * 5
+    clear_backend_cache()
+
+
+def test_decorator_non_block_allows_over_capacity():
+    clear_backend_cache()
+    get_backend("memory")  # pre-warm so all threads share one in-process backend
+    release = threading.Event()
+
+    @concurrency_limit(key="ip", max_concurrent=1, backend="memory", block=False)
+    def view(_request):
+        release.wait(timeout=5)
+        return HttpResponse("ok")
+
+    def call():
+        return view(_req(ip="8.8.8.8")).status_code
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(call) for _ in range(2)]
+            time.sleep(0.3)
+            release.set()
+            codes = [f.result(timeout=5) for f in futures]
+        # block=False: the over-capacity request runs anyway.
+        assert codes == [200, 200]
+    finally:
+        release.set()
+        clear_backend_cache()
+
+
+def test_decorator_requires_semaphore_backend():
+    from django_smart_ratelimit.concurrency import _require_semaphore_backend
+
+    class _NoSemaphore:
+        pass
+
+    with pytest.raises(ImproperlyConfigured):
+        _require_semaphore_backend(_NoSemaphore())
+
+
+@skip_without_redis
+def test_decorator_over_redis():
+    clear_backend_cache()
+    release = threading.Event()
+
+    @concurrency_limit(key="ip", max_concurrent=2, backend="redis")
+    def view(_request):
+        release.wait(timeout=5)
+        return HttpResponse("ok")
+
+    def call():
+        return view(_req(ip="7.7.7.7")).status_code
+
+    try:
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            futures = [pool.submit(call) for _ in range(3)]
+            time.sleep(0.5)
+            release.set()
+            codes = sorted(f.result(timeout=5) for f in futures)
+        assert codes == [200, 200, 429]
+    finally:
+        release.set()
+        clear_backend_cache()


### PR DESCRIPTION
The first of the three high-leverage additive features from the post-4.x roadmap (#76). **Additive and opt-in.**

## `@concurrency_limit`
Caps how many requests are processed **at the same time** for a key — e.g. "5 simultaneous exports per user" — rather than requests per time window.

```python
from django_smart_ratelimit import concurrency_limit

@concurrency_limit(key="user", max_concurrent=5)
def export_view(request):
    ...   # at most 5 in flight per user; the 6th gets 429 until one finishes
```

- Backed by an **atomic semaphore**: a Redis sorted set (`concurrency_acquire`/`concurrency_release` via Lua) or the in-memory backend.
- **Self-healing**: a slot whose request crashed before releasing is reclaimed after `ttl` seconds.
- Sync **and** async views; same `key` forms as `@rate_limit`; `block=False` for observe-only mode.
- Requires the redis or memory backend (others raise `ImproperlyConfigured`). Use Redis for multi-process/multi-host.

The Redis Lua script is lazy-loaded, so the init-time `script_load` count is unchanged.

## Tests
- Backend semaphore contract (memory always; Redis when reachable), leaked-slot reclaim.
- Decorator under **real threads**: the over-capacity request gets 429 while others are in flight; `block=False` lets it through; async; the require-semaphore-backend guard.
- Docs: a Concurrency Limiting guide + nav.

Full suite: **1929 passed** (a transient local MongoDB out-of-disk failure was unrelated, resolved by freeing space). pre-commit clean.

Part of #76 (concurrency limiting → quota management → tier-based rates).