### PR TITLE
docs(deps): correct the inverted pytest-django constraint rationale

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,8 +95,13 @@ dev = [
     # (see the Framework :: Django classifiers above). 4.13.0 is the only
     # release carrying the bug and no 4.13.1 was published; 4.14.0 fixes it.
     # Verified on Django 5.1: 4.13.0 -> AttributeError on every DB-backed
-    # test, 4.14.0 -> passes. So exclude the 4.13 series rather than capping
-    # below it, which would have pinned us to the one broken version.
+    # test, 4.14.0 -> passes.
+    #
+    # Hence an exclusion rather than an upper bound. Both bounds get it wrong
+    # in opposite directions: `<4.13` excludes the bug but also locks out
+    # 4.14+, i.e. the fix; `<4.14` (proposed in #110) keeps 4.13.0 as the
+    # newest installable release, i.e. it pins to the bug. `!=4.13.*` skips
+    # the one broken series and tracks everything after it.
     "pytest-django>=4.5,!=4.13.*",
     "pytest-asyncio>=0.21",
     "pytest-cov>=4.0",


### PR DESCRIPTION
Follow-up to #111, from [Copilot's review comment](https://github.com/YasserShkeir/django-smart-ratelimit/pull/111#discussion_r) on that PR — it was right and the merge went in before it was addressed.

The comment claimed a `<4.13` cap "would have pinned us to the one broken version". It would not:

- **`<4.13`** — excludes 4.13.0 *and* everything after it. Cost: you lose 4.14.0, the fix. (This was the state after #109, correct at the time, since 4.14.0 did not exist yet.)
- **`<4.14`** — leaves 4.13.0 as the newest installable release. *This* is the bound that pins to the bug. It is what Dependabot proposed in #110.
- **`!=4.13.*`** — skips the one broken series, tracks everything after it. Current state, unchanged by this PR.

The PR description and commit message on #111 stated this correctly; only the inline comment in `pyproject.toml` garbled it. Constraint and code are untouched — this is comment-only.

Worth correcting rather than leaving: a dependency pin's rationale is read years later by someone deciding whether the pin is still needed, and this one argued for the opposite of what it demonstrated.