### PR TITLE
fix: ImproperlyConfigured exception: Multiple values for argument 'url'.

### DIFF
--- a/django_smart_ratelimit/backends/redis_backend.py
+++ b/django_smart_ratelimit/backends/redis_backend.py
@@ -330,7 +330,9 @@ class RedisBackend(BaseBackend):
 
         try:
             # Get or create connection pool
-            self._pool = self._get_or_create_pool(url, **self.config)
+            config = self.config.copy()
+            config.pop("url", None)
+            self._pool = self._get_or_create_pool(url, **config)
             self.init_client()
 
             # Initial verification


### PR DESCRIPTION
## Description

The `_get_or_create_pool` function already has a `url` parameter, so it cannot be in `self.config` again. If it is there, it will throw an `ImproperlyConfigured exception`:

`django.core.exceptions.ImproperlyConfigured: Cannot connect to Redis: RedisBackend._get_or_create_pool() got multiple values for argument 'url'
`