### PR TITLE
release: v4.12.1 — Redis url-config crash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.12.1] - 2026-06-05
+
+### Fixed
+
+- **Redis backend crashed when configured with a `url`.** A `url` key in
+  `RATELIMIT_REDIS` was passed to `_get_or_create_pool()` both positionally and
+  as a keyword, raising `ImproperlyConfigured: ... got multiple values for
+  argument 'url'`. The config copy now drops `url` before the call. Thanks to
+  @zbohm (CZ-NIC) (#97). Added a regression test.
+
 ## [4.12.0] - 2026-06-05
 
 Third and final high-leverage feature from the post-4.x roadmap (#76):

--- a/django_smart_ratelimit/__init__.py
+++ b/django_smart_ratelimit/__init__.py
@@ -5,7 +5,7 @@ with support for multiple backends, algorithms (including token bucket),
 and comprehensive rate limiting strategies.
 """
 
-__version__ = "4.12.0"
+__version__ = "4.12.1"
 __author__ = "Yasser Shkeir"
 
 # Optional backend imports (may not be available)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-smart-ratelimit"
-version = "4.12.0"
+version = "4.12.1"
 dynamic = []
 description = "A flexible and efficient rate limiting library for Django applications"
 readme = "README.md"

--- a/tests/unit/backends/test_redis_backend.py
+++ b/tests/unit/backends/test_redis_backend.py
@@ -55,6 +55,25 @@ class RedisBackendTests(TestCase):
         self.mock_redis_client.ping.assert_called_once()
         self.assertEqual(self.mock_redis_client.script_load.call_count, 6)
 
+    def test_url_in_redis_config_does_not_collide(self):
+        """A ``url`` key in RATELIMIT_REDIS must not crash init (PR #97 regression).
+
+        Previously ``_get_or_create_pool(url, **self.config)`` passed ``url`` both
+        positionally and (via the config dict) as a keyword, raising
+        "got multiple values for argument 'url'".
+        """
+        from django.test import override_settings
+
+        from django_smart_ratelimit.config import reset_settings
+
+        with override_settings(RATELIMIT_REDIS={"url": "redis://localhost:6379/0"}):
+            reset_settings()
+            try:
+                backend = self.RedisBackend()
+                self.assertIsNotNone(backend.redis)
+            finally:
+                reset_settings()
+
     def test_redis_backend_initialization_no_redis_module(self):
         """Test Redis backend initialization when redis module is not available."""
         with patch("django_smart_ratelimit.backends.redis_backend.redis", None):


### PR DESCRIPTION
Patch release for the bug fixed in #97 (thanks @zbohm).

## Fixed
`RATELIMIT_REDIS = {"url": "redis://..."}` crashed the Redis backend at init with `ImproperlyConfigured: ... got multiple values for argument 'url'` — `url` was passed to `_get_or_create_pool()` both positionally and via the config dict. The config copy now drops `url` before the call (the fix merged from #97).

## Added
- A regression test (`test_url_in_redis_config_does_not_collide`) so this can't regress.
- Version bump to 4.12.1 + changelog.

Verified locally: the bug reproduces on 4.12.0 and is resolved with the fix.