### PR TITLE
fix(ci): exclude pytest-django 4.13.* instead of capping below it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,15 +87,17 @@ all = [
 ]
 dev = [
     "pytest>=7.0",
-    # <4.13 is a hard upper bound, not caution: pytest-django 4.13.0 accesses
+    # !=4.13.* is a hard exclusion, not caution: pytest-django 4.13.0 accesses
     # PytestDjangoTestCase._pre_setup_ran_eagerly (fixtures.py:292), which is
     # absent on Django <= 5.1, so every DB-backed test errors with
     # "AttributeError: type object 'PytestDjangoTestCase' has no attribute
     # '_pre_setup_ran_eagerly'". This project still supports Django 3.2-5.1
-    # (see the Framework :: Django classifiers above), so it cannot take 4.13
-    # until those are dropped. Verified: Django 5.1 + pytest-django 4.13.0 =>
-    # 34 errors; the same tree with 4.12.0 => 34 passed.
-    "pytest-django>=4.5,<4.13",
+    # (see the Framework :: Django classifiers above). 4.13.0 is the only
+    # release carrying the bug and no 4.13.1 was published; 4.14.0 fixes it.
+    # Verified on Django 5.1: 4.13.0 -> AttributeError on every DB-backed
+    # test, 4.14.0 -> passes. So exclude the 4.13 series rather than capping
+    # below it, which would have pinned us to the one broken version.
+    "pytest-django>=4.5,!=4.13.*",
     "pytest-asyncio>=0.21",
     "pytest-cov>=4.0",
     "pytest-xdist>=3.0",


### PR DESCRIPTION
Supersedes #110.

#109 pinned `pytest-django<4.13` to keep 4.13.0 out: it accesses `PytestDjangoTestCase._pre_setup_ran_eagerly` (`fixtures.py:292`), an attribute absent on Django <= 5.1, so every DB-backed test errors on the Django 3.2 / 4.2 / 5.0 / 5.1 legs of the matrix.

That bound is now the wrong shape. **4.13.0 is the only release carrying the bug** — no 4.13.1 was ever published — and **4.14.0 (2026-08-10) fixes it**. A `<4.13` cap locks the project out of every future release in order to exclude one.

Dependabot #110 proposes `<4.14`, which is worse: it admits 4.13.0, the single broken version, while still excluding the fix.

### Verified

Clean venv, Django 5.1.15, changing only pytest-django:

| pytest-django | Result on a DB-backed test |
| --- | --- |
| 4.13.0 | `AttributeError: type object 'PytestDjangoTestCase' has no attribute '_pre_setup_ran_eagerly'` |
| 4.14.0 | passes |

Local suite on pytest-django 4.14.0 + Django 6.1: **1022 passed, 43 skipped**. The 2 failures are `BackendSelectionTests::test_get_backend_mongodb*`, which fail identically on unmodified `main` (no local `mongod`; CI runs the service).

Closes #110.