### PR TITLE
feat: tier-based rates via tiered() (v4.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.12.0] - 2026-06-05
+
+Third and final high-leverage feature from the post-4.x roadmap (#76):
+**tier-based rates**. Additive and opt-in. Completes the top-three set
+(concurrency limiting, quota management, tier-based rates).
+
+### Added
+
+- **`tiered()`** — pick the rate by plan/tier inline, with no models:
+  `@rate_limit(rate=tiered({"free": "100/h", "pro": "10000/h"}, by="user.plan",
+  default="100/h"))`. `by` is a dotted attribute path or a callable; a `"*"`
+  entry is the wildcard. A lightweight alternative to `RATELIMIT_USE_USER_TIERS`
+  when you just need a rate that varies by an attribute already on the request.
+- **`@rate_limit` (and `ratelimit`) now accept a callable `rate`** — a
+  `(request) -> "N/period"` resolved per request. String rates behave exactly as
+  before (validated up front); a callable rate is resolved on each call. Powers
+  `tiered()` and any custom per-request rate logic.
+
+### Docs
+
+- A "tier-based rates with `tiered()`" section in the User Tiers guide.
+
 ## [4.11.0] - 2026-06-05
 
 Second of the high-leverage additive features from the post-4.x roadmap (#76):

--- a/django_smart_ratelimit/__init__.py
+++ b/django_smart_ratelimit/__init__.py
@@ -5,7 +5,7 @@ with support for multiple backends, algorithms (including token bucket),
 and comprehensive rate limiting strategies.
 """
 
-__version__ = "4.11.0"
+__version__ = "4.12.0"
 __author__ = "Yasser Shkeir"
 
 # Optional backend imports (may not be available)
@@ -74,7 +74,7 @@ from .enums import Algorithm, RateLimitKey
 
 def ratelimit(
     key: Union[str, Callable],
-    rate: Optional[str] = None,
+    rate: Optional[Union[str, Callable[..., str]]] = None,
     block: bool = True,
     backend: Optional[str] = None,
     skip_if: Optional[Callable] = None,
@@ -202,6 +202,7 @@ from .tiers import (
     get_user_tier,
     resolve_effective_user_rate,
     tier_key,
+    tiered,
 )
 
 # Utilities
@@ -391,6 +392,7 @@ __all__ = [
     "get_user_override",
     "resolve_effective_user_rate",
     "tier_key",
+    "tiered",
     "create_user_override",
     "get_tier_from_groups",
     "group_key",

--- a/django_smart_ratelimit/decorator.py
+++ b/django_smart_ratelimit/decorator.py
@@ -430,7 +430,7 @@ def _apply_user_tiers(
 
 def rate_limit(
     key: Union[str, Callable],
-    rate: Optional[str] = None,
+    rate: Optional[Union[str, Callable[..., str]]] = None,
     block: bool = True,
     backend: Optional[str] = None,
     skip_if: Optional[Callable] = None,
@@ -538,8 +538,13 @@ def rate_limit(
         if _rate is None:
             _rate = _settings.default_limit
 
+        # ``rate`` may be a callable ``(request) -> "N/period"`` (e.g. tiered())
+        # resolved per request; a string is validated up front as before.
+
         # Validate configuration early
-        if algorithm is not None or algorithm_config is not None:
+        if not callable(_rate) and (
+            algorithm is not None or algorithm_config is not None
+        ):
             validate_rate_config(_rate, algorithm, algorithm_config)
 
         # Parse CIDR allow/deny lists ONCE at decoration time instead of on
@@ -617,10 +622,11 @@ def rate_limit(
                     backend_instance.config["algorithm"] = algorithm
 
                 # Resolve key + rate + cost + adaptive in one place (v3 pipeline)
+                _eff_rate = _rate(_request) if callable(_rate) else _rate
                 try:
                     resolved = resolve_effective_rate(
                         key=key,
-                        rate=_rate,
+                        rate=_eff_rate,
                         request=_request,
                         args=args,
                         kwargs=kwargs,
@@ -639,7 +645,9 @@ def rate_limit(
                 # Per-user tiers/overrides (no-op unless RATELIMIT_USE_USER_TIERS).
                 # Skipped when adaptive is active, which owns the limit instead.
                 if adaptive is None:
-                    _tiered = _apply_user_tiers(_request, _rate, limit_key, _settings)
+                    _tiered = _apply_user_tiers(
+                        _request, _eff_rate, limit_key, _settings
+                    )
                     if _tiered is not None:
                         limit, period, limit_key = _tiered
 
@@ -841,10 +849,11 @@ def rate_limit(
                     backend_instance.config["algorithm"] = algorithm
 
                 # Resolve key, rate, cost, adaptive via the v3 pipeline.
+                _eff_rate = _rate(_request) if callable(_rate) else _rate
                 try:
                     resolved = resolve_effective_rate(
                         key=key,
-                        rate=_rate,
+                        rate=_eff_rate,
                         request=_request,
                         args=args,
                         kwargs=kwargs,
@@ -862,7 +871,9 @@ def rate_limit(
                 # Per-user tiers/overrides (no-op unless RATELIMIT_USE_USER_TIERS).
                 # Skipped when adaptive is active, which owns the limit instead.
                 if adaptive is None:
-                    _tiered = _apply_user_tiers(_request, _rate, limit_key, _settings)
+                    _tiered = _apply_user_tiers(
+                        _request, _eff_rate, limit_key, _settings
+                    )
                     if _tiered is not None:
                         limit, period, limit_key = _tiered
 

--- a/django_smart_ratelimit/tiers.py
+++ b/django_smart_ratelimit/tiers.py
@@ -10,7 +10,7 @@ Resolves the effective rate limit for a request by precedence:
 """
 
 from datetime import timedelta
-from typing import Any, Optional
+from typing import Any, Callable, Dict, Optional, Union
 
 from django.utils import timezone
 
@@ -170,3 +170,57 @@ def create_user_override(
         starts_at=now,
         expires_at=expires_at,
     )
+
+
+def tiered(
+    rates: Dict[Any, str],
+    by: Union[str, Callable[[Any], Any]],
+    default: Optional[str] = None,
+) -> Callable[..., str]:
+    """Build a per-request ``rate`` that varies by plan/tier (roadmap #76).
+
+    A lightweight, model-free alternative to ``RATELIMIT_USE_USER_TIERS``: pick
+    the rate string by an attribute of the request. Pass the result as
+    ``@rate_limit(rate=tiered(...))``::
+
+        @rate_limit(key="user", rate=tiered(
+            {"free": "100/h", "pro": "10000/h"}, by="user.plan", default="100/h"))
+        def api(request): ...
+
+    Args:
+        rates: Mapping of tier value -> rate string. A ``"*"`` entry is the
+            wildcard for any unlisted tier.
+        by: How to read the tier from the request -- a callable ``(request) ->
+            tier`` or a dotted attribute path (e.g. ``"user.plan"``).
+        default: Rate used when the tier is missing/unlisted and no ``"*"`` entry
+            exists. Provide this or a ``"*"`` entry.
+
+    Returns:
+        A callable ``(request, ...) -> rate_string`` for ``@rate_limit``.
+    """
+
+    def _resolve_tier(request: Any) -> Any:
+        if callable(by):
+            return by(request)
+        obj: Any = request
+        for part in by.split("."):
+            obj = getattr(obj, part, None)
+            if obj is None:
+                return None
+        return obj
+
+    def _rate_for(request: Any, *args: Any, **kwargs: Any) -> str:
+        tier = _resolve_tier(request)
+        if tier is not None and tier in rates:
+            return rates[tier]
+        if "*" in rates:
+            return rates["*"]
+        if default is not None:
+            return default
+        from django.core.exceptions import ImproperlyConfigured
+
+        raise ImproperlyConfigured(
+            f"tiered(): no rate for tier {tier!r} and no '*'/default provided."
+        )
+
+    return _rate_for

--- a/docs/user_tiers.md
+++ b/docs/user_tiers.md
@@ -36,6 +36,40 @@ All five models (`UserTier`, `UserTierAssignment`, `GroupRateLimit`,
 `UserRateLimitOverride`, `APIKey`) are registered in the Django admin, so most
 day-to-day management can happen there.
 
+## Inline tier-based rates with `tiered()` (no models)
+
+If you don't need database-managed tiers, `tiered()` is a lightweight,
+model-free alternative (roadmap #76): pick the **rate** directly from an
+attribute of the request, and pass it as the decorator's `rate`. The
+`@rate_limit` `rate` argument accepts a callable `(request) -> "N/period"`.
+
+```python
+from django_smart_ratelimit import rate_limit, tiered
+
+@rate_limit(
+    key="user",
+    rate=tiered(
+        {"free": "100/h", "pro": "10000/h", "*": "100/h"},
+        by="user.plan",          # a dotted attribute path, or a callable
+    ),
+)
+def api_view(request):
+    ...
+```
+
+- `rates` — a `{tier: rate_string}` mapping; a `"*"` entry is the wildcard for
+  any unlisted tier.
+- `by` — how to read the tier: a dotted attribute path (`"user.plan"`,
+  `"user.profile.tier"`) resolved on the request, or a callable
+  `(request) -> tier`.
+- `default` — the rate when the tier is missing/unlisted and there is no `"*"`.
+  Provide `default` or a `"*"` entry, or `tiered()` raises for an unknown tier.
+
+This needs no settings, models, or migrations — it's resolved per request from
+whatever attribute already carries the plan. Use the model-driven tiers below
+when you want admin-managed tiers, group mapping, overrides, or per-user
+bucketing.
+
 ## Precedence
 
 For an authenticated request, the effective rate is resolved in this order

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-smart-ratelimit"
-version = "4.11.0"
+version = "4.12.0"
 dynamic = []
 description = "A flexible and efficient rate limiting library for Django applications"
 readme = "README.md"

--- a/tests/integration/test_tiered_rates.py
+++ b/tests/integration/test_tiered_rates.py
@@ -1,0 +1,136 @@
+"""Tests for tier-based rates: tiered() + callable @rate_limit rate (roadmap #76)."""
+
+import time
+
+import pytest
+
+from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpResponse
+from django.test import RequestFactory
+
+from django_smart_ratelimit import rate_limit, tiered
+from django_smart_ratelimit.backends import clear_backend_cache, get_backend
+
+
+class _User:
+    is_authenticated = True
+
+    def __init__(self, plan):
+        self.plan = plan
+
+
+def _req(plan=None, ip="203.0.113.5"):
+    request = RequestFactory().get("/")
+    request.META["REMOTE_ADDR"] = ip
+    if plan is not None:
+        request.user = _User(plan)
+    return request
+
+
+# ---------------------------------------------------------------------------
+# tiered() resolution
+# ---------------------------------------------------------------------------
+
+
+def test_tiered_by_attribute_path():
+    fn = tiered({"free": "100/h", "pro": "10000/h"}, by="user.plan", default="100/h")
+    assert fn(_req(plan="pro")) == "10000/h"
+    assert fn(_req(plan="free")) == "100/h"
+
+
+def test_tiered_by_callable():
+    fn = tiered({"a": "1/m", "b": "2/m"}, by=lambda r: r.headers.get("X-Tier"))
+    req = RequestFactory().get("/")
+    req.META["HTTP_X_TIER"] = "b"
+    assert fn(req) == "2/m"
+
+
+def test_tiered_wildcard_and_default():
+    # "*" wildcard covers unlisted tiers.
+    fn = tiered({"pro": "1000/h", "*": "50/h"}, by="user.plan")
+    assert fn(_req(plan="enterprise")) == "50/h"
+    # default covers a missing tier when there's no "*".
+    fn2 = tiered({"pro": "1000/h"}, by="user.plan", default="10/h")
+    assert fn2(_req(plan="free")) == "10/h"
+    assert fn2(_req()) == "10/h"  # no user.plan at all
+
+
+def test_tiered_raises_without_match_or_default():
+    fn = tiered({"pro": "1000/h"}, by="user.plan")
+    with pytest.raises(ImproperlyConfigured):
+        fn(_req(plan="free"))
+
+
+# ---------------------------------------------------------------------------
+# Decorator with a callable / tiered rate
+# ---------------------------------------------------------------------------
+
+
+def _uid():
+    return time.time_ns()
+
+
+def test_decorator_tiered_rate_enforced_per_plan():
+    clear_backend_cache()
+    get_backend("memory")
+    bucket = _uid()
+
+    @rate_limit(
+        key=lambda r, *a, **k: f"u:{r.user.plan}:{bucket}",
+        rate=tiered({"free": "2/m", "pro": "5/m"}, by="user.plan", default="2/m"),
+        algorithm="fixed_window",
+        backend="memory",
+    )
+    def view(_request):
+        return HttpResponse("ok")
+
+    free = [view(_req(plan="free")).status_code for _ in range(4)]
+    pro = [view(_req(plan="pro")).status_code for _ in range(7)]
+    assert free == [200, 200, 429, 429]
+    assert pro == [200, 200, 200, 200, 200, 429, 429]
+    clear_backend_cache()
+
+
+def test_decorator_plain_callable_rate():
+    clear_backend_cache()
+    get_backend("memory")
+    bucket = _uid()
+
+    @rate_limit(
+        key=lambda r, *a, **k: f"c:{bucket}",
+        rate=lambda r, *a, **k: "3/m",
+        algorithm="fixed_window",
+        backend="memory",
+    )
+    def view(_request):
+        return HttpResponse("ok")
+
+    codes = [view(_req(ip="9.9.9.9")).status_code for _ in range(5)]
+    assert codes == [200, 200, 200, 429, 429]
+    clear_backend_cache()
+
+
+@pytest.mark.asyncio
+async def test_decorator_tiered_rate_async():
+    clear_backend_cache()
+    get_backend("memory")
+    bucket = _uid()
+
+    @rate_limit(
+        key=lambda r, *a, **k: f"a:{r.user.plan}:{bucket}",
+        rate=tiered({"free": "1/m", "pro": "3/m"}, by="user.plan", default="1/m"),
+        algorithm="fixed_window",
+        backend="memory",
+    )
+    async def view(_request):
+        return HttpResponse("ok")
+
+    free = []
+    for _ in range(2):
+        free.append((await view(_req(plan="free"))).status_code)
+    pro = []
+    for _ in range(4):
+        pro.append((await view(_req(plan="pro"))).status_code)
+    assert free == [200, 429]
+    assert pro == [200, 200, 200, 429]
+    clear_backend_cache()


### PR DESCRIPTION
The **third and final** high-leverage feature from the post-4.x roadmap (#76). Completes the top-three set: concurrency limiting ✓, quota management ✓, **tier-based rates** ✓. Additive and opt-in.

## `tiered()` — pick the rate by plan, no models
```python
from django_smart_ratelimit import rate_limit, tiered

@rate_limit(key="user", rate=tiered(
    {"free": "100/h", "pro": "10000/h", "*": "100/h"},
    by="user.plan",            # dotted attribute path, or a callable
))
def api_view(request):
    ...
```
- `rates` mapping with a `"*"` wildcard; `by` as a dotted attribute path or `(request) -> tier` callable; `default` for unlisted tiers (or raise).
- A lightweight, model-free alternative to `RATELIMIT_USE_USER_TIERS` for when the plan is already an attribute on the request.

## `@rate_limit` now accepts a callable `rate`
`rate` can be a `(request) -> "N/period"` resolved per request (powers `tiered()` and any custom per-request rate). **String rates are unchanged** — still validated up front; only a callable is resolved per call. The `ratelimit` alias accepts it too.

## Tests
- `tiered()`: attribute-path & callable `by`, `"*"` wildcard, `default`, raises without a match/default.
- Decorator: tiered rate enforced per plan (free 2/m vs pro 5/m), a plain callable rate, async.
- 7 new tests; **no regression** in the 139 existing decorator tests; mypy clean.
- Docs: a "tier-based rates with `tiered()`" section.

Full suite: **1956 passed**. Closes the #76 top-three.