### PR TITLE
fix(ci): pin pytest-django<4.13 — 4.13.0 breaks Django <=5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,15 @@ all = [
 ]
 dev = [
     "pytest>=7.0",
-    "pytest-django>=4.5",
+    # <4.13 is a hard upper bound, not caution: pytest-django 4.13.0 accesses
+    # PytestDjangoTestCase._pre_setup_ran_eagerly (fixtures.py:292), which is
+    # absent on Django <= 5.1, so every DB-backed test errors with
+    # "AttributeError: type object 'PytestDjangoTestCase' has no attribute
+    # '_pre_setup_ran_eagerly'". This project still supports Django 3.2-5.1
+    # (see the Framework :: Django classifiers above), so it cannot take 4.13
+    # until those are dropped. Verified: Django 5.1 + pytest-django 4.13.0 =>
+    # 34 errors; the same tree with 4.12.0 => 34 passed.
+    "pytest-django>=4.5,<4.13",
     "pytest-asyncio>=0.21",
     "pytest-cov>=4.0",
     "pytest-xdist>=3.0",


### PR DESCRIPTION
## The failure

`main` is red. Every DB-backed test on Django 3.2 / 4.2 / 5.0 / 5.1 errors with:

```
AttributeError: type object 'PytestDjangoTestCase' has no attribute '_pre_setup_ran_eagerly'
```

268 errors per job, 13 of 23 matrix jobs failing.

## It's upstream, not us

That attribute is read by **pytest-django itself** (`pytest_django/fixtures.py:292`). Nothing in this package references it — `grep -rn "_pre_setup_ran_eagerly" django_smart_ratelimit/ tests/` returns nothing. It doesn't exist on Django ≤ 5.1, so pytest-django 4.13.0 is simply incompatible with the Django versions this project still supports.

CI installs `pytest-django>=4.5` unpinned, so this broke the moment 4.13.0 shipped — independent of any change here.

## The matrix shows the axis cleanly

| | Result |
|---|---|
| Django ≥ 5.2 (all Pythons) | ✅ pass |
| Django ≤ 5.1, Python ≥ 3.10 | ❌ fail |
| Django ≤ 5.1, Python 3.9 | ✅ pass |

Python 3.9 passing is the tell: it can't resolve 4.13.0 and falls back to a working release.

## Reproduced

One tree, one variable changed:

```
Django 5.1 + pytest-django 4.13.0  ->  34 errors
Django 5.1 + pytest-django 4.12.0  ->  34 passed
```

## The fix

`pytest-django>=4.5,<4.13`. The bound is documented inline with the reason and the exit condition — it comes off when Django ≤ 5.1 is dropped from the `Framework :: Django` classifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)