### PR TITLE
fix: enhance token bucket rate limiting header accuracy and stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Token bucket `Retry-After` advertised the wrong wait.** It was derived from
+  the period grid, so a genuine 6 second refill wait was reported as anywhere
+  between 5 and 120 seconds depending on where the wall clock happened to sit.
+  It now tracks the bucket's real refill time (`tokens_needed / refill_rate`,
+  rounded up). Thanks to @sronveaux (#104).
+- **Token bucket `Retry-After` was missing on the multi-token-cost path.** The
+  header was gated on `tokens_remaining <= 0`, so a request that cost more
+  tokens than were left (3 in the bucket, request costs 5) was rejected with no
+  back-off guidance at all. It is now emitted on every rejection. Thanks to
+  @sronveaux (#104).
+- **Token bucket headers raised on `bucket_size=None`.** `dict.get` returns a
+  present `None` rather than the default, so the value reached `int()` and
+  raised `TypeError`. On sync views that re-ran the view body a second time via
+  the decorator's fallback path; on async views it surfaced a `TypeError` to the
+  caller after the view had already run. All optional metadata is now coerced
+  defensively, and a malformed field degrades only itself instead of dropping
+  every token-bucket header.
+- **Fractional `bucket_size` was truncated.** A `bucket_size` of `10.5` (which
+  `format_token_bucket_metadata` types as `Optional[float]`, and which the Redis
+  fail-open path really passes) was advertised as `10`.
+- **`refill_rate=0` produced a nonsensical `Retry-After: 1`.** A bucket that
+  never refills has no refill wait; producers spell that either `inf` or `0`,
+  and both now fall back to the rate's period.
+
+### Unchanged (deliberately)
+
+- **`X-RateLimit-Reset` stays period-aligned.** It remains anchored to the
+  clock-aligned period grid and stable across successive requests, as issue #14
+  requires. `Retry-After` — not `X-RateLimit-Reset` — is the header that tracks
+  the bucket's refill state.
+
 ## [4.12.1] - 2026-06-05
 
 ### Fixed

--- a/django_smart_ratelimit/decorator.py
+++ b/django_smart_ratelimit/decorator.py
@@ -749,7 +749,11 @@ def rate_limit(
                         )
                         if bucket_metadata is not None:
                             add_token_bucket_headers(
-                                response, bucket_metadata, limit, period
+                                response,
+                                bucket_metadata,
+                                limit,
+                                period,
+                                rate_limited=True,
                             )
                         else:
                             reset_time = int(time.time() + period)
@@ -765,11 +769,16 @@ def rate_limit(
                 # Call view
                 response = await func(*args, **kwargs)
 
-                # Add headers
+                # Add headers. The request was served, so any Retry-After on
+                # this response is the view's business, not the limiter's.
                 if hasattr(response, "headers"):
                     if bucket_metadata is not None:
                         add_token_bucket_headers(
-                            response, bucket_metadata, limit, period
+                            response,
+                            bucket_metadata,
+                            limit,
+                            period,
+                            rate_limited=False,
                         )
                     elif "X-RateLimit-Limit" not in response.headers:
                         reset_time = int(time.time() + period)
@@ -1203,7 +1212,9 @@ def _handle_token_bucket_algorithm(
                     request=_request,
                     response_callback=response_callback,
                 )
-                add_token_bucket_headers(response, metadata, limit, period)
+                add_token_bucket_headers(
+                    response, metadata, limit, period, rate_limited=True
+                )
                 return response
             else:
                 # Add rate limit headers but don't block
@@ -1213,12 +1224,17 @@ def _handle_token_bucket_algorithm(
                     args[0].rate_limit_exceeded = True
 
                 response = func(*args, **kwargs)
-                add_token_bucket_headers(response, metadata, limit, period)
+                # The request was served: Retry-After is the view's to set.
+                add_token_bucket_headers(
+                    response, metadata, limit, period, rate_limited=False
+                )
                 return response
 
         # Execute the original function
         response = func(*args, **kwargs)
-        add_token_bucket_headers(response, metadata, limit, period)
+        # Allowed by the limiter, so leave Retry-After entirely alone -- a 429
+        # the view chose to return is answering a different question.
+        add_token_bucket_headers(response, metadata, limit, period, rate_limited=False)
         return response
 
     except Exception as e:

--- a/django_smart_ratelimit/utils.py
+++ b/django_smart_ratelimit/utils.py
@@ -8,6 +8,7 @@ Note: This module is now a facade that imports from specialized modules.
 """
 
 import logging
+import math
 import re
 import time
 from typing import Any, Callable, Dict, Optional, Union
@@ -183,39 +184,44 @@ def add_token_bucket_headers(
     if not hasattr(response, "headers"):
         return
 
+    current_time = time.time()
+
+    # Extract useful metadata and type them cleanly
+    tokens_remaining = int(metadata.get("tokens_remaining", 0))
+    bucket_size = int(metadata.get("bucket_size", limit))
+    refill_rate = float(metadata.get("refill_rate", 0.0))
+
+    # Retrieve time_to_refill and manage edge cases
+    time_to_refill = metadata.get("time_to_refill")
+    if (
+        time_to_refill is None
+        or time_to_refill == float("inf")
+        or math.isnan(time_to_refill)
+    ):
+        time_to_refill = float(period)
+
     # Standard headers
     response.headers["X-RateLimit-Limit"] = str(limit)
-    tokens_remaining = int(metadata.get("tokens_remaining", 0))
     response.headers["X-RateLimit-Remaining"] = str(tokens_remaining)
 
-    # Calculate reset time for token bucket using a stable approach
-    # For token buckets, we provide a predictable reset time by using fixed time periods
-    current_time = time.time()
-    tokens_remaining = int(metadata.get("tokens_remaining", 0))
-    bucket_size = metadata.get("bucket_size", limit)
-
-    # Use period-based buckets for consistency, regardless of current token state
-    # This provides users with predictable reset times
-    bucket_start = int(current_time // period) * period
-    reset_time = int(bucket_start + period)
-
-    # If very close to current time, advance to next period
-    if reset_time - current_time < 5:
-        reset_time += period
+    # Calculate reset time for token bucket using data returned by the backend
+    # If request is allowed, time_to_refill is the time before the bucket is full again
+    # If request is not allowed, time_to_refill is the time before the number
+    # of requested tokens is available
+    reset_time = int(current_time + time_to_refill)
     response.headers["X-RateLimit-Reset"] = str(reset_time)
 
-    # Add Retry-After header only for 429 responses when no tokens remaining
-    if tokens_remaining <= 0 and getattr(response, "status_code", 200) == 429:
-        retry_after = max(0, reset_time - int(time.time()))
+    # Add Retry-After header only for 429 responses
+    if getattr(response, "status_code", 200) == 429:
+        # We round the value to the upper second
+        retry_after = max(1, int(math.ceil(time_to_refill)))
         response.headers["Retry-After"] = str(retry_after)
 
     # Token bucket specific headers
-    bucket_size = metadata.get("bucket_size", limit)
     response.headers["X-RateLimit-Bucket-Size"] = str(bucket_size)
     response.headers["X-RateLimit-Bucket-Remaining"] = str(tokens_remaining)
 
     # Optional: Add refill rate information
-    refill_rate = metadata.get("refill_rate", 0)
     if refill_rate > 0:
         response.headers["X-RateLimit-Refill-Rate"] = f"{refill_rate:.2f}"
 

--- a/django_smart_ratelimit/utils.py
+++ b/django_smart_ratelimit/utils.py
@@ -217,8 +217,44 @@ def _format_header_number(value: float) -> str:
     return str(int(number)) if number.is_integer() else str(number)
 
 
+def _limiter_rejected(
+    response: HttpResponse, tokens_remaining: int, rate_limited: Optional[bool]
+) -> bool:
+    """
+    Decide whether this response is the *rate limiter* saying no.
+
+    ``Retry-After`` may only be written when the limiter itself rejected the
+    request. A 429 alone does not prove that: the limiter can allow a request
+    and the view can then return its own 429 for its own reasons, in which case
+    the bucket's refill estimate answers a question nobody asked (it measures
+    time until the bucket is full, not time until *that* view will serve you).
+
+    Args:
+        response: HTTP response object.
+        tokens_remaining: Tokens left in the bucket, already coerced.
+        rate_limited: The caller's own verdict. ``True``/``False`` when the
+            caller knows (the decorator always does); ``None`` for callers that
+            do not pass it, which falls back to the conservative pre-#104 rule
+            -- a 429 with an empty bucket. Such a caller cannot distinguish the
+            multi-token-cost rejection (tokens remain, but fewer than the
+            request costs), so it should pass the flag explicitly.
+
+    Returns:
+        True if ``Retry-After`` should be emitted.
+    """
+    if getattr(response, "status_code", 200) != 429:
+        return False
+    if rate_limited is not None:
+        return rate_limited
+    return tokens_remaining <= 0
+
+
 def add_token_bucket_headers(
-    response: HttpResponse, metadata: Dict[str, Any], limit: int, period: int
+    response: HttpResponse,
+    metadata: Dict[str, Any],
+    limit: int,
+    period: int,
+    rate_limited: Optional[bool] = None,
 ) -> None:
     """
     Add token bucket specific headers to HTTP response.
@@ -233,6 +269,11 @@ def add_token_bucket_headers(
         metadata: Token bucket metadata from algorithm
         limit: Rate limit value
         period: Rate limit period in seconds
+        rate_limited: Whether the *rate limiter* rejected this request. Pass
+            ``True`` on the blocking path and ``False`` whenever the request
+            was served, so that a 429 chosen by the view keeps whatever
+            ``Retry-After`` the view did (or did not) set. ``None`` means
+            "unknown" and keeps the conservative pre-#104 behaviour.
     """
     if not hasattr(response, "headers"):
         return
@@ -274,10 +315,12 @@ def add_token_bucket_headers(
 
     # Retry-After answers a different question than X-RateLimit-Reset: "how
     # long until this request would be served?". For a token bucket that is
-    # the backend-computed refill wait, and it applies to every rejection --
-    # including the multi-token-cost case where tokens remain (3 left) but not
-    # enough for the request (costs 5).
-    if getattr(response, "status_code", 200) == 429:
+    # the backend-computed refill wait, and it applies to every *limiter*
+    # rejection -- including the multi-token-cost case where tokens remain
+    # (3 left) but not enough for the request (costs 5). It is deliberately not
+    # written on a request the limiter allowed, whatever status the view then
+    # chose: that response's Retry-After belongs to the view.
+    if _limiter_rejected(response, tokens_remaining, rate_limited):
         # A refill_rate of 0 means the bucket never refills. Producers spell
         # that either `inf` (backends/utils) or `0` (algorithms/token_bucket,
         # redis lua), and neither is a usable wait -- fall back to `period` on
@@ -286,8 +329,20 @@ def add_token_bucket_headers(
         time_to_refill = _coerce_finite_float(metadata.get("time_to_refill"), fallback)
         if time_to_refill <= 0:
             time_to_refill = fallback
+        # Upper bound, so that a backend reporting nonsense (time_to_refill of
+        # 1e9) cannot advertise a 31 year wait. A token bucket can never
+        # legitimately require longer than refilling the whole bucket from
+        # empty, so `bucket_size / refill_rate` is the ceiling -- floored at
+        # the period, which is the ceiling we can still defend when refill_rate
+        # is unusable. Clamping to the period *alone* would be wrong: a 100
+        # token bucket refilling at 0.1 tokens/s really does need 1000s, and
+        # truncating that to 60 sends the client back for another 429.
+        ceiling = fallback
+        if refill_rate > 0 and bucket_size > 0:
+            ceiling = max(ceiling, bucket_size / refill_rate)
         # Round up: waiting a fraction of a second short would just 429 again.
-        response.headers["Retry-After"] = str(max(1, int(math.ceil(time_to_refill))))
+        retry_after = max(1, int(math.ceil(min(time_to_refill, ceiling))))
+        response.headers["Retry-After"] = str(retry_after)
 
     # Token bucket specific headers
     response.headers["X-RateLimit-Bucket-Size"] = _format_header_number(bucket_size)

--- a/django_smart_ratelimit/utils.py
+++ b/django_smart_ratelimit/utils.py
@@ -169,11 +169,64 @@ def add_rate_limit_headers(
                 response.headers["Retry-After"] = str(period)
 
 
+def _coerce_finite_float(value: Any, default: float) -> float:
+    """
+    Best-effort conversion of backend metadata to a finite float.
+
+    Backends are free to omit any optional metadata field, to report it as
+    ``None``, or (for the "never refills" case) as ``inf``. ``dict.get`` only
+    applies its default when the key is *absent*, so a key present with a
+    ``None`` value would otherwise reach ``int()``/``float()`` and raise. This
+    helper never raises: anything that is not a finite number becomes
+    ``default``.
+
+    Args:
+        value: Raw metadata value.
+        default: Value to use when ``value`` is missing or unusable.
+
+    Returns:
+        A finite float.
+    """
+    if value is None or isinstance(value, bool):
+        return default
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return default
+    if math.isnan(result) or math.isinf(result):
+        return default
+    return result
+
+
+def _format_header_number(value: float) -> str:
+    """
+    Render a numeric header value without truncating a fractional part.
+
+    ``10.5`` must stay ``"10.5"`` (``format_token_bucket_metadata`` types
+    ``bucket_size`` as ``Optional[float]`` and the Redis fail-open path really
+    does pass a float), while a whole number stays ``"10"`` rather than
+    becoming ``"10.0"``.
+
+    Args:
+        value: Numeric header value.
+
+    Returns:
+        String representation for the header.
+    """
+    number = float(value)
+    return str(int(number)) if number.is_integer() else str(number)
+
+
 def add_token_bucket_headers(
     response: HttpResponse, metadata: Dict[str, Any], limit: int, period: int
 ) -> None:
     """
     Add token bucket specific headers to HTTP response.
+
+    ``X-RateLimit-Reset`` is period-aligned and therefore stable across
+    successive requests (issue #14); ``Retry-After`` tracks the bucket's real
+    refill wait so a caller told to wait actually waits the right amount of
+    time.
 
     Args:
         response: HTTP response object
@@ -186,39 +239,58 @@ def add_token_bucket_headers(
 
     current_time = time.time()
 
-    # Extract useful metadata and type them cleanly
-    tokens_remaining = int(metadata.get("tokens_remaining", 0))
-    bucket_size = int(metadata.get("bucket_size", limit))
-    refill_rate = float(metadata.get("refill_rate", 0.0))
+    # Every value below is coerced defensively. A single malformed optional
+    # field must degrade only itself -- it must never raise (the sync decorator
+    # would then re-run the view body through its fallback path, and the async
+    # decorator would surface a TypeError to the caller) and it must never cost
+    # us the headers we *can* compute.
+    period_seconds = _coerce_finite_float(period, 0.0)
+    if period_seconds < 0:
+        period_seconds = 0.0
 
-    # Retrieve time_to_refill and manage edge cases
-    time_to_refill = metadata.get("time_to_refill")
-    if (
-        time_to_refill is None
-        or time_to_refill == float("inf")
-        or math.isnan(time_to_refill)
-    ):
-        time_to_refill = float(period)
+    tokens_remaining = int(_coerce_finite_float(metadata.get("tokens_remaining"), 0.0))
+    bucket_size = _coerce_finite_float(
+        metadata.get("bucket_size"), _coerce_finite_float(limit, 0.0)
+    )
+    refill_rate = _coerce_finite_float(metadata.get("refill_rate"), 0.0)
 
     # Standard headers
     response.headers["X-RateLimit-Limit"] = str(limit)
     response.headers["X-RateLimit-Remaining"] = str(tokens_remaining)
 
-    # Calculate reset time for token bucket using data returned by the backend
-    # If request is allowed, time_to_refill is the time before the bucket is full again
-    # If request is not allowed, time_to_refill is the time before the number
-    # of requested tokens is available
-    reset_time = int(current_time + time_to_refill)
-    response.headers["X-RateLimit-Reset"] = str(reset_time)
+    # X-RateLimit-Reset stays anchored to the fixed period grid rather than to
+    # the bucket's refill state. Clients need a reset time that does not move
+    # on every request (issue #14), so it is deliberately *not* derived from
+    # time_to_refill.
+    if period_seconds > 0:
+        bucket_start = int(current_time // period_seconds) * period_seconds
+        reset_time = bucket_start + period_seconds
+        # If very close to current time, advance to next period.
+        if reset_time - current_time < 5:
+            reset_time += period_seconds
+    else:
+        reset_time = current_time
+    response.headers["X-RateLimit-Reset"] = str(int(reset_time))
 
-    # Add Retry-After header only for 429 responses
+    # Retry-After answers a different question than X-RateLimit-Reset: "how
+    # long until this request would be served?". For a token bucket that is
+    # the backend-computed refill wait, and it applies to every rejection --
+    # including the multi-token-cost case where tokens remain (3 left) but not
+    # enough for the request (costs 5).
     if getattr(response, "status_code", 200) == 429:
-        # We round the value to the upper second
-        retry_after = max(1, int(math.ceil(time_to_refill)))
-        response.headers["Retry-After"] = str(retry_after)
+        # A refill_rate of 0 means the bucket never refills. Producers spell
+        # that either `inf` (backends/utils) or `0` (algorithms/token_bucket,
+        # redis lua), and neither is a usable wait -- fall back to `period` on
+        # both rather than emitting a nonsensical `Retry-After: 1`.
+        fallback = period_seconds if period_seconds > 0 else 1.0
+        time_to_refill = _coerce_finite_float(metadata.get("time_to_refill"), fallback)
+        if time_to_refill <= 0:
+            time_to_refill = fallback
+        # Round up: waiting a fraction of a second short would just 429 again.
+        response.headers["Retry-After"] = str(max(1, int(math.ceil(time_to_refill))))
 
     # Token bucket specific headers
-    response.headers["X-RateLimit-Bucket-Size"] = str(bucket_size)
+    response.headers["X-RateLimit-Bucket-Size"] = _format_header_number(bucket_size)
     response.headers["X-RateLimit-Bucket-Remaining"] = str(tokens_remaining)
 
     # Optional: Add refill rate information

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -64,6 +64,19 @@ def api_with_bursts(request):
 - Batch file processing
 - API retry mechanisms
 
+### Token Bucket Response Headers
+
+Token-bucket responses carry two time-valued headers that answer different
+questions — don't use one where you mean the other:
+
+| Header | Meaning |
+| --- | --- |
+| `X-RateLimit-Reset` | The next **period boundary**, on the clock-aligned grid. Stable across successive requests, so clients and caches see the same value throughout a period. |
+| `Retry-After` | On a `429`, the **actual seconds to wait** before the rejected request would be served — `tokens_needed / refill_rate`, rounded up. Sent whenever the request is rejected, including when the bucket still holds tokens but fewer than the request costs. |
+
+If the bucket never refills (`refill_rate=0`), there is no meaningful refill
+wait, so `Retry-After` falls back to the rate's period.
+
 ## Sliding Window Algorithm
 
 The sliding window algorithm provides smooth, consistent rate limiting:

--- a/tests/e2e/test_utils_pipeline_e2e.py
+++ b/tests/e2e/test_utils_pipeline_e2e.py
@@ -456,7 +456,7 @@ def test_add_rate_limit_headers_sets_standard_and_retry_after():
 
 def test_add_token_bucket_headers_emits_bucket_fields():
     """``add_token_bucket_headers`` writes the bucket-specific headers and a
-    dynamically computed token-refill reset time.
+    stable, period-aligned reset time.
     """
     resp = HttpResponse("ok")
     metadata = {
@@ -470,21 +470,30 @@ def test_add_token_bucket_headers_emits_bucket_fields():
     assert resp.headers["X-RateLimit-Bucket-Size"] == "20"
     assert resp.headers["X-RateLimit-Bucket-Remaining"] == "6"
     assert resp.headers["X-RateLimit-Refill-Rate"] == "2.00"
-    # Reset time is a positive integer string.
-    assert int(resp.headers["X-RateLimit-Reset"]) > 0
+    # Reset time sits on the 60s period grid (issue #14), not on now + refill.
+    assert int(resp.headers["X-RateLimit-Reset"]) % 60 == 0
 
 
 def test_add_token_bucket_headers_retry_after_when_empty():
-    """A 429 token-bucket response with no tokens left also gets Retry-After."""
+    """A 429 token-bucket response with no tokens left also gets Retry-After.
+
+    The bucket refills at 1 token/s and the request needs 1 token, so the
+    advertised wait is exactly 1 second -- not the 60 second period.
+    """
     resp = HttpResponse("blocked", status=429)
     add_token_bucket_headers(
         resp,
-        {"tokens_remaining": 0, "bucket_size": 5, "refill_rate": 1.0},
+        {
+            "tokens_remaining": 0,
+            "bucket_size": 5,
+            "refill_rate": 1.0,
+            "time_to_refill": 1.0,
+        },
         limit=5,
         period=60,
     )
     assert resp.headers["X-RateLimit-Bucket-Remaining"] == "0"
-    assert int(resp.headers["Retry-After"]) >= 0
+    assert resp.headers["Retry-After"] == "1"
 
 
 def test_debug_ratelimit_status_reads_real_backend(real_backend):

--- a/tests/e2e/test_utils_pipeline_e2e.py
+++ b/tests/e2e/test_utils_pipeline_e2e.py
@@ -456,7 +456,7 @@ def test_add_rate_limit_headers_sets_standard_and_retry_after():
 
 def test_add_token_bucket_headers_emits_bucket_fields():
     """``add_token_bucket_headers`` writes the bucket-specific headers and a
-    stable, period-aligned reset time.
+    dynamically computed token-refill reset time.
     """
     resp = HttpResponse("ok")
     metadata = {

--- a/tests/unit/core/test_token_bucket_headers.py
+++ b/tests/unit/core/test_token_bucket_headers.py
@@ -137,7 +137,9 @@ def test_retry_after_present_and_correct_on_multi_token_cost_path():
     assert metadata["time_to_refill"] == pytest.approx(4.0, abs=0.05)
 
     response = _blocked_response()
-    add_token_bucket_headers(response, metadata, limit=10, period=PERIOD)
+    add_token_bucket_headers(
+        response, metadata, limit=10, period=PERIOD, rate_limited=True
+    )
 
     # Tokens really do remain -- this is the case the old guard skipped.
     assert response.headers["X-RateLimit-Bucket-Remaining"] == "3"
@@ -518,3 +520,235 @@ async def test_async_view_does_not_raise_when_bucket_size_is_none():
     assert len(calls) == 1
     assert response.status_code == 200
     assert response.headers["X-RateLimit-Bucket-Size"] == "10"
+
+
+# ---------------------------------------------------------------------------
+# Retry-After belongs to the *limiter*, not to every 429 that goes past
+# ---------------------------------------------------------------------------
+
+
+@override_settings(RATELIMIT_BACKEND=MEMORY_BACKEND)
+def test_view_owned_429_gets_no_retry_after_when_limiter_allowed():
+    """The limiter said yes; the *view* returned the 429. Stay out of it.
+
+    On the allowed path ``time_to_refill`` measures "time until the bucket is
+    *full* again", which is not an answer to "when may I retry?" -- and nobody
+    asked, because the limiter never rejected anything. Writing it here made a
+    view's own 429 carry a wait derived from an unrelated quantity.
+    """
+    clear_backend_cache()
+
+    @rate_limit(key="ip", rate="10/m", algorithm="token_bucket", block=True)
+    def view(_request):
+        return HttpResponse("view says no", status=429)
+
+    request = RequestFactory().get("/")
+    request.META["REMOTE_ADDR"] = "203.0.113.21"
+
+    response = view(request)
+
+    assert response.status_code == 429
+    # The bucket headers still describe the limiter's state...
+    assert response.headers["X-RateLimit-Bucket-Remaining"] == "9"
+    # ...but the limiter has nothing to say about retrying.
+    assert response.headers.get("Retry-After") is None
+
+
+@override_settings(RATELIMIT_BACKEND=MEMORY_BACKEND)
+def test_view_set_retry_after_survives_an_allowed_request():
+    """A Retry-After the view set itself is never overwritten."""
+    clear_backend_cache()
+
+    @rate_limit(key="ip", rate="10/m", algorithm="token_bucket", block=True)
+    def view(_request):
+        response = HttpResponse("come back in 7", status=429)
+        response.headers["Retry-After"] = "7"
+        return response
+
+    request = RequestFactory().get("/")
+    request.META["REMOTE_ADDR"] = "203.0.113.22"
+
+    response = view(request)
+
+    assert response.headers["Retry-After"] == "7"
+
+
+@override_settings(RATELIMIT_BACKEND=MEMORY_BACKEND)
+async def test_async_view_owned_429_gets_no_retry_after_when_limiter_allowed():
+    """Same rule on the async path, which writes headers after awaiting."""
+    clear_backend_cache()
+
+    @rate_limit(key="ip", rate="10/m", algorithm="token_bucket", block=True)
+    async def view(_request):
+        return HttpResponse("view says no", status=429)
+
+    request = RequestFactory().get("/")
+    request.META["REMOTE_ADDR"] = "203.0.113.23"
+
+    response = await view(request)
+
+    assert response.status_code == 429
+    assert response.headers.get("Retry-After") is None
+
+
+@override_settings(RATELIMIT_BACKEND=MEMORY_BACKEND)
+def test_limiter_429_still_carries_retry_after_through_the_decorator():
+    """The genuinely blocked case keeps its wait -- this is the PR's point."""
+    clear_backend_cache()
+
+    @rate_limit(
+        key="ip",
+        rate="2/m",
+        algorithm="token_bucket",
+        algorithm_config={"bucket_size": 2, "refill_rate": 0.5},
+        block=True,
+    )
+    def view(_request):
+        return HttpResponse("ok")
+
+    request = RequestFactory().get("/")
+    request.META["REMOTE_ADDR"] = "203.0.113.24"
+
+    assert view(request).status_code == 200
+    assert view(request).status_code == 200
+    blocked = view(request)
+
+    assert blocked.status_code == 429
+    # Empty bucket, 1 token needed at 0.5 tokens/s -> 2 seconds.
+    assert blocked.headers["Retry-After"] == "2"
+
+
+@override_settings(RATELIMIT_BACKEND=MEMORY_BACKEND)
+def test_multi_token_cost_429_still_carries_retry_after_through_the_decorator():
+    """3 tokens left, request costs 5: blocked, and told how long to wait.
+
+    This is the path the pre-#104 ``tokens_remaining <= 0`` guard skipped
+    entirely, so it must keep working end to end and not just in the helper.
+    """
+    clear_backend_cache()
+
+    @rate_limit(
+        key="ip",
+        rate="10/m",
+        algorithm="token_bucket",
+        algorithm_config={
+            "bucket_size": 10,
+            "refill_rate": 0.5,
+            "initial_tokens": 3,
+        },
+        block=True,
+        cost=5,
+    )
+    def view(_request):
+        return HttpResponse("ok")
+
+    request = RequestFactory().get("/")
+    request.META["REMOTE_ADDR"] = "203.0.113.25"
+
+    response = view(request)
+
+    assert response.status_code == 429
+    assert response.headers["X-RateLimit-Bucket-Remaining"] == "3"
+    # 2 more tokens needed at 0.5 tokens/s -> 4 seconds.
+    assert response.headers["Retry-After"] == "4"
+
+
+def test_allowed_request_never_touches_retry_after_in_the_helper():
+    """``rate_limited=False`` leaves the header exactly as the view left it."""
+    response = HttpResponse("view says no", status=429)
+    response.headers["Retry-After"] = "7"
+    add_token_bucket_headers(
+        response,
+        {
+            "tokens_remaining": 0,
+            "bucket_size": 5,
+            "refill_rate": 0.5,
+            "time_to_refill": 10.0,
+        },
+        limit=5,
+        period=PERIOD,
+        rate_limited=False,
+    )
+    assert response.headers["Retry-After"] == "7"
+
+
+def test_blocked_request_emits_retry_after_even_with_tokens_left():
+    """``rate_limited=True`` emits regardless of tokens still in the bucket."""
+    response = _blocked_response()
+    add_token_bucket_headers(
+        response,
+        {
+            "tokens_remaining": 3,
+            "bucket_size": 10,
+            "refill_rate": 0.5,
+            "time_to_refill": 4.0,
+        },
+        limit=10,
+        period=PERIOD,
+        rate_limited=True,
+    )
+    assert response.headers["Retry-After"] == "4"
+
+
+# ---------------------------------------------------------------------------
+# Retry-After has an upper bound
+# ---------------------------------------------------------------------------
+
+
+def test_retry_after_is_clamped_to_a_defensible_ceiling():
+    """An absurd backend wait is capped; a genuinely long one is not.
+
+    The ceiling is a full refill of the bucket from empty
+    (``bucket_size / refill_rate``), never less than the period. Nothing a
+    token bucket can legitimately ask for exceeds that, so ``time_to_refill``
+    of 1e9 is a bug in the backend rather than a 31 year wait. Clamping to the
+    period alone would be the opposite error: the 100 token bucket below really
+    does need 100 seconds, and truncating that would send the client back early
+    for another 429.
+    """
+    absurd = _blocked_response()
+    add_token_bucket_headers(
+        absurd,
+        {
+            "tokens_remaining": 0,
+            "bucket_size": 5,
+            "refill_rate": 1.0,
+            "time_to_refill": 1e9,
+        },
+        limit=5,
+        period=PERIOD,
+    )
+    # Full refill is 5s, floored at the 60s period -> 60, not 1000000000.
+    assert absurd.headers["Retry-After"] == str(PERIOD)
+
+    legitimate = _blocked_response()
+    add_token_bucket_headers(
+        legitimate,
+        {
+            "tokens_remaining": 0,
+            "bucket_size": 100,
+            "refill_rate": 0.1,
+            "time_to_refill": 100.0,
+        },
+        limit=100,
+        period=PERIOD,
+    )
+    # Full refill is 1000s, so a real 100s wait passes through untruncated.
+    assert legitimate.headers["Retry-After"] == "100"
+
+
+def test_retry_after_ceiling_survives_a_garbage_refill_rate():
+    """With no usable refill_rate the period is the only defensible bound."""
+    response = _blocked_response()
+    add_token_bucket_headers(
+        response,
+        {
+            "tokens_remaining": 0,
+            "bucket_size": 5,
+            "refill_rate": "nonsense",
+            "time_to_refill": 1e9,
+        },
+        limit=5,
+        period=PERIOD,
+    )
+    assert response.headers["Retry-After"] == str(PERIOD)

--- a/tests/unit/core/test_token_bucket_headers.py
+++ b/tests/unit/core/test_token_bucket_headers.py
@@ -1,0 +1,520 @@
+"""Numeric contract for the token-bucket rate-limit response headers.
+
+``add_token_bucket_headers`` emits two time-valued headers that answer
+*different* questions, and both have been wrong at some point:
+
+* ``X-RateLimit-Reset`` is period-aligned. It must stay put across successive
+  requests -- that stability is exactly what issue #14 ("Time window changing
+  after each request") asked for, and it must not be re-derived from the
+  bucket's refill state.
+* ``Retry-After`` is the real wait before the *rejected* request would be
+  served. Deriving it from the period grid meant a true 6 second wait was
+  advertised as anywhere from 5 to 120 seconds depending on where the wall
+  clock happened to sit, and it was skipped entirely whenever tokens remained
+  but not enough of them (the multi-token-cost path).
+
+These tests pin the exact numbers rather than ``> 0``, so that a regression in
+either computation fails loudly.
+"""
+
+import time
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
+
+from django_smart_ratelimit import rate_limit
+from django_smart_ratelimit.algorithms.token_bucket import TokenBucketAlgorithm
+from django_smart_ratelimit.backends import clear_backend_cache
+from django_smart_ratelimit.backends.memory import MemoryBackend
+from django_smart_ratelimit.utils import add_token_bucket_headers
+
+MEMORY_BACKEND = "django_smart_ratelimit.backends.memory.MemoryBackend"
+
+# The full set of headers a token-bucket response is expected to carry.
+BUCKET_HEADERS = (
+    "X-RateLimit-Limit",
+    "X-RateLimit-Remaining",
+    "X-RateLimit-Reset",
+    "X-RateLimit-Bucket-Size",
+    "X-RateLimit-Bucket-Remaining",
+    "X-RateLimit-Refill-Rate",
+)
+
+# A clock position deliberately *not* aligned to a 60s boundary, and far enough
+# from the next boundary that the "advance if within 5s" rule does not kick in.
+FIXED_NOW = 1_700_000_000.0
+PERIOD = 60
+# 1_700_000_000 // 60 * 60 == 1_699_999_980, so the aligned reset is:
+EXPECTED_RESET = 1_700_000_040
+
+
+def _bucket_metadata(
+    bucket_size: int, refill_rate: float, initial_tokens: int, cost: int
+) -> Dict[str, Any]:
+    """Drive the real algorithm and return the metadata a backend would emit.
+
+    Using the production code path (rather than a hand-written dict) keeps the
+    expected ``Retry-After`` values honest: they are derived from the same
+    ``tokens_needed / refill_rate`` arithmetic the backends perform.
+    """
+    algorithm = TokenBucketAlgorithm(
+        {
+            "bucket_size": bucket_size,
+            "refill_rate": refill_rate,
+            "initial_tokens": initial_tokens,
+        }
+    )
+    key = (
+        f"tb-headers-{bucket_size}-{refill_rate}-{initial_tokens}-{cost}-{time.time()}"
+    )
+    _allowed, metadata = algorithm.is_allowed(
+        MemoryBackend(), key, bucket_size, PERIOD, tokens_requested=cost
+    )
+    return metadata
+
+
+def _blocked_response() -> HttpResponse:
+    """Return a 429 response with an empty header set."""
+    return HttpResponse("blocked", status=429)
+
+
+# ---------------------------------------------------------------------------
+# Retry-After tracks the real refill wait
+# ---------------------------------------------------------------------------
+
+
+def test_retry_after_equals_refill_wait_for_empty_bucket():
+    """An empty bucket advertises the arithmetic refill wait, not the period.
+
+    bucket refills at 0.5 tokens/s and the request costs 3 tokens, so the wait
+    is 3 / 0.5 = 6 seconds. The 60 second period must not leak into this value.
+    """
+    metadata = _bucket_metadata(
+        bucket_size=5, refill_rate=0.5, initial_tokens=0, cost=3
+    )
+    assert metadata["tokens_remaining"] == pytest.approx(0.0, abs=0.05)
+    assert metadata["time_to_refill"] == pytest.approx(6.0, abs=0.05)
+
+    response = _blocked_response()
+    add_token_bucket_headers(response, metadata, limit=5, period=PERIOD)
+
+    assert response.headers["Retry-After"] == "6"
+
+
+def test_retry_after_rounds_up_to_the_next_whole_second():
+    """A fractional wait rounds up: waiting 2s for a 2.5s refill just 429s."""
+    response = _blocked_response()
+    add_token_bucket_headers(
+        response,
+        {
+            "tokens_remaining": 0,
+            "bucket_size": 5,
+            "refill_rate": 0.4,
+            "time_to_refill": 2.5,
+        },
+        limit=5,
+        period=PERIOD,
+    )
+    assert response.headers["Retry-After"] == "3"
+
+
+def test_retry_after_present_and_correct_on_multi_token_cost_path():
+    """Tokens remaining but not enough of them still gets a Retry-After.
+
+    3 tokens are in the bucket and the request costs 5, so 2 more tokens are
+    needed at 0.5 tokens/s: a 4 second wait. This path used to emit no
+    ``Retry-After`` at all because the header was gated on
+    ``tokens_remaining <= 0``.
+    """
+    metadata = _bucket_metadata(
+        bucket_size=10, refill_rate=0.5, initial_tokens=3, cost=5
+    )
+    assert metadata["tokens_remaining"] == pytest.approx(3.0, abs=0.05)
+    assert metadata["time_to_refill"] == pytest.approx(4.0, abs=0.05)
+
+    response = _blocked_response()
+    add_token_bucket_headers(response, metadata, limit=10, period=PERIOD)
+
+    # Tokens really do remain -- this is the case the old guard skipped.
+    assert response.headers["X-RateLimit-Bucket-Remaining"] == "3"
+    assert response.headers["Retry-After"] == "4"
+
+
+def test_retry_after_does_not_depend_on_clock_position():
+    """The same 6 second wait is advertised wherever the wall clock sits.
+
+    The period-derived implementation returned anything from 5 to 120 for this
+    exact input depending on the moment the request arrived.
+    """
+    metadata = {
+        "tokens_remaining": 0,
+        "bucket_size": 5,
+        "refill_rate": 0.5,
+        "time_to_refill": 6.0,
+    }
+    for offset in (0, 1, 7, 29, 55, 58, 59.5, 61, 119):
+        response = _blocked_response()
+        with patch(
+            "django_smart_ratelimit.utils.time.time",
+            return_value=FIXED_NOW + offset,
+        ):
+            add_token_bucket_headers(response, metadata, limit=5, period=PERIOD)
+        assert response.headers["Retry-After"] == "6", f"offset={offset}"
+
+
+def test_no_retry_after_on_allowed_response():
+    """A served request is not told to back off."""
+    response = HttpResponse("ok")
+    add_token_bucket_headers(
+        response,
+        {
+            "tokens_remaining": 4,
+            "bucket_size": 5,
+            "refill_rate": 0.5,
+            "time_to_refill": 2.0,
+        },
+        limit=5,
+        period=PERIOD,
+    )
+    assert "Retry-After" not in response.headers
+
+
+# ---------------------------------------------------------------------------
+# X-RateLimit-Reset stays period-aligned and stable (issue #14)
+# ---------------------------------------------------------------------------
+
+
+def test_reset_is_period_aligned():
+    """The reset time lands on a period boundary, not on ``now + wait``."""
+    response = HttpResponse("ok")
+    with patch("django_smart_ratelimit.utils.time.time", return_value=FIXED_NOW):
+        add_token_bucket_headers(
+            response,
+            {
+                "tokens_remaining": 2,
+                "bucket_size": 5,
+                "refill_rate": 0.5,
+                "time_to_refill": 6.0,
+            },
+            limit=5,
+            period=PERIOD,
+        )
+    reset = int(response.headers["X-RateLimit-Reset"])
+    assert reset == EXPECTED_RESET
+    assert reset % PERIOD == 0
+
+
+def test_reset_is_stable_across_successive_requests():
+    """Successive requests inside one period report the *same* reset time.
+
+    This is the guarantee issue #14 asked for. The bucket drains and the refill
+    estimate changes on every call; the reset time must not move with it.
+    """
+    seen = set()
+    for offset, tokens_left, refill_wait in (
+        (0.0, 5, 0.0),
+        (3.0, 4, 2.0),
+        (11.5, 3, 4.0),
+        (24.0, 2, 6.0),
+        (30.0, 0, 10.0),
+    ):
+        response = HttpResponse("ok")
+        with patch(
+            "django_smart_ratelimit.utils.time.time",
+            return_value=FIXED_NOW + offset,
+        ):
+            add_token_bucket_headers(
+                response,
+                {
+                    "tokens_remaining": tokens_left,
+                    "bucket_size": 5,
+                    "refill_rate": 0.5,
+                    "time_to_refill": refill_wait,
+                },
+                limit=5,
+                period=PERIOD,
+            )
+        seen.add(response.headers["X-RateLimit-Reset"])
+
+    assert seen == {str(EXPECTED_RESET)}
+
+
+def test_reset_advances_to_next_period_near_the_boundary():
+    """Within 5s of the boundary the reset advances rather than expiring."""
+    response = HttpResponse("ok")
+    # 1_700_000_038 is 2s before the 1_700_000_040 boundary.
+    with patch("django_smart_ratelimit.utils.time.time", return_value=FIXED_NOW + 38):
+        add_token_bucket_headers(
+            response,
+            {"tokens_remaining": 1, "bucket_size": 5, "refill_rate": 0.5},
+            limit=5,
+            period=PERIOD,
+        )
+    assert int(response.headers["X-RateLimit-Reset"]) == EXPECTED_RESET + PERIOD
+
+
+# ---------------------------------------------------------------------------
+# refill_rate == 0: fall back to the period, never to a bare 1
+# ---------------------------------------------------------------------------
+
+
+def test_refill_rate_zero_reported_as_inf_falls_back_to_period():
+    """``backends.utils`` spells "never refills" as ``inf``."""
+    metadata = _bucket_metadata(bucket_size=5, refill_rate=0, initial_tokens=0, cost=1)
+    assert metadata["time_to_refill"] == float("inf")
+
+    response = _blocked_response()
+    add_token_bucket_headers(response, metadata, limit=5, period=PERIOD)
+
+    assert response.headers["Retry-After"] == str(PERIOD)
+
+
+def test_refill_rate_zero_reported_as_zero_falls_back_to_period():
+    """``algorithms.token_bucket`` spells the same case as ``0``.
+
+    That producer guards its division, so there is no ZeroDivisionError -- the
+    value simply arrives as 0 and used to be emitted as a meaningless
+    ``Retry-After: 1``.
+    """
+    response = _blocked_response()
+    add_token_bucket_headers(
+        response,
+        {
+            "tokens_remaining": 0,
+            "bucket_size": 5,
+            "refill_rate": 0,
+            "time_to_refill": 0,
+        },
+        limit=5,
+        period=PERIOD,
+    )
+    assert response.headers["Retry-After"] == str(PERIOD)
+
+
+def test_missing_time_to_refill_falls_back_to_period():
+    """A backend that omits the field entirely still gets a usable wait."""
+    response = _blocked_response()
+    add_token_bucket_headers(
+        response,
+        {"tokens_remaining": 0, "bucket_size": 5, "refill_rate": 1.0},
+        limit=5,
+        period=PERIOD,
+    )
+    assert response.headers["Retry-After"] == str(PERIOD)
+
+
+def test_nan_time_to_refill_falls_back_to_period():
+    """A not-a-number wait is not a wait either."""
+    response = _blocked_response()
+    add_token_bucket_headers(
+        response,
+        {
+            "tokens_remaining": 0,
+            "bucket_size": 5,
+            "refill_rate": 1.0,
+            "time_to_refill": float("nan"),
+        },
+        limit=5,
+        period=PERIOD,
+    )
+    assert response.headers["Retry-After"] == str(PERIOD)
+
+
+# ---------------------------------------------------------------------------
+# Malformed optional metadata degrades gracefully
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_size_none_does_not_raise_and_keeps_every_header():
+    """``bucket_size=None`` must not raise.
+
+    ``dict.get("bucket_size", limit)`` returns the *present* ``None``, so the
+    default never applies. Raising here is not a cosmetic problem: the sync
+    decorator wraps the view call and the header call in one ``try``, so the
+    fallback path re-runs the view body a second time, and the async decorator
+    has no ``try`` at all and surfaces a TypeError after the view already ran.
+    """
+    response = HttpResponse("ok")
+    add_token_bucket_headers(
+        response,
+        {"tokens_remaining": 2, "bucket_size": None, "refill_rate": 1.0},
+        limit=10,
+        period=PERIOD,
+    )
+    for header in BUCKET_HEADERS:
+        assert header in response.headers, header
+    assert response.headers["X-RateLimit-Bucket-Size"] == "10"
+
+
+def test_bucket_size_missing_falls_back_to_limit():
+    """An absent bucket_size falls back to the configured limit."""
+    response = HttpResponse("ok")
+    add_token_bucket_headers(
+        response,
+        {"tokens_remaining": 2, "refill_rate": 1.0},
+        limit=10,
+        period=PERIOD,
+    )
+    for header in BUCKET_HEADERS:
+        assert header in response.headers, header
+    assert response.headers["X-RateLimit-Bucket-Size"] == "10"
+
+
+def test_bucket_size_garbage_falls_back_without_losing_headers():
+    """A non-numeric bucket_size degrades only itself."""
+    response = HttpResponse("ok")
+    add_token_bucket_headers(
+        response,
+        {"tokens_remaining": 2, "bucket_size": "not-a-number", "refill_rate": 1.0},
+        limit=10,
+        period=PERIOD,
+    )
+    for header in BUCKET_HEADERS:
+        assert header in response.headers, header
+    assert response.headers["X-RateLimit-Bucket-Size"] == "10"
+
+
+def test_float_bucket_size_is_not_truncated():
+    """A fractional bucket_size keeps its fraction.
+
+    ``format_token_bucket_metadata`` types ``bucket_size`` as
+    ``Optional[float]`` and the Redis fail-open path passes a float, so
+    ``int()``-coercing the value would silently under-report capacity.
+    """
+    response = HttpResponse("ok")
+    add_token_bucket_headers(
+        response,
+        {"tokens_remaining": 2, "bucket_size": 10.5, "refill_rate": 1.0},
+        limit=10,
+        period=PERIOD,
+    )
+    assert response.headers["X-RateLimit-Bucket-Size"] == "10.5"
+
+
+def test_whole_float_bucket_size_renders_without_decimal_point():
+    """``20.0`` is still advertised as ``20``, not ``20.0``."""
+    response = HttpResponse("ok")
+    add_token_bucket_headers(
+        response,
+        {"tokens_remaining": 2, "bucket_size": 20.0, "refill_rate": 1.0},
+        limit=20,
+        period=PERIOD,
+    )
+    assert response.headers["X-RateLimit-Bucket-Size"] == "20"
+
+
+def test_none_tokens_remaining_does_not_raise():
+    """``tokens_remaining=None`` degrades to 0 instead of raising."""
+    response = HttpResponse("ok")
+    add_token_bucket_headers(
+        response,
+        {"tokens_remaining": None, "bucket_size": 5, "refill_rate": 1.0},
+        limit=5,
+        period=PERIOD,
+    )
+    assert response.headers["X-RateLimit-Remaining"] == "0"
+    assert response.headers["X-RateLimit-Bucket-Remaining"] == "0"
+
+
+def test_garbage_refill_rate_drops_only_the_refill_rate_header():
+    """A bad refill_rate costs us that one header and nothing else."""
+    response = HttpResponse("ok")
+    add_token_bucket_headers(
+        response,
+        {"tokens_remaining": 2, "bucket_size": 5, "refill_rate": None},
+        limit=5,
+        period=PERIOD,
+    )
+    for header in BUCKET_HEADERS:
+        if header == "X-RateLimit-Refill-Rate":
+            continue
+        assert header in response.headers, header
+    assert "X-RateLimit-Refill-Rate" not in response.headers
+
+
+def test_empty_metadata_still_emits_the_computable_headers():
+    """Nothing at all from the backend must not blow up the response."""
+    response = _blocked_response()
+    add_token_bucket_headers(response, {}, limit=7, period=PERIOD)
+    assert response.headers["X-RateLimit-Limit"] == "7"
+    assert response.headers["X-RateLimit-Remaining"] == "0"
+    assert response.headers["X-RateLimit-Bucket-Size"] == "7"
+    assert response.headers["X-RateLimit-Bucket-Remaining"] == "0"
+    assert int(response.headers["X-RateLimit-Reset"]) % PERIOD == 0
+    assert response.headers["Retry-After"] == str(PERIOD)
+
+
+# ---------------------------------------------------------------------------
+# The concrete damage a raising header helper does through the decorator
+# ---------------------------------------------------------------------------
+
+
+def _null_bucket_size_check(*_args, **_kwargs):
+    """Stand in for a backend that reports ``bucket_size`` as ``None``."""
+    return True, {"tokens_remaining": 4, "bucket_size": None, "refill_rate": 1.0}
+
+
+@override_settings(RATELIMIT_BACKEND=MEMORY_BACKEND)
+def test_sync_view_body_runs_once_when_bucket_size_is_none():
+    """A raising header helper made the *sync* decorator run the view twice.
+
+    ``_handle_token_bucket_rate_limiting`` wraps the ``func()`` call and the
+    ``add_token_bucket_headers`` call in a single ``try``; its ``except`` falls
+    back to ``_handle_standard_rate_limiting``, which calls ``func()`` again.
+    Any exception from header formatting therefore double-executes the view --
+    duplicated writes, duplicated emails, duplicated charges.
+    """
+    clear_backend_cache()
+    calls = []
+
+    @rate_limit(key="ip", rate="10/m", algorithm="token_bucket", block=True)
+    def view(_request):
+        calls.append(1)
+        return HttpResponse("ok")
+
+    request = RequestFactory().get("/")
+    request.META["REMOTE_ADDR"] = "203.0.113.7"
+
+    with patch.object(TokenBucketAlgorithm, "is_allowed", _null_bucket_size_check):
+        response = view(request)
+
+    assert len(calls) == 1
+    assert response.status_code == 200
+    assert response.headers["X-RateLimit-Bucket-Size"] == "10"
+
+
+@override_settings(RATELIMIT_BACKEND=MEMORY_BACKEND)
+async def test_async_view_does_not_raise_when_bucket_size_is_none():
+    """The *async* decorator has no ``try`` around the header call.
+
+    A raising header helper there surfaces a TypeError to the caller after the
+    view body has already run, turning a served request into a 500.
+    """
+    clear_backend_cache()
+    calls = []
+
+    @rate_limit(key="ip", rate="10/m", algorithm="token_bucket", block=True)
+    async def view(_request):
+        calls.append(1)
+        return HttpResponse("ok")
+
+    request = RequestFactory().get("/")
+    request.META["REMOTE_ADDR"] = "203.0.113.8"
+
+    with patch(
+        "django_smart_ratelimit.decorator._run_bucket_check",
+        return_value=(
+            True,
+            {"tokens_remaining": 4, "bucket_size": None, "refill_rate": 1.0},
+            4,
+        ),
+    ):
+        response = await view(request)
+
+    assert len(calls) == 1
+    assert response.status_code == 200
+    assert response.headers["X-RateLimit-Bucket-Size"] == "10"


### PR DESCRIPTION
## Description

Currently, the `add_token_bucket_headers` function relies on a fixed, period-aligned calculation to determine the rate limit reset time and `Retry-After` values. While predictable, this approach doesn't precisely reflect the real-time continuous refill state of the token bucket algorithm managed by the backends.

This PR aligns the HTTP response headers directly with the dynamic data already computed by the storage backends (Memory, DB, and Redis Lua script), leveraging the `time_to_refill` value they provide and safely falling back to `period` in case it's missing.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [X] Code refactoring
- [ ] Other (please describe):

## Testing

- [ ] I have added tests for my changes
- [X] All existing tests pass
- [X] I have tested the changes manually
- [ ] I have tested with multiple Django versions (if applicable)
- [ ] I have tested with multiple Python versions (if applicable)

## Documentation

- [ ] I have updated the README.md (if needed)
- [ ] I have updated the documentation (if needed)
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated type hints

## Code Quality

- [X] I have run `black` to format the code
- [X] I have run `flake8` and fixed any linting issues
- [X] I have run `mypy` and fixed any type checking issues
- [X] I have run the pre-commit hooks
- [X] My code follows the project's style guidelines

## Backwards Compatibility

- [X] This change is backwards compatible
- [ ] This change requires a migration or configuration update
- [ ] This change breaks existing functionality (requires major version bump)

## Checklist

- [X] I have read the contributing guidelines
- [ ] I have signed off my commits (if required)
- [ ] I have squashed my commits into logical units
- [X] I have written clear commit messages
- [X] I have tested my changes thoroughly
- [ ] I have documented any new functionality
