### PR TITLE
docs: add support page and funding links

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,18 @@ Contributions are welcome. Please see [CONTRIBUTING.md](CONTRIBUTING.md) for det
 
 ## Sponsors
 
-Support the ongoing development of Django Smart Ratelimit:
+Django Smart Ratelimit is maintained in the open. If it has absorbed a traffic spike, kept an abusive client off your API, or saved you a production incident, consider funding the time that keeps it that way.
 
-[![Sponsor](https://img.shields.io/badge/Sponsor-Support%20Development-blue.svg)](https://www.yasser-shkeir.com/donate)
+[![Sponsor on GitHub](https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-ea4aaa.svg)](https://github.com/sponsors/YasserShkeir)
+
+[GitHub Sponsors](https://github.com/sponsors/YasserShkeir) is the most direct route -- it charges a 0% platform fee, so the full amount reaches development.
+
+Prefer a card checkout? Fixed Stripe tiers:
+
+- **One-time** -- [$5](https://buy.stripe.com/6oUfZbgh17Km5xQ2HzcMM00), [$10](https://buy.stripe.com/bJe00d8Oz4ya8K21DvcMM01), [$25](https://buy.stripe.com/00wfZb5Cn7Km8K21DvcMM02), [$50](https://buy.stripe.com/aFa14h7Kv0hU1hAfulcMM03)
+- **Monthly** -- [$5/mo](https://buy.stripe.com/8x2eV76Gr9Su1hAci9cMM04), [$15/mo](https://buy.stripe.com/28EeV7e8TaWy2lE5TLcMM05), [$50/mo](https://buy.stripe.com/bJe8wJ7Kvc0C7FY2HzcMM06)
+
+See the [support page](https://django-smart-ratelimit.readthedocs.io/en/latest/support/) for corporate sponsorship and non-financial ways to help, or the [donate page](https://www.yasser-shkeir.com/donate) for every option in one place.
 
 ## License
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,73 @@
+# Support the Project
+
+Django Smart Ratelimit is free, open-source software maintained by
+[Yasser Shkeir](https://github.com/YasserShkeir) and contributors.
+
+## Ways to Support
+
+### Financial Support
+
+If this library has absorbed a traffic spike, kept an abusive client off your
+API, or saved you a production incident, consider funding the time that keeps it
+that way.
+
+**[GitHub Sponsors](https://github.com/sponsors/YasserShkeir)** is the most
+direct route. It charges a 0% platform fee, so the full amount reaches
+development, and it supports both one-time and recurring sponsorship.
+
+Prefer a card checkout? Fixed Stripe tiers are available:
+
+| One-time                                                        | Monthly                                                              |
+| --------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [$5](https://buy.stripe.com/6oUfZbgh17Km5xQ2HzcMM00)            | [$5/mo](https://buy.stripe.com/8x2eV76Gr9Su1hAci9cMM04)              |
+| [$10](https://buy.stripe.com/bJe00d8Oz4ya8K21DvcMM01)           | [$15/mo](https://buy.stripe.com/28EeV7e8TaWy2lE5TLcMM05)             |
+| [$25](https://buy.stripe.com/00wfZb5Cn7Km8K21DvcMM02)           | [$50/mo](https://buy.stripe.com/bJe8wJ7Kvc0C7FY2HzcMM06)             |
+| [$50](https://buy.stripe.com/aFa14h7Kv0hU1hAfulcMM03)           |                                                                      |
+
+Every option is also collected on the
+[donate page](https://www.yasser-shkeir.com/donate).
+
+Your support helps cover:
+
+- Development time for new features, algorithms, and backends
+- Testing infrastructure (CI/CD, Redis/MongoDB/Memcached integration matrices)
+- Documentation and community support
+- Security maintenance and dependency updates
+
+### Non-Financial Support
+
+Funding is not the only way to help. You can also:
+
+- **Star the repository** - Help others discover the project
+- **Report issues** - Help improve quality by reporting bugs
+- **Contribute code** - Submit pull requests for features or fixes
+- **Write documentation** - Improve guides, examples, or benchmarks
+- **Spread the word** - Share with your team, blog about it, or present at
+  meetups
+
+## Corporate Sponsorship
+
+If your company runs Django Smart Ratelimit in production and would like to
+sponsor development or needs enterprise support:
+
+- **Priority bug fixes** for your use cases
+- **Custom backend or algorithm development** for your traffic patterns
+- **Integration assistance** for your deployment and observability stack
+- **Training sessions** for your engineering team
+
+Contact: [shkeiryasser@gmail.com](mailto:shkeiryasser@gmail.com)
+
+## Thank You
+
+A huge thank you to everyone who has contributed to this project, whether
+through code, documentation, bug reports, or financial support. Open source
+thrives because of people like you.
+
+## Current Sponsors
+
+*Be the first to sponsor!*
+
+---
+
+*Want to see your name or company logo here?
+[Become a sponsor](https://www.yasser-shkeir.com/donate).*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
       - Multi-Tenant: multi_tenant.md
       - GraphQL: graphql.md
   - Design: design.md
+  - Support: support.md
 
 markdown_extensions:
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ Repository = "https://github.com/YasserShkeir/django-smart-ratelimit"
 Issues = "https://github.com/YasserShkeir/django-smart-ratelimit/issues"
 Discussions = "https://github.com/YasserShkeir/django-smart-ratelimit/discussions"
 Changelog = "https://github.com/YasserShkeir/django-smart-ratelimit/blob/main/CHANGELOG.md"
+Funding = "https://www.yasser-shkeir.com/donate"
 
 [project.entry-points."pytest11"]
 django_smart_ratelimit = "django_smart_ratelimit.testing"


### PR DESCRIPTION
Adds sponsorship surfaces to the project so users have a clear, low-friction way to fund maintenance. Branched from `main`; does not touch `chore/funding-config` / #107.

## Changes

**README.md** — expands the existing `## Sponsors` section (still below install/usage/config, never above the fold). Leads with GitHub Sponsors since it carries a 0% platform fee, then lists fixed Stripe tiers for anyone who prefers a card checkout. Framed around what the library saves the reader rather than a generic plea.

**docs/support.md** — new page. The repo already had the full mkdocs publishing setup but no support page, while `django-safe-migrations` has one; this ports the equivalent structure (financial, non-financial, and corporate sponsorship) adapted to this library.

**mkdocs.yml** — wires the new page into the nav as a top-level `Support` entry, matching where `django-safe-migrations` places it.

**pyproject.toml** — adds a `Funding` key to `[project.urls]`. PyPI renders a "Funding" link in the project sidebar when this key is present.

| `[project.urls]` | Before | After |
| :--- | :--- | :--- |
| Homepage | present | unchanged |
| Documentation | present | unchanged |
| Repository | present | unchanged |
| Issues | present | unchanged |
| Discussions | present | unchanged |
| Changelog | present | unchanged |
| **Funding** | **absent** | **`https://www.yasser-shkeir.com/donate`** |

## Notes

- Seven fixed tiers only (one-time $5/$10/$25/$50, monthly $5/$15/$50). No variable-amount wording anywhere.
- Stripe URLs are live payment links, copied verbatim and verified byte-for-byte against the source list.
- No version numbers, changelog entries, or release workflows were touched.
- `pre-commit run --files ...` passes on all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)