### PR TITLE
Add GitHub Sponsors funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,15 +1,4 @@
 # These are supported funding model platforms
 
-github: yassershkeir
-patreon: # Replace with a single Patreon username
-open_collective: # Removed as of Jan. 2026
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: # Replace with a single Polar username
-buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
-thanks_dev: # Replace with a single thanks.dev username
+github: YasserShkeir
 custom: ["https://www.yasser-shkeir.com/donate"]


### PR DESCRIPTION
Replaces the unedited GitHub FUNDING template with the same minimal config used in `django-safe-migrations`.

- Removes 11 commented-out placeholder platforms
- Corrects the `github:` username casing to `YasserShkeir`
- Keeps the existing `custom:` link to yasser-shkeir.com/donate

🤖 Generated with [Claude Code](https://claude.com/claude-code)